### PR TITLE
fix: run relay-gossip tests on CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - checkout
       - run: go get -u github.com/ory/go-acc
       - run: go get -v -t -d ./...
-      - run: go-acc ./... cmd/relay-gossip
+      - run: go-acc ./... ./cmd/relay-gossip
       - run: bash <(curl -s https://codecov.io/bash)
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - checkout
       - run: go get -u github.com/ory/go-acc
       - run: go get -v -t -d ./...
-      - run: go-acc ./...
+      - run: go-acc ./... cmd/relay-gossip
       - run: bash <(curl -s https://codecov.io/bash)
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,8 @@ jobs:
       - checkout
       - run: go get -u github.com/ory/go-acc
       - run: go get -v -t -d ./...
-      - run: go-acc ./... ./cmd/relay-gossip
+      - run: go-acc ./...
+      - run: cd ./cmd/relay-gossip && go-acc ./...
       - run: bash <(curl -s https://codecov.io/bash)
   deploy:
     docker:


### PR DESCRIPTION
Currently not included because it is a separate module.

I added a test in https://github.com/drand/drand/pull/404 but it was not showing in codecov.