### PR TITLE
Level up the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,6 @@ VOLUME $DRAND_HOME
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
 
 # Defaults for ipfs-cluster-service go here
-CMD ["start", "--tls-disable", "--control 8888", "--listen 127.0.0.1:4444"]
+CMD ["start", "--tls-disable", "--control 8888", "--listen 0.0.0.0:4444"]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,69 @@
-FROM golang:alpine AS builder
+FROM golang:1.14.2-buster AS builder
+MAINTAINER Hector Sanjuan <hector@protocol.ai>
 
 ARG version=unknown
 ARG gitCommit
 
-WORKDIR /go/src/drand
-COPY . .
-ENV CGO_ENABLED 0
-RUN go build -ldflags "-X main.version=${version} -X main.buildDate=`date -u +%d/%m/%Y@%H:%M:%S` -X main.gitCommit=${gitCommit}" -o /go/src/drand/drand
-RUN chmod a+x /go/src/drand/drand
+ENV GOPATH /go
+ENV SRC_PATH $GOPATH/src/github.com/drand/drand/
+ENV GOPROXY https://proxy.golang.org
 
-FROM scratch
-MAINTAINER Nicolas GAILLY <nikkolasg@gmail.com>
-ENV USER /
-COPY --from=builder /go/src/drand/drand /drand
-CMD ["/drand"]
-ENTRYPOINT ["/drand"]
+ENV SUEXEC_VERSION v0.2
+ENV TINI_VERSION v0.19.0
+RUN set -x \
+  && cd /tmp \
+  && git clone https://github.com/ncopa/su-exec.git \
+  && cd su-exec \
+  && git checkout -q $SUEXEC_VERSION \
+  && make \
+  && cd /tmp \
+  && wget -q -O tini https://github.com/krallin/tini/releases/download/$TINI_VERSION/tini \
+  && chmod +x tini
+
+# Get the TLS CA certificates, they're not provided by busybox.
+RUN apt-get update && apt-get install -y ca-certificates
+
+COPY go.* $SRC_PATH
+WORKDIR $SRC_PATH
+RUN go mod download
+
+COPY . $SRC_PATH
+RUN \
+  go install \
+    -mod=readonly \
+    -ldflags \
+      "-X main.version=${version} \
+       -X main.buildDate=`date -u +%d/%m/%Y@%H:%M:%S` \
+       -X main.gitCommit=${gitCommit}"
+
+
+
+FROM busybox:1-glibc
+MAINTAINER Hector Sanjuan <hector@protocol.ai>
+
+ENV GOPATH                 /go
+ENV SRC_PATH               /go/src/github.com/drand/drand
+ENV DRAND_HOME             /data/drand
+ENV DRAND_PUBLIC_ADDRESS   ""
+
+EXPOSE 8888
+EXPOSE 4444
+
+COPY --from=builder $GOPATH/bin/drand /usr/local/bin/drand
+COPY --from=builder $SRC_PATH/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --from=builder /tmp/su-exec/su-exec /sbin/su-exec
+COPY --from=builder /tmp/tini /sbin/tini
+COPY --from=builder /etc/ssl/certs /etc/ssl/certs
+
+RUN mkdir -p $DRAND_HOME && \
+    addgroup -g 994 drand && \
+    adduser -D -h $DRAND_HOME -u 996 -G drand drand && \
+    chown drand:drand $DRAND_HOME
+
+VOLUME $DRAND_HOME
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint.sh"]
+
+# Defaults for ipfs-cluster-service go here
+CMD ["start", "--tls-disable", "--control 8888", "--listen 127.0.0.1:4444"]
+
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,21 @@
+#!bin/sh
+
+set -e
+user=drand
+
+if [ -n "$DOCKER_DEBUG" ]; then
+   set -x
+fi
+
+if [ `id -u` -eq 0 ]; then
+    echo "Changing user to $user"
+    # ensure directories are writable
+    su-exec "$user" test -w "${DRAND_HOME}" || chown -R -- "$user" "${DRAND_HOME}"
+    exec su-exec "$user" "$0" $@
+fi
+
+if [ ! -d "${DRAND_HOME}/.drand" -a -n "${DRAND_PUBLIC_ADDRESS}" ]; then
+    drand generate-keypair --tls-disable "${DRAND_PUBLIC_ADDRESS}"
+fi
+
+exec drand $@


### PR DESCRIPTION
* Install certificate authorities
* Run on a sandboxed user
* Move to busybox
* Wrap with tiny
* Faster builds
* Automatically generate key-pair when no config present

These changes are ported from go-ipfs and ipfs-cluster which work
reasonably well in Dockerized environments.