### PR TITLE
log to stdout if not otherwise specified

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -87,6 +87,8 @@ func Relay(c *cli.Context) error {
 		}
 		defer logFile.Close()
 		handler = handlers.CombinedLoggingHandler(logFile, handler)
+	} else {
+		handler = handlers.CombinedLoggingHandler(os.Stdout, handler)
 	}
 
 	bind := ":0"


### PR DESCRIPTION
fix #358 