### PR TITLE
http export of binary version

### DIFF
--- a/client/http_test.go
+++ b/client/http_test.go
@@ -29,7 +29,7 @@ func withServer(t *testing.T) (string, []byte, context.CancelFunc) {
 
 	client := drand.NewPublicClient(conn)
 
-	handler, err := dhttp.New(ctx, client, nil)
+	handler, err := dhttp.New(ctx, client, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -735,6 +735,7 @@ func contextToConfig(c *cli.Context) *core.Config {
 	}
 	config := c.String(folderFlag.Name)
 	opts = append(opts, core.WithConfigFolder(config))
+	opts = append(opts, core.WithVersion(fmt.Sprintf("%s/%s", version, gitCommit)))
 
 	if c.Bool("tls-disable") {
 		opts = append(opts, core.WithInsecure())

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -735,7 +735,7 @@ func contextToConfig(c *cli.Context) *core.Config {
 	}
 	config := c.String(folderFlag.Name)
 	opts = append(opts, core.WithConfigFolder(config))
-	opts = append(opts, core.WithVersion(fmt.Sprintf("%s/%s", version, gitCommit)))
+	opts = append(opts, core.WithVersion(fmt.Sprintf("drand/%s (%s)", version, gitCommit)))
 
 	if c.Bool("tls-disable") {
 		opts = append(opts, core.WithInsecure())

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -82,7 +82,7 @@ func Relay(c *cli.Context) error {
 
 	client := drand.NewPublicClient(conn)
 
-	handler, err := dhttp.New(c.Context, client, fmt.Sprintf("%s/%s", version, gitCommit), log.DefaultLogger.With("binary", "relay"))
+	handler, err := dhttp.New(c.Context, client, fmt.Sprintf("drand/%s (%s)", version, gitCommit), log.DefaultLogger.With("binary", "relay"))
 	if err != nil {
 		return fmt.Errorf("Failed to create rest handler: %w", err)
 	}

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -19,6 +19,13 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+// Automatically set through -ldflags
+// Example: go install -ldflags "-X main.version=`git describe --tags` -X main.gitCommit=`git rev-parse HEAD`"
+var (
+	version   = "master"
+	gitCommit = "none"
+)
+
 var accessLogFlag = &cli.StringFlag{
 	Name:  "access-log",
 	Usage: "file to log http accesses to",
@@ -75,7 +82,7 @@ func Relay(c *cli.Context) error {
 
 	client := drand.NewPublicClient(conn)
 
-	handler, err := dhttp.New(c.Context, client, log.DefaultLogger.With("binary", "relay"))
+	handler, err := dhttp.New(c.Context, client, fmt.Sprintf("%s/%s", version, gitCommit), log.DefaultLogger.With("binary", "relay"))
 	if err != nil {
 		return fmt.Errorf("Failed to create rest handler: %w", err)
 	}

--- a/core/config.go
+++ b/core/config.go
@@ -20,6 +20,7 @@ type ConfigOption func(*Config)
 type Config struct {
 	configFolder      string
 	dbFolder          string
+	version           string
 	privateListenAddr string
 	publicListenAddr  string
 	controlPort       string
@@ -88,6 +89,11 @@ func (d *Config) PublicListenAddress(defaultAddr string) string {
 		return d.publicListenAddr
 	}
 	return defaultAddr
+}
+
+// Version returns the configured version of the binary
+func (d *Config) Version() string {
+	return d.version
 }
 
 // ControlPort returns the port used for control port communications
@@ -259,5 +265,12 @@ func withClock(c clock.Clock) ConfigOption {
 func WithPrivateRandomness() ConfigOption {
 	return func(d *Config) {
 		d.enablePrivate = true
+	}
+}
+
+// WithVersion sets a version for drand, a visible string to other peers.
+func WithVersion(version string) ConfigOption {
+	return func(d *Config) {
+		d.version = version
 	}
 }

--- a/core/drand.go
+++ b/core/drand.go
@@ -107,7 +107,7 @@ func initDrand(s key.Store, c *Config) (*Drand, error) {
 		var err error
 		d.log.Info("network", "tls-disable")
 		if pubAddr != "" {
-			handler, err := http.New(ctx, &drandProxy{d}, logger.With("server", "http"))
+			handler, err := http.New(ctx, &drandProxy{d}, c.Version(), logger.With("server", "http"))
 			if err != nil {
 				return nil, err
 			}
@@ -122,7 +122,7 @@ func initDrand(s key.Store, c *Config) (*Drand, error) {
 		var err error
 		d.log.Info("network", "tls-enabled")
 		if pubAddr != "" {
-			handler, err := http.New(ctx, &drandProxy{d}, logger.With("server", "http"))
+			handler, err := http.New(ctx, &drandProxy{d}, c.Version(), logger.With("server", "http"))
 			if err != nil {
 				return nil, err
 			}

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -36,7 +36,7 @@ func TestHTTPRelay(t *testing.T) {
 	defer cancel()
 	client := withClient(t)
 
-	handler, err := New(ctx, client, nil)
+	handler, err := New(ctx, client, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,7 @@ func TestHTTPWaiting(t *testing.T) {
 	defer cancel()
 	client := withClient(t)
 
-	handler, err := New(ctx, client, nil)
+	handler, err := New(ctx, client, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Defer to @hsanjuan on value of this.
We have metrics that should capture this in influx, but it's nice to be able to go to `/version` and see when the thing you're interacting with was built e.g. to know if a fix should be in the version you're interacting with.