### PR TITLE
Close HTTP Response Body after use to allow HTTP Keep-Alive

### DIFF
--- a/client/http.go
+++ b/client/http.go
@@ -76,6 +76,7 @@ func (h *httpClient) FetchGroupInfo(groupHash []byte) (*key.Group, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer groupResp.Body.Close()
 
 	protoGrp := drand.GroupPacket{}
 	if err := json.NewDecoder(groupResp.Body).Decode(&protoGrp); err != nil {
@@ -129,6 +130,7 @@ func (h *httpClient) Get(ctx context.Context, round uint64) (Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer randResponse.Body.Close()
 
 	randResp := RandomData{}
 	if err := json.NewDecoder(randResponse.Body).Decode(&randResp); err != nil {


### PR DESCRIPTION
If Response.Body is not closed, the connection cannot be reused.
This patch reduces time needed for lotus chain generation and sync tests with
drand from 45s to 18s.