### PR TITLE
feat: add failover client

### DIFF
--- a/client/failover.go
+++ b/client/failover.go
@@ -44,6 +44,7 @@ func (c *failoverWatcher) Watch(ctx context.Context) <-chan Result {
 
 	sendResult := func(r Result) {
 		if latest >= r.Round() {
+			c.log.Warn("failover_client", "randomness notification dropped: out of date", "round", r.Round(), "latest", latest)
 			return
 		}
 		latest = r.Round()
@@ -51,7 +52,7 @@ func (c *failoverWatcher) Watch(ctx context.Context) <-chan Result {
 		select {
 		case ch <- r:
 		default:
-			c.log.Warn("failover_client", "randomness notification dropped due to a full channel")
+			c.log.Warn("failover_client", "randomness notification dropped: full channel")
 		}
 	}
 

--- a/client/failover.go
+++ b/client/failover.go
@@ -1,0 +1,91 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/drand/drand/beacon"
+	"github.com/drand/drand/key"
+	"github.com/drand/drand/log"
+)
+
+const defaultFailoverGracePeriod = time.Second * 5
+
+// NewFailoverWatcher creates a client whose Watch function will failover to
+// Get-ing new randomness if it does not receive it after the passed grace period.
+func NewFailoverWatcher(core Client, group *key.Group, gracePeriod time.Duration, l log.Logger) Client {
+	if gracePeriod == 0 {
+		gracePeriod = defaultFailoverGracePeriod
+	}
+
+	return &failoverWatcher{
+		Client:      core,
+		group:       group,
+		gracePeriod: gracePeriod,
+		log:         l,
+	}
+}
+
+type failoverWatcher struct {
+	Client
+	group       *key.Group
+	gracePeriod time.Duration
+	log         log.Logger
+}
+
+// Watch returns new randomness as it becomes available.
+func (c *failoverWatcher) Watch(ctx context.Context) <-chan Result {
+	var latest uint64
+	ch := make(chan Result, 5)
+
+	sendResult := func(r Result) {
+		if latest >= r.Round() {
+			return
+		}
+		latest = r.Round()
+
+		select {
+		case ch <- r:
+		default:
+			c.log.Warn("failover_client", "randomness notification dropped due to a full channel")
+		}
+	}
+
+	go func() {
+		watchC := c.Client.Watch(ctx)
+		var t *time.Timer
+		defer func() {
+			t.Stop()
+			close(ch)
+		}()
+
+		for {
+			_, nextTime := beacon.NextRound(time.Now().Unix(), c.group.Period, c.group.GenesisTime)
+			remPeriod := time.Duration(nextTime-time.Now().Unix()) * time.Second
+			t = time.NewTimer(remPeriod + c.gracePeriod)
+
+			select {
+			case res, ok := <-watchC:
+				if !ok {
+					return
+				}
+				t.Stop()
+				sendResult(res)
+			case <-t.C:
+				res, err := c.Get(ctx, 0)
+				if ctx.Err() != nil {
+					return
+				}
+				if err != nil {
+					c.log.Warn("failover_client", "failed to failover", "error", err)
+					continue
+				}
+				sendResult(res)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch
+}

--- a/client/failover.go
+++ b/client/failover.go
@@ -13,6 +13,10 @@ const defaultFailoverGracePeriod = time.Second * 5
 
 // NewFailoverWatcher creates a client whose Watch function will failover to
 // Get-ing new randomness if it does not receive it after the passed grace period.
+//
+// Note that this client may skip rounds in some cases: e.g. if the group halts
+// for a bit and then catches up quickly, this could jump up to 'current round'
+// and not emit the intermediate values.
 func NewFailoverWatcher(core Client, group *key.Group, gracePeriod time.Duration, l log.Logger) Client {
 	if gracePeriod == 0 {
 		gracePeriod = defaultFailoverGracePeriod

--- a/client/failover_test.go
+++ b/client/failover_test.go
@@ -97,8 +97,6 @@ func TestFailoverDefaultGrace(t *testing.T) {
 	compare(t, next(t, watchC), &results[0])
 }
 
-var errGet = fmt.Errorf("client get error")
-
 // errOnGetClient sends it's error to an error channel when Get is called.
 type errOnGetClient struct {
 	MockClient
@@ -108,7 +106,7 @@ type errOnGetClient struct {
 
 func (c *errOnGetClient) Get(ctx context.Context, round uint64) (Result, error) {
 	c.errC <- c.err
-	return nil, errGet
+	return nil, c.err
 }
 
 func TestFailoverGetFail(t *testing.T) {

--- a/client/failover_test.go
+++ b/client/failover_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -10,7 +11,17 @@ import (
 	"github.com/drand/drand/log"
 )
 
-func compareResult(t *testing.T, a, b Result) {
+// next reads the next result form the channel and fails the test if it closes before a value is read.
+func next(t *testing.T, ch <-chan Result) Result {
+	r, ok := <-ch
+	if !ok {
+		t.Fatal("closed before result")
+	}
+	return r
+}
+
+// compare asserts that two results are the same.
+func compare(t *testing.T, a, b Result) {
 	if a.Round() != b.Round() {
 		t.Fatal("unexpected result round", a.Round(), b.Round())
 	}
@@ -31,38 +42,17 @@ func TestFailover(t *testing.T) {
 	}
 
 	failC := make(chan Result, 1)
-	failC <- &results[0]
-
 	mockClient := &MockClient{WatchCh: failC, Results: results[1:3]}
 	group := &key.Group{Period: time.Second, GenesisTime: time.Now().Unix()}
 	failoverClient := NewFailoverWatcher(mockClient, group, time.Millisecond*50, log.DefaultLogger)
 	watchC := failoverClient.Watch(ctx)
 
-	r0, ok := <-watchC // Normal operation
-	if !ok {
-		t.Fatal("closed without result")
-	}
-	compareResult(t, r0, &results[0])
-
-	r1, ok := <-watchC // First fail
-	if !ok {
-		t.Fatal("closed without result")
-	}
-	compareResult(t, r1, &results[1])
-
-	r2, ok := <-watchC // Second fail
-	if !ok {
-		t.Fatal("closed without result")
-	}
-	compareResult(t, r2, &results[2])
-
+	failC <- &results[0]
+	compare(t, next(t, watchC), &results[0]) // Normal operation
+	compare(t, next(t, watchC), &results[1]) // First fail
+	compare(t, next(t, watchC), &results[2]) // Second fail
 	failC <- &results[3]
-
-	r3, ok := <-watchC // Resume normal operattion
-	if !ok {
-		t.Fatal("closed without result")
-	}
-	compareResult(t, r3, &results[3])
+	compare(t, next(t, watchC), &results[3]) // Resume normal operattion
 }
 
 func TestFailoverDedupe(t *testing.T) {
@@ -77,34 +67,20 @@ func TestFailoverDedupe(t *testing.T) {
 	}
 
 	failC := make(chan Result, 2)
-	failC <- &results[0]
-
 	mockClient := &MockClient{WatchCh: failC, Results: results[1:2]}
 	group := &key.Group{Period: time.Second, GenesisTime: time.Now().Unix()}
 	failoverClient := NewFailoverWatcher(mockClient, group, time.Millisecond*50, log.DefaultLogger)
 	watchC := failoverClient.Watch(ctx)
 
-	r0, ok := <-watchC // Normal operation
-	if !ok {
-		t.Fatal("closed without result")
-	}
-	compareResult(t, r0, &results[0])
-
-	r1, ok := <-watchC // Failover
-	if !ok {
-		t.Fatal("closed without result")
-	}
-	compareResult(t, r1, &results[1])
+	failC <- &results[0]
+	compare(t, next(t, watchC), &results[0]) // Normal operation
+	compare(t, next(t, watchC), &results[1]) // Failover
 
 	// Two sends but only 1 write to watchC
 	failC <- &results[2]
 	failC <- &results[3]
 
-	r2, ok := <-watchC // Success but duplicate
-	if !ok {
-		t.Fatal("closed without result")
-	}
-	compareResult(t, r2, &results[3])
+	compare(t, next(t, watchC), &results[3]) // Success deduped previous
 }
 
 func TestFailoverDefaultGrace(t *testing.T) {
@@ -118,9 +94,51 @@ func TestFailoverDefaultGrace(t *testing.T) {
 	failoverClient := NewFailoverWatcher(mockClient, group, 0, log.DefaultLogger)
 	watchC := failoverClient.Watch(ctx)
 
-	r0, ok := <-watchC
-	if !ok {
-		t.Fatal("closed without result")
+	compare(t, next(t, watchC), &results[0])
+}
+
+var errGet = fmt.Errorf("client get error")
+
+// errOnGetClient sends it's error to an error channel when Get is called.
+type errOnGetClient struct {
+	MockClient
+	err  error
+	errC chan error
+}
+
+func (c *errOnGetClient) Get(ctx context.Context, round uint64) (Result, error) {
+	c.errC <- c.err
+	return nil, errGet
+}
+
+func TestFailoverGetFail(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	results := []MockResult{
+		{rnd: 1, rand: []byte{1}},
+		{rnd: 2, rand: []byte{2}},
 	}
-	compareResult(t, r0, &results[0])
+
+	failC := make(chan Result, 1)
+	getErr := fmt.Errorf("client get error")
+	getErrC := make(chan error, 1)
+
+	mockClient := &errOnGetClient{MockClient: MockClient{WatchCh: failC}, errC: getErrC, err: getErr}
+	group := &key.Group{Period: time.Second, GenesisTime: time.Now().Unix()}
+	failoverClient := NewFailoverWatcher(mockClient, group, time.Millisecond*50, log.DefaultLogger)
+	watchC := failoverClient.Watch(ctx)
+
+	failC <- &results[0]
+	compare(t, next(t, watchC), &results[0]) // Normal operation
+
+	// Wait for error from failover to Get
+	err, _ := <-getErrC
+	if err != getErr {
+		t.Fatal("expected error from failover to Get")
+	}
+
+	// Write another result and ensure we recover
+	failC <- &results[1]
+	compare(t, next(t, watchC), &results[1])
 }

--- a/client/failover_test.go
+++ b/client/failover_test.go
@@ -1,0 +1,126 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drand/drand/key"
+	"github.com/drand/drand/log"
+)
+
+func compareResult(t *testing.T, a, b Result) {
+	if a.Round() != b.Round() {
+		t.Fatal("unexpected result round", a.Round(), b.Round())
+	}
+	if bytes.Compare(a.Randomness(), b.Randomness()) != 0 {
+		t.Fatal("unexpected result randomness", a.Randomness(), b.Randomness())
+	}
+}
+
+func TestFailover(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	results := []MockResult{
+		{rnd: 1, rand: []byte{1}}, // Success
+		{rnd: 2, rand: []byte{2}}, // Failover
+		{rnd: 3, rand: []byte{3}}, // Failover
+		{rnd: 4, rand: []byte{4}}, // Success
+	}
+
+	failC := make(chan Result, 1)
+	failC <- &results[0]
+
+	mockClient := &MockClient{WatchCh: failC, Results: results[1:3]}
+	group := &key.Group{Period: time.Second, GenesisTime: time.Now().Unix()}
+	failoverClient := NewFailoverWatcher(mockClient, group, time.Millisecond*50, log.DefaultLogger)
+	watchC := failoverClient.Watch(ctx)
+
+	r0, ok := <-watchC // Normal operation
+	if !ok {
+		t.Fatal("closed without result")
+	}
+	compareResult(t, r0, &results[0])
+
+	r1, ok := <-watchC // First fail
+	if !ok {
+		t.Fatal("closed without result")
+	}
+	compareResult(t, r1, &results[1])
+
+	r2, ok := <-watchC // Second fail
+	if !ok {
+		t.Fatal("closed without result")
+	}
+	compareResult(t, r2, &results[2])
+
+	failC <- &results[3]
+
+	r3, ok := <-watchC // Resume normal operattion
+	if !ok {
+		t.Fatal("closed without result")
+	}
+	compareResult(t, r3, &results[3])
+}
+
+func TestFailoverDedupe(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	results := []MockResult{
+		{rnd: 1, rand: []byte{1}}, // Success
+		{rnd: 2, rand: []byte{2}}, // Failover
+		{rnd: 2, rand: []byte{2}}, // Success but duplicate
+		{rnd: 3, rand: []byte{3}}, // Success
+	}
+
+	failC := make(chan Result, 2)
+	failC <- &results[0]
+
+	mockClient := &MockClient{WatchCh: failC, Results: results[1:2]}
+	group := &key.Group{Period: time.Second, GenesisTime: time.Now().Unix()}
+	failoverClient := NewFailoverWatcher(mockClient, group, time.Millisecond*50, log.DefaultLogger)
+	watchC := failoverClient.Watch(ctx)
+
+	r0, ok := <-watchC // Normal operation
+	if !ok {
+		t.Fatal("closed without result")
+	}
+	compareResult(t, r0, &results[0])
+
+	r1, ok := <-watchC // Failover
+	if !ok {
+		t.Fatal("closed without result")
+	}
+	compareResult(t, r1, &results[1])
+
+	// Two sends but only 1 write to watchC
+	failC <- &results[2]
+	failC <- &results[3]
+
+	r2, ok := <-watchC // Success but duplicate
+	if !ok {
+		t.Fatal("closed without result")
+	}
+	compareResult(t, r2, &results[3])
+}
+
+func TestFailoverDefaultGrace(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	results := []MockResult{{rnd: 1, rand: []byte{1}}}
+	failC := make(chan Result)
+	mockClient := &MockClient{WatchCh: failC, Results: results}
+	group := &key.Group{Period: time.Second * 10, GenesisTime: time.Now().Unix() - 9}
+	failoverClient := NewFailoverWatcher(mockClient, group, 0, log.DefaultLogger)
+	watchC := failoverClient.Watch(ctx)
+
+	r0, ok := <-watchC
+	if !ok {
+		t.Fatal("closed without result")
+	}
+	compareResult(t, r0, &results[0])
+}


### PR DESCRIPTION
`NewFailoverWatcher` creates a client whose Watch function will failover to `Get`-ing new randomness if it does not receive it after the passed grace period.

Note: with the failover watcher - if network conditions slow down the delivery of a round, the client will skip as many rounds as the duration of the network condition. i.e. the failover is currently only catering for the case where a pubsub message is not received, not when network issues occur.

TODO:

* [x] Add test