### PR TITLE
BUG: Use same hash algorithm to generate and verify randomness

### DIFF
--- a/core/client_public.go
+++ b/core/client_public.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"bytes"
-	"crypto/sha512"
 	"errors"
 
 	"github.com/drand/drand/beacon"
@@ -112,7 +111,7 @@ func (c *Client) verify(public kyber.Point, resp *drand.PublicRandResponse) erro
 	if ver != nil {
 		return ver
 	}
-	hash := sha512.New()
+	hash := RandomnessHash()
 	hash.Write(resp.GetSignature())
 	randExpected := hash.Sum(nil)
 	if !bytes.Equal(randExpected, rand) {


### PR DESCRIPTION
### Problem

It looks like `core.Drand` changed to use a [sha256 RandomnessHash](https://github.com/drand/drand/blob/a40dc25e1aec6822a79c72b4aaca12e65c700f01/core/drand_public.go#L99) instead of the sha512 hash it had used earlier. This change did not carry over to [verification in the go client](https://github.com/drand/drand/blob/a40dc25e1aec6822a79c72b4aaca12e65c700f01/core/client_public.go#L115), so it fails to validate correct randomness on retrieval.

### Proposed Solution

Use the sha256 algorithm defined by `RandomnessHash` for the client as well.