### PR TITLE
Add prioritizer for multiple URLs, functional option constructor

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,118 @@
+package client
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/drand/drand/key"
+)
+
+// New Creates a client with specified configuration.
+func New(options ...Option) (Client, error) {
+	cfg := clientConfig{}
+	for _, opt := range options {
+		if err := opt(cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	return makeClient(cfg)
+}
+
+// makeClient creates a client from a configuration.
+func makeClient(cfg clientConfig) (Client, error) {
+	if !cfg.insecure && cfg.groupHash == nil && cfg.group == nil {
+		return nil, errors.New("No root of trust specified")
+	}
+	if len(cfg.urls) == 0 {
+		return nil, errors.New("No points of contact specified")
+	}
+	clients := []Client{}
+	var c Client
+	var err error
+	for _, url := range cfg.urls {
+		if cfg.group != nil {
+			c, err = NewHTTPClientWithGroup(url, cfg.group, cfg.getter)
+		} else {
+			c, err = NewHTTPClient(url, cfg.groupHash, cfg.getter)
+		}
+		if err != nil {
+			return nil, err
+		}
+		clients = append(clients, c)
+	}
+	if len(clients) == 1 {
+		return clients[0], nil
+	}
+	return NewPrioritizingClient(clients, cfg.groupHash, cfg.group)
+}
+
+type clientConfig struct {
+	// URLs when specified will create an HTTP client.
+	urls []string
+	// Insecure will allow creating the HTTP client without a bound group.
+	insecure bool
+	// from `key.GroupInfo.Hash()` - serves as a root of trust.
+	groupHash []byte
+	// Full group information - serves as a root of trust.
+	group *key.Group
+	// getter configures the http transport parameters used when fetching randomness.
+	getter HTTPGetter
+}
+
+// Option is an option configuring a client.
+type Option func(cfg clientConfig) error
+
+// WithHTTPEndpoints configures the client to use the provided URLs.
+func WithHTTPEndpoints(urls []string) Option {
+	return func(cfg clientConfig) error {
+		if cfg.insecure {
+			return errors.New("Cannot mix secure and insecure URLs")
+		}
+		cfg.urls = append(cfg.urls, urls...)
+		return nil
+	}
+}
+
+// WithHTTPGetter specifies the HTTP Client (or mocked equivalent) for fetching
+// randomness from an HTTP endpoint.
+func WithHTTPGetter(getter HTTPGetter) Option {
+	return func(cfg clientConfig) error {
+		cfg.getter = getter
+		return nil
+	}
+}
+
+// WithInsecureHTTPEndpoints configures the client to pull randomness from
+// provided URLs without validating the group trust root.
+func WithInsecureHTTPEndpoints(urls []string) Option {
+	return func(cfg clientConfig) error {
+		if len(cfg.urls) != 0 && !cfg.insecure {
+			return errors.New("Cannot mix secure and insecure URLs")
+		}
+		cfg.urls = append(cfg.urls, urls...)
+		cfg.insecure = true
+		return nil
+	}
+}
+
+// WithGroupHash configures the client to root trust with a given drand group
+// hash, the group parameters will be fetched from an HTTP endpoint.
+func WithGroupHash(grouphash []byte) Option {
+	return func(cfg clientConfig) error {
+		if cfg.group != nil && !bytes.Equal(cfg.group.Hash(), grouphash) {
+			return errors.New("refusing to override group with non-matching hash")
+		}
+		cfg.groupHash = grouphash
+		return nil
+	}
+}
+
+// WithGroup configures the client to root trust in the given group information
+func WithGroup(group *key.Group) Option {
+	return func(cfg clientConfig) error {
+		cfg.group = group
+		cfg.groupHash = nil
+		return nil
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -121,8 +121,10 @@ func WithGroupHash(grouphash []byte) Option {
 // WithGroup configures the client to root trust in the given group information
 func WithGroup(group *key.Group) Option {
 	return func(cfg *clientConfig) error {
+		if cfg.groupHash != nil && !bytes.Equal(cfg.groupHash, group.Hash()) {
+			return errors.New("refusing to override hash with non-matching group")
+		}
 		cfg.group = group
-		cfg.groupHash = nil
 		return nil
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drand/drand/key"
+)
+
+func TestClientConstraints(t *testing.T) {
+	if _, e := New(); e == nil {
+		t.Fatal("client can't be created without root of trust")
+	}
+
+	if _, e := New(WithGroupHash([]byte{0})); e == nil {
+		t.Fatal("Client needs URLs if only a group hash is specified")
+	}
+
+	if _, e := New(WithHTTPEndpoints([]string{"http://test.com"})); e == nil {
+		t.Fatal("Client needs root of trust unless insecure specified explicitly")
+	}
+
+	addr, _, cancel := withServer(t)
+	defer cancel()
+
+	if _, e := New(WithInsecureHTTPEndpoints([]string{"http://" + addr})); e != nil {
+		t.Fatal(e)
+	}
+}
+
+func TestClientMultiple(t *testing.T) {
+	addr1, hash, cancel := withServer(t)
+	defer cancel()
+	addr2, _, cancel2 := withServer(t)
+	defer cancel2()
+
+	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1, "http://" + addr2}), WithGroupHash(hash))
+	if e != nil {
+		t.Fatal(e)
+	}
+	r, e := c.Get(context.Background(), 0)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if r.Round() <= 0 {
+		t.Fatal("expected valid client")
+	}
+}
+
+func TestClientWithGroup(t *testing.T) {
+	c, err := New(WithGroup(key.NewGroup([]*key.Identity{}, 1, 100, time.Second)), WithHTTPEndpoints([]string{"http://nxdomain.local/"}))
+	if err != nil {
+		t.Fatal("existing group creation shouldn't do additional validaiton.")
+	}
+	_, err = c.Get(context.Background(), 0)
+	if err == nil {
+		t.Fatal("bad urls should clearly not provide randomness.")
+	}
+}

--- a/client/http.go
+++ b/client/http.go
@@ -23,6 +23,9 @@ type HTTPGetter interface {
 
 // NewHTTPClient creates a new client pointing to an HTTP endpoint
 func NewHTTPClient(url string, groupHash []byte, client HTTPGetter) (Client, error) {
+	if client == nil {
+		client = &http.Client{}
+	}
 	c := &httpClient{
 		root:   url,
 		client: client,
@@ -39,6 +42,9 @@ func NewHTTPClient(url string, groupHash []byte, client HTTPGetter) (Client, err
 
 // NewHTTPClientWithGroup constructs an http client when the group parameters are already known.
 func NewHTTPClientWithGroup(url string, group *key.Group, client HTTPGetter) (Client, error) {
+	if client == nil {
+		client = &http.Client{}
+	}
 	c := &httpClient{
 		root:   url,
 		group:  group,

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -1,0 +1,58 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// MockClient provide a mocked client interface
+type MockClient struct {
+	Results []MockResult
+}
+
+// Get returns a the randomness at `round` or an error.
+func (m *MockClient) Get(ctx context.Context, round uint64) (Result, error) {
+	if len(m.Results) == 0 {
+		return nil, errors.New("No result available")
+	}
+	r := m.Results[0]
+	m.Results = m.Results[1:]
+	return &r, nil
+}
+
+// Watch returns new randomness as it becomes available.
+func (m *MockClient) Watch(ctx context.Context) <-chan Result {
+	ch := make(chan Result, 1)
+	r, _ := m.Get(ctx, 0)
+	ch <- r
+	close(ch)
+	return ch
+}
+
+// RoundAt will return the most recent round of randomness
+func (m *MockClient) RoundAt(time time.Time) uint64 {
+	return 0
+}
+
+// ClientWithResults returns a client on which `Get` works `m-n` times.
+func MockClientWithResults(n, m int) Client {
+	c := new(MockClient)
+	for i := n; i < m; i++ {
+		c.Results = append(c.Results, MockResult{uint64(i), []byte{byte(i)}})
+	}
+	return c
+}
+
+type MockResult struct {
+	rnd  uint64
+	rand []byte
+}
+
+func (r *MockResult) Randomness() []byte {
+	return r.rand
+}
+
+func (r *MockResult) Round() uint64 {
+	return r.rnd
+}

--- a/client/prioritizing.go
+++ b/client/prioritizing.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/drand/drand/key"
+	"github.com/drand/drand/log"
+)
+
+// NewPrioritizingClient is a meta client that asks each sub-client
+// in succession on requests until an answer is found. If a sub-client
+// fails, it is moved to the end of the list.
+func NewPrioritizingClient(clients []Client, groupHash []byte, group *key.Group) (Client, error) {
+	return &prioritizingClient{clients, groupHash, group}, nil
+}
+
+type prioritizingClient struct {
+	Clients   []Client
+	groupHash []byte
+	group     *key.Group
+}
+
+// Get returns a the randomness at `round` or an error.
+func (p *prioritizingClient) Get(ctx context.Context, round uint64) (res Result, err error) {
+	for i, c := range p.Clients {
+		res, err = c.Get(ctx, round)
+		if err == nil {
+			// previous clients failed. move them to end of priority.
+			if i > 0 {
+				p.Clients = append(p.Clients[i:], p.Clients[:i]...)
+			}
+			return
+		}
+		// context deadline hit
+		if ctx.Err() != nil {
+			return
+		}
+	}
+	return
+}
+
+// Attempt to learn the trust root for the group from group-hash.
+func (p *prioritizingClient) learnGroup(ctx context.Context) error {
+	var group *key.Group
+	var err error
+
+	for _, c := range p.Clients {
+		if hc, ok := c.(*httpClient); ok {
+			group, err = hc.FetchGroupInfo(p.groupHash)
+			if err == nil {
+				p.group = group
+				return nil
+			}
+		}
+	}
+	if err == nil {
+		err = errors.New("No clients to learn group info from")
+	}
+	return err
+}
+
+// Watch returns new randomness as it becomes available.
+func (p *prioritizingClient) Watch(ctx context.Context) <-chan Result {
+	if p.group == nil {
+		if err := p.learnGroup(ctx); err != nil {
+			log.DefaultLogger.Warn("prioritizing_client", "failed to learn group", "err", err)
+			ch := make(chan Result, 0)
+			close(ch)
+			return ch
+		}
+	}
+	return pollingWatcher(ctx, p, p.group, log.DefaultLogger)
+}
+
+// RoundAt will return the most recent round of randomness that will be available
+// at time for the current client.
+func (p *prioritizingClient) RoundAt(time time.Time) uint64 {
+	return p.Clients[0].RoundAt(time)
+}

--- a/client/prioritizing_test.go
+++ b/client/prioritizing_test.go
@@ -1,0 +1,84 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drand/drand/key"
+)
+
+func TestPrioritizingGet(t *testing.T) {
+	c := MockClientWithResults(0, 5)
+	c2 := MockClientWithResults(6, 10)
+
+	p, err := NewPrioritizingClient([]Client{c, c2}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 5; i++ {
+		r, err := p.Get(context.Background(), 0)
+		if err != nil {
+			t.Fatal("should get from first client")
+		}
+		if r.Round() >= 5 {
+			t.Fatal("wrong client prioritized")
+		}
+	}
+
+	r, err := p.Get(context.Background(), 0)
+	if err != nil {
+		t.Fatal("should not error even when one client does")
+	}
+	if r.Round() != 6 {
+		t.Fatal("failed to switch priority")
+	}
+
+	c.(*MockClient).Results = []MockResult{MockResult{50, []byte{50}}}
+
+	r, err = p.Get(context.Background(), 0)
+	if err != nil {
+		t.Fatal("should not error")
+	}
+	if r.Round() != 7 {
+		t.Fatal("failed client should remain deprioritized")
+	}
+}
+
+func TestPrioritizingWatch(t *testing.T) {
+	c := MockClientWithResults(0, 5)
+	c2 := MockClientWithResults(6, 10)
+
+	p, _ := NewPrioritizingClient([]Client{c, c2}, nil, nil)
+	ch := p.Watch(context.Background())
+	r, ok := <-ch
+	if r != nil || ok {
+		t.Fatal("watch should fail without group provided")
+	}
+
+	p, _ = NewPrioritizingClient([]Client{c, c2}, nil, &key.Group{Period: time.Second, GenesisTime: time.Now().Unix()})
+	ch = p.Watch(context.Background())
+	r, ok = <-ch
+	if r == nil || !ok {
+		t.Fatal("watch should succeed with group for timing")
+	}
+	if r.Round() != 0 {
+		t.Fatal("wrong client prioritized")
+	}
+}
+
+func TestPrioritizingWatchFromClient(t *testing.T) {
+	c := MockClientWithResults(0, 5)
+	c2, _ := NewHTTPClientWithGroup("", &key.Group{Period: time.Second, GenesisTime: time.Now().Unix()}, nil)
+
+	p, _ := NewPrioritizingClient([]Client{c, c2}, nil, nil)
+	ch := p.Watch(context.Background())
+	r, ok := <-ch
+	if r == nil || !ok {
+		t.Fatal("watch should succeed if http client provided")
+	}
+	if r.Round() != 0 {
+		t.Fatal("wrong client prioritized")
+	}
+}

--- a/client/util.go
+++ b/client/util.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/drand/drand/beacon"
+	"github.com/drand/drand/key"
+	"github.com/drand/drand/log"
+)
+
+// pollingWatcher generalizes the `Watch` interface for clients which learn new values
+// by asking for them once each group period.
+func pollingWatcher(ctx context.Context, client Client, group *key.Group, log log.Logger) <-chan Result {
+	ch := make(chan Result, 1)
+	r := client.RoundAt(time.Now())
+	val, err := client.Get(ctx, r)
+	if err != nil {
+		log.Error("polling_client", "failed to watch", "err", err)
+		close(ch)
+		return ch
+	}
+	ch <- val
+
+	go func() {
+		defer close(ch)
+
+		// Initially, wait to synchronize to the round boundary.
+		_, nextTime := beacon.NextRound(time.Now().Unix(), group.Period, group.GenesisTime)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Duration(nextTime-time.Now().Unix()) * time.Second):
+		}
+
+		r, err := client.Get(ctx, client.RoundAt(time.Now()))
+		if err == nil {
+			ch <- r
+		} else {
+			log.Error("polling_client", "failed to watch", "err", err)
+		}
+
+		// Then tick each period.
+		t := time.NewTicker(group.Period)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				r, err := client.Get(ctx, client.RoundAt(time.Now()))
+				if err == nil {
+					ch <- r
+				} else {
+					log.Error("polling_client", "failed to watch", "err", err)
+				}
+				// TODO: keep trying on errors?
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch
+}


### PR DESCRIPTION
A second pass on fleshing out the client library.

* [x] Accept multiple URLs, fetch from whichever ones work
* [x] Central constructor with functional options
* [x] Unit tests for prioritizing client
* [x] unit tests for functional option constraints

The functional options allow us to relatively easily provide a `WithNotifier` hook to allow overlaying the client in #279