### PR TITLE
HTTP metrics, exposed on http relay

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -7,6 +7,7 @@ import (
 	"github.com/drand/drand/core"
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/metrics"
+	"github.com/drand/drand/metrics/pprof"
 	"github.com/urfave/cli/v2"
 )
 
@@ -44,7 +45,7 @@ func startCmd(c *cli.Context) error {
 	}
 	// Start metrics server
 	if c.IsSet(metricsFlag.Name) {
-		go metrics.Start(c.String(metricsFlag.Name))
+		go metrics.Start(c.String(metricsFlag.Name), pprof.WithProfile())
 	}
 	<-drand.WaitExit()
 

--- a/metrics/pprof/pprof.go
+++ b/metrics/pprof/pprof.go
@@ -1,0 +1,23 @@
+// Package pprof is separated out from metrics to isolate the 'init' functionality of pprof, so that it is
+// included when used by binaries, but not if other drand packages get used or integrated into clients that
+// don't expect the pprof side effect to have taken effect.
+package pprof
+
+import (
+	"net/http"
+
+	pprof "net/http/pprof" // adds default pprof endpoint at /debug/pprof
+)
+
+// WithProfile provides an http mux setup to serve pprof endpoints. it should be mounted at /debug/pprof
+func WithProfile() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", pprof.Index)
+	mux.HandleFunc("/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/profile", pprof.Profile)
+	mux.HandleFunc("/symbol", pprof.Symbol)
+	mux.HandleFunc("/trace", pprof.Trace)
+
+	return mux
+}


### PR DESCRIPTION
* makes use of pprof a bit safer - only included by binary packages.
* adds HTTP metrics / instruments http server on both drand node and relay
* adds flag to `cmd/relay` for also exposing metrics