### PR TITLE
feat: gossip client swarm bind

### DIFF
--- a/cmd/relay-gossip/lp2p/swarm.go
+++ b/cmd/relay-gossip/lp2p/swarm.go
@@ -1,0 +1,38 @@
+package lp2p
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// SwarmBind ensures a persistent connection between host and peers by periodically connecting to them.
+func SwarmBind(ctx context.Context, h host.Host, bindAddrs []ma.Multiaddr, period time.Duration) {
+	go func() {
+		for {
+			t := time.NewTimer(period)
+			select {
+			case <-t.C:
+				for _, ma := range bindAddrs {
+					ai, err := peer.AddrInfoFromP2pAddr(ma)
+					if err != nil {
+						fmt.Println("invalid p2p address", err)
+						continue
+					}
+					err = h.Connect(ctx, *ai)
+					if err != nil {
+						fmt.Printf("failed to connect to %v\n", ma)
+						continue
+					}
+				}
+			case <-ctx.Done():
+				t.Stop()
+				return
+			}
+		}
+	}()
+}

--- a/cmd/relay-gossip/lp2p/swarm_test.go
+++ b/cmd/relay-gossip/lp2p/swarm_test.go
@@ -1,0 +1,86 @@
+package lp2p
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/multiformats/go-multiaddr"
+)
+
+func isConnected(h0, h1 host.Host) bool {
+	return len(h0.Network().ConnsToPeer(h1.ID())) > 0
+}
+
+func waitConnect(ctx context.Context, h0, h1 host.Host, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if isConnected(h0, h1) {
+			return nil
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+}
+
+func TestSwarmBind(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h0, err := libp2p.New(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h0.Close()
+
+	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h1, err := libp2p.New(ctx, libp2p.Identity(priv))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if isConnected(h0, h1) {
+		t.Fatal("peers should not be connected yet")
+	}
+
+	h1Addrs := h1.Addrs()
+	h1P2PAddr, _ := multiaddr.NewMultiaddr(fmt.Sprintf("%v/p2p/%v", h1Addrs[0], h1.ID()))
+
+	SwarmBind(ctx, h0, []multiaddr.Multiaddr{h1P2PAddr}, time.Second)
+
+	err = waitConnect(ctx, h0, h1, time.Second*10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h1.Close() // get disconnected
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(time.Second * 2)
+
+	// start up again
+	h1, err = libp2p.New(ctx, libp2p.Identity(priv), libp2p.ListenAddrs(h1Addrs...))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = waitConnect(ctx, h0, h1, time.Second*10)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/relay-gossip/main.go
+++ b/cmd/relay-gossip/main.go
@@ -208,9 +208,13 @@ var clientCmd = &cli.Command{
 			return xerrors.Errorf("generating ed25519 key: %w", err)
 		}
 
-		_, ps, err := lp2p.ConstructHost(datastore.NewMapDatastore(), priv, "/ip4/0.0.0.0/tcp/0", bootstrap)
+		h, ps, err := lp2p.ConstructHost(datastore.NewMapDatastore(), priv, "/ip4/0.0.0.0/tcp/0", bootstrap)
 		if err != nil {
 			return xerrors.Errorf("constructing host: %w", err)
+		}
+
+		if len(bootstrap) > 0 {
+			lp2p.SwarmBind(context.Background(), h, bootstrap, time.Second*5)
 		}
 
 		c, err := client.NewWithPubsub(ps, cctx.String("network-name"))


### PR DESCRIPTION
This PR adds a function that periodically connects to peers passed in the `peer-with` param. This ensures that if we get disconnected from a gossipsub drand relay we'll reconnect again.