### PR TITLE
fix: coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,14 +40,10 @@ jobs:
         CIRCLE_CI: on
     steps:
       - checkout
-      - run: go get github.com/wadey/gocovmerge
       - run: go get -v -t -d ./...
       - run:
           name: Tests with coverage
-          command: |
-            make test-unit-cover
-            gocovmerge coverage.txt democoverage.txt > coverage.txt
-            rm democoverage.txt
+          command: make test-unit-cover
       - run: bash <(curl -s https://codecov.io/bash)
   deploy:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 test: test-unit test-integration
 
 test-unit:
-	GO111MODULE=on go test -race -v $(go list ./... | grep -v /demo/)
+	GO111MODULE=on go test -race -v $$(go list ./... | grep -v /demo/)
 
 test-unit-cover:
-	GO111MODULE=on go test -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=all $(go list ./... | grep -v /demo/)
+	GO111MODULE=on go test -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=all $$(go list ./... | grep -v /demo/)
 	GO111MODULE=on go test -v -coverprofile=democoverage.txt -covermode=atomic -coverpkg=./... ./demo
 
 test-integration:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test-unit:
 
 test-unit-cover:
 	GO111MODULE=on go test -v -coverprofile=coverage.txt -covermode=atomic -coverpkg=all $$(go list ./... | grep -v /demo/)
-	GO111MODULE=on go test -v -coverprofile=democoverage.txt -covermode=atomic -coverpkg=./... ./demo
+	GO111MODULE=on go test -v -coverprofile=demo/coverage.txt -covermode=atomic -coverpkg=./... ./demo
 
 test-integration:
 	go test -v ./demo


### PR DESCRIPTION
I was seeing all the `client/*` coverage wiped away by gocovmerge. Good news though, codecov detects and merges coverage files so there's no need for us to do it on circleci. It now uploads both reports:

![Screenshot 2020-05-22 at 11 55 20](https://user-images.githubusercontent.com/152863/82661212-82c5a200-9c23-11ea-865a-c7ac809da0f9.png)

Note that I changed the demo coverage output location.

We now see coverage on all coverage files, including `client/`:

![Screenshot 2020-05-22 at 11 56 48](https://user-images.githubusercontent.com/152863/82661345-c02a2f80-9c23-11ea-8220-41ad5cd26520.png)

fixes https://github.com/drand/drand/issues/370