### PR TITLE
refactor: rename network-name to chain-hash

### DIFF
--- a/cmd/relay-gossip/client/client.go
+++ b/cmd/relay-gossip/client/client.go
@@ -31,9 +31,9 @@ type Client struct {
 
 // WithPubsub provides an option for integrating pubsub notification
 // into a drand client.
-func WithPubsub(ps *pubsub.PubSub, networkName string) dclient.Option {
+func WithPubsub(ps *pubsub.PubSub, chainHash string) dclient.Option {
 	return dclient.WithWatcher(func(_ *key.Group) (dclient.Watcher, error) {
-		c, err := NewWithPubsub(ps, networkName)
+		c, err := NewWithPubsub(ps, chainHash)
 		if err != nil {
 			return nil, err
 		}
@@ -42,8 +42,8 @@ func WithPubsub(ps *pubsub.PubSub, networkName string) dclient.Option {
 }
 
 // NewWithPubsub creates a gossip randomness client.
-func NewWithPubsub(ps *pubsub.PubSub, networkName string) (*Client, error) {
-	t, err := ps.Join(lp2p.PubSubTopic(networkName))
+func NewWithPubsub(ps *pubsub.PubSub, chainHash string) (*Client, error) {
+	t, err := ps.Join(lp2p.PubSubTopic(chainHash))
 	if err != nil {
 		return nil, xerrors.Errorf("joining pubsub: %w", err)
 	}

--- a/cmd/relay-gossip/client/relayclient_test.go
+++ b/cmd/relay-gossip/client/relayclient_test.go
@@ -25,7 +25,7 @@ func TestClient(t *testing.T) {
 
 	// start mock relay-node
 	cfg := &node.GossipRelayConfig{
-		Network:         "test",
+		ChainHash:       "test",
 		PeerWith:        nil,
 		Addr:            "/ip4/0.0.0.0/tcp/" + test.FreePort(),
 		DataDir:         path.Join(os.TempDir(), "test-gossip-relay-node-datastore"),
@@ -60,7 +60,7 @@ func TestClient(t *testing.T) {
 	}
 }
 
-func newTestClient(name string, relayMultiaddr []ma.Multiaddr, network string) (*Client, error) {
+func newTestClient(name string, relayMultiaddr []ma.Multiaddr, chainHash string) (*Client, error) {
 	ds, err := bds.NewDatastore(path.Join(os.TempDir(), "client-"+name+"-datastore"), nil)
 	if err != nil {
 		return nil, err
@@ -78,5 +78,5 @@ func newTestClient(name string, relayMultiaddr []ma.Multiaddr, network string) (
 	if err != nil {
 		return nil, err
 	}
-	return NewWithPubsub(ps, network)
+	return NewWithPubsub(ps, chainHash)
 }

--- a/cmd/relay-gossip/main.go
+++ b/cmd/relay-gossip/main.go
@@ -32,8 +32,9 @@ func main() {
 		Usage:   "pubsub relay for randomness beacon",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:    "network-name",
-				Aliases: []string{"nn"},
+				Name:     "chain-hash",
+				Aliases:  []string{"h"},
+				Required: true,
 			},
 		},
 		Commands: []*cli.Command{runCmd, clientCmd, idCmd},
@@ -80,7 +81,7 @@ var runCmd = &cli.Command{
 
 	Action: func(cctx *cli.Context) error {
 		cfg := &node.GossipRelayConfig{
-			Network:         cctx.String("network-name"),
+			ChainHash:       cctx.String("chain-hash"),
 			PeerWith:        cctx.StringSlice(peerWithFlag.Name),
 			Addr:            cctx.String("listen"),
 			DataDir:         cctx.String("store"),
@@ -116,7 +117,7 @@ var clientCmd = &cli.Command{
 			return xerrors.Errorf("constructing host: %w", err)
 		}
 
-		c, err := client.NewWithPubsub(ps, cctx.String("network-name"))
+		c, err := client.NewWithPubsub(ps, cctx.String("chain-hash"))
 		if err != nil {
 			return xerrors.Errorf("constructing client: %w", err)
 		}

--- a/cmd/relay-gossip/node/relaynode.go
+++ b/cmd/relay-gossip/node/relaynode.go
@@ -22,7 +22,8 @@ import (
 
 // GossipRelayConfig configures a gossip relay node.
 type GossipRelayConfig struct {
-	Network         string
+	// ChainHash is a hash that uniquely identifies the drand chain.
+	ChainHash       string
 	PeerWith        []string
 	Addr            string
 	DataDir         string
@@ -77,7 +78,7 @@ func NewGossipRelayNode(l log.Logger, cfg *GossipRelayConfig) (*GossipRelayNode,
 		l.Info(fmt.Sprintf("%s/p2p/%s\n", a, h.ID()))
 	}
 
-	t, err := ps.Join(lp2p.PubSubTopic(cfg.Network))
+	t, err := ps.Join(lp2p.PubSubTopic(cfg.ChainHash))
 	if err != nil {
 		return nil, xerrors.Errorf("joining topic: %w", err)
 	}


### PR DESCRIPTION
This PR renames network-name to chain-hash and makes the parameter required - this stops the relay or client publishing to a topic with an empty string.

BREAKING CHANGE: the `network-name` option to the relay-gossip CLI has been renamed `chain-hash` and is now a required parameter.