### PR TITLE
Multi-stage docker file for building a standalone binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM golang:1.14-alpine
+FROM golang:alpine AS builder
 
+ARG version=unknown
+ARG gitCommit
+
+WORKDIR /go/src/drand
+COPY . .
+ENV CGO_ENABLED 0
+RUN go build -ldflags "-X main.version=${version} -X main.buildDate=`date -u +%d/%m/%Y@%H:%M:%S` -X main.gitCommit=${gitCommit}" -o /go/src/drand/drand
+RUN chmod a+x /go/src/drand/drand
+
+FROM scratch
 MAINTAINER Nicolas GAILLY <nikkolasg@gmail.com>
-
-COPY drand /
+ENV USER /
+COPY --from=builder /go/src/drand/drand /drand
+CMD ["/drand"]
 ENTRYPOINT ["/drand"]
 


### PR DESCRIPTION
This extends the current `Dockerfile` in the repository to perform the compilation of the binary in a standardized environment, rather than doing so implicitly.

It also shrinks the execution / final image to a scratch image with only the binary and no additional file system. This reduces the final redistribution size to 19MB from several hundred.