### PR TITLE
fix: nil pointer when using failover without passing chainInfo

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -49,7 +49,7 @@ func TestClientMultiple(t *testing.T) {
 	}
 }
 
-func TestClientWithGroup(t *testing.T) {
+func TestClientWithChainInfo(t *testing.T) {
 	id := test.GenerateIDs(1)[0]
 	chainInfo := &chain.Info{
 		PublicKey:   id.Public.Key,
@@ -107,5 +107,20 @@ func TestClientWithoutCache(t *testing.T) {
 	_, e = c.Get(context.Background(), 0)
 	if e == nil {
 		t.Fatal("cache should be disabled.")
+	}
+}
+
+func TestClientWithFailover(t *testing.T) {
+	addr1, hash, cancel := withServer(t)
+	defer cancel()
+
+	// ensure a client with failover can be created successfully without error
+	_, err := New(
+		WithHTTPEndpoints([]string{"http://" + addr1}),
+		WithChainHash(hash),
+		WithFailoverGracePeriod(time.Second*5),
+	)
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/client/failover.go
+++ b/client/failover.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/drand/drand/chain"
@@ -18,11 +19,15 @@ const defaultFailoverGracePeriod = time.Second * 5
 // and not emit the intermediate values.
 //
 // If grace period is 0, it'll be set to 5s or the chain period / 2, whichever is smaller.
-func NewFailoverWatcher(core Client, chainInfo *chain.Info, gracePeriod time.Duration, l log.Logger) Client {
+func NewFailoverWatcher(core Client, chainInfo *chain.Info, gracePeriod time.Duration, l log.Logger) (Client, error) {
+	if chainInfo == nil {
+		return nil, errors.New("missing chain info")
+	}
+
 	if gracePeriod == 0 {
 		gracePeriod = defaultFailoverGracePeriod
 
-		if gracePeriod > chainInfo.Period / 2 {
+		if gracePeriod > chainInfo.Period/2 {
 			gracePeriod = chainInfo.Period / 2
 		}
 	}
@@ -32,7 +37,7 @@ func NewFailoverWatcher(core Client, chainInfo *chain.Info, gracePeriod time.Dur
 		chainInfo:   chainInfo,
 		gracePeriod: gracePeriod,
 		log:         l,
-	}
+	}, nil
 }
 
 type failoverWatcher struct {


### PR DESCRIPTION
When `chainInfo` is not passed to a new client, it's retrieved from `/info` and set on `cfg.chainInfo`.

The `NewFailoverWatcher` constructor was being called outside of `makeClient` so although `makeClient` retrieved `chainInfo` and set it on `cfg.chainInfo`, it was not observed by `NewFailoverWatcher` because `makeClient` is passed a _copy_ of `clientConfig` not a pointer.

This PR moves the `NewFailoverWatcher` constructor into `makeClient`, as well as `NewCachingClient` and `newWatchAggregator`.