### PR TITLE
docs: rename and fix docker readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ make install
 
 ### Via Docker
 The setup is explained in
-[README\_docker.md](https://github.com/drand/drand/tree/master/docker/README_docker.md).
+[docker/README.md](https://github.com/drand/drand/tree/master/docker/README.md).
 
 ## Usage
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Drand on docker
 
-The main readme for the drand project is [here](../README.md). This readme describes how to run a *production* version of `drand` based on `docker-compose`. 
+The main readme for the drand project is [here](../README.md). This readme describes how to run a *production* version of `drand` based on `docker-compose`.
 
 **Note:** this is meant as a production setup; it notably involves generating TLS certificates for your public-facing server. If you simply want a local demo of drand, run `make demo` in the root folder instead.
 
@@ -15,14 +15,14 @@ a VPS with the following software setup:
 
 ## First steps
 
-Copy/send the `deploy-example` folder on your server, then open a shell in it.
+Copy/send this folder on your server, then open a shell in it.
 You may place this directory where you want, e.g. `~/deploy-example`. Its name is irrelevant too, should you want to change it (just don't call it `~/.drand` which is used for the config files).
 
 At this point, your current working directory should look like this:
 
 ```bash
 $ pwd
-../drand/deploy-example
+/home/drand/deploy-example 
 ------------------------------------------------------------
 $ tree
 .
@@ -30,7 +30,7 @@ $ tree
 │   ├── tls_certificates
 │   └── tls_keypair
 ├── docker-compose.yml
-└── README_docker.md
+└── README.md
 ```
 
 Also make sure `data` is owned by your user, and have rights `740`:
@@ -82,7 +82,7 @@ This guide will continue focusing on drand; jump to the end of this guide to con
 
 ## Public HTTP api
 
-The compose file also opens a public http API to be consumed by the clients. 
+The compose file also opens a public http API to be consumed by the clients.
 This public endpoint is exposed on the 1235 port (private endpont + 1).
 If you wish to not expose the public http endpoint, you need to change the
 docker file to remove references to public port, as follow:
@@ -181,7 +181,7 @@ docker-compose up --build -d
 
 ### Reset the docker state (without losing the keys)
 
-This part is if you need to reset drand's internal state without loosing the keys. 
+This part is if you need to reset drand's internal state without loosing the keys.
 
 #### Method 1: using `drand clean`
 
@@ -248,7 +248,7 @@ server {
   listen 443 ssl http2;
   ssl_protocols   SSLv3 TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers   HIGH:!aNULL:!MD5;
-  
+
   location / {
     // default --public-listen port specified in the docker compose
     grpc_pass grpc://localhost:1234;
@@ -256,13 +256,13 @@ server {
 
   location /group {
     // default --public-listen flag specified in the docker compose
-    proxy_pass http://localhost:1235; 
+    proxy_pass http://localhost:1235;
     proxy_set_header Host $host;
   }
-  
+
   location /public/ {
     // default --public-listen flag specified in the docker compose
-    proxy_pass http://localhost:1235; 
+    proxy_pass http://localhost:1235;
     proxy_set_header Host $host;
   }
 


### PR DESCRIPTION
Renames README_DOCKER.md to README.md so that it renders on the GitHub dir listing. Updates old references.

@nikkolasg there is an entrypoint script in the folder that is neither listed in the readme's tree nor mentioned anywhere else. 