### PR TITLE
feat: gossip relay from HTTP CDN

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/drand/drand/chain"
+	cmock "github.com/drand/drand/client/test/mock"
 	"github.com/drand/drand/test"
-	"github.com/drand/drand/test/mock"
 )
 
 func TestClientConstraints(t *testing.T) {
@@ -23,7 +23,7 @@ func TestClientConstraints(t *testing.T) {
 		t.Fatal("Client needs root of trust unless insecure specified explicitly")
 	}
 
-	addr, _, cancel := mock.NewMockHTTPPublicServer(t, false)
+	addr, _, cancel := cmock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
 	if _, e := New(WithInsecureHTTPEndpoints([]string{"http://" + addr})); e != nil {
@@ -32,9 +32,9 @@ func TestClientConstraints(t *testing.T) {
 }
 
 func TestClientMultiple(t *testing.T) {
-	addr1, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
+	addr1, chainInfo, cancel := cmock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
-	addr2, _, cancel2 := mock.NewMockHTTPPublicServer(t, false)
+	addr2, _, cancel2 := cmock.NewMockHTTPPublicServer(t, false)
 	defer cancel2()
 
 	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1, "http://" + addr2}), WithChainHash(chainInfo.Hash()))
@@ -68,7 +68,7 @@ func TestClientWithChainInfo(t *testing.T) {
 }
 
 func TestClientCache(t *testing.T) {
-	addr1, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
+	addr1, chainInfo, cancel := cmock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
 	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1}), WithChainHash(chainInfo.Hash()), WithCacheSize(1))
@@ -93,7 +93,7 @@ func TestClientCache(t *testing.T) {
 }
 
 func TestClientWithoutCache(t *testing.T) {
-	addr1, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
+	addr1, chainInfo, cancel := cmock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
 	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1}), WithChainHash(chainInfo.Hash()), WithCacheSize(0))
@@ -112,7 +112,7 @@ func TestClientWithoutCache(t *testing.T) {
 }
 
 func TestClientWithFailover(t *testing.T) {
-	addr1, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
+	addr1, chainInfo, cancel := cmock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
 	// ensure a client with failover can be created successfully without error
@@ -127,7 +127,7 @@ func TestClientWithFailover(t *testing.T) {
 }
 
 func TestClientWithWatcher(t *testing.T) {
-	addr1, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
+	addr1, chainInfo, cancel := cmock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
 	results := []MockResult{

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/test"
+	"github.com/drand/drand/test/mock"
 )
 
 func TestClientConstraints(t *testing.T) {
@@ -22,7 +23,7 @@ func TestClientConstraints(t *testing.T) {
 		t.Fatal("Client needs root of trust unless insecure specified explicitly")
 	}
 
-	addr, _, cancel := withServer(t, false)
+	addr, _, cancel := mock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
 	if _, e := New(WithInsecureHTTPEndpoints([]string{"http://" + addr})); e != nil {
@@ -31,12 +32,12 @@ func TestClientConstraints(t *testing.T) {
 }
 
 func TestClientMultiple(t *testing.T) {
-	addr1, hash, cancel := withServer(t, false)
+	addr1, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
-	addr2, _, cancel2 := withServer(t, false)
+	addr2, _, cancel2 := mock.NewMockHTTPPublicServer(t, false)
 	defer cancel2()
 
-	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1, "http://" + addr2}), WithChainHash(hash))
+	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1, "http://" + addr2}), WithChainHash(chainInfo.Hash()))
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -67,10 +68,10 @@ func TestClientWithChainInfo(t *testing.T) {
 }
 
 func TestClientCache(t *testing.T) {
-	addr1, hash, cancel := withServer(t, false)
+	addr1, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
-	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1}), WithChainHash(hash), WithCacheSize(1))
+	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1}), WithChainHash(chainInfo.Hash()), WithCacheSize(1))
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -92,10 +93,10 @@ func TestClientCache(t *testing.T) {
 }
 
 func TestClientWithoutCache(t *testing.T) {
-	addr1, hash, cancel := withServer(t, false)
+	addr1, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
-	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1}), WithChainHash(hash), WithCacheSize(0))
+	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1}), WithChainHash(chainInfo.Hash()), WithCacheSize(0))
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -111,13 +112,13 @@ func TestClientWithoutCache(t *testing.T) {
 }
 
 func TestClientWithFailover(t *testing.T) {
-	addr1, hash, cancel := withServer(t, false)
+	addr1, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
 	// ensure a client with failover can be created successfully without error
 	_, err := New(
 		WithHTTPEndpoints([]string{"http://" + addr1}),
-		WithChainHash(hash),
+		WithChainHash(chainInfo.Hash()),
 		WithFailoverGracePeriod(time.Second*5),
 	)
 	if err != nil {
@@ -126,7 +127,7 @@ func TestClientWithFailover(t *testing.T) {
 }
 
 func TestClientWithWatcher(t *testing.T) {
-	addr1, hash, cancel := withServer(t, false)
+	addr1, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
 	results := []MockResult{
@@ -146,7 +147,7 @@ func TestClientWithWatcher(t *testing.T) {
 
 	c, err := New(
 		WithHTTPEndpoints([]string{"http://" + addr1}),
-		WithChainHash(hash),
+		WithChainHash(chainInfo.Hash()),
 		WithWatcher(watcherCtor),
 	)
 	if err != nil {

--- a/client/http.go
+++ b/client/http.go
@@ -114,7 +114,7 @@ func (h *httpClient) FetchChainInfo(chainHash []byte) (*chain.Info, error) {
 	}
 
 	if chainHash == nil {
-		h.l.Warn("http_client", "instantiated without trustroot", "groupHash", hex.EncodeToString(chainInfo.Hash()))
+		h.l.Warn("http_client", "instantiated without trustroot", "chainHash", hex.EncodeToString(chainInfo.Hash()))
 	}
 	if chainHash != nil && !bytes.Equal(chainInfo.Hash(), chainHash) {
 		return nil, fmt.Errorf("%s does not advertise the expected drand group (%x vs %x)", h.root, chainInfo.Hash(), chainHash)

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/drand/drand/test/mock"
+	"github.com/drand/drand/client/test/mock"
 )
 
 func TestHTTPClient(t *testing.T) {

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -87,10 +87,6 @@ func TestHTTPWatch(t *testing.T) {
 	if len(first.Randomness()) == 0 {
 		t.Fatal("should get randomness from watching")
 	}
-	_, ok = <-result
-	if ok {
-		// Note. there is a second value polled for by the client, but it will
-		// be invalid per the mocked grpc backing server.
-		t.Fatal("second result should fail per context timeout")
+	for range result { // drain the channel until the context expires
 	}
 }

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -2,73 +2,18 @@ package client
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"testing"
 	"time"
 
-	"github.com/drand/drand/chain"
-	dhttp "github.com/drand/drand/http"
-	"github.com/drand/drand/protobuf/drand"
 	"github.com/drand/drand/test/mock"
-	"google.golang.org/grpc"
 )
 
-func withServer(t *testing.T, badSecondRound bool) (string, []byte, context.CancelFunc) {
-	t.Helper()
-	l, s := mock.NewMockGRPCPublicServer(":0", badSecondRound)
-	lAddr := l.Addr()
-	go l.Start()
-
-	conn, err := grpc.Dial(lAddr, grpc.WithInsecure())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	client := drand.NewPublicClient(conn)
-
-	handler, err := dhttp.New(ctx, client, "", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var hash []byte
-	for i := 0; i < 3; i++ {
-		protoInfo, err := s.ChainInfo(ctx, &drand.ChainInfoRequest{})
-		if err != nil {
-			time.Sleep(10 * time.Millisecond)
-			continue
-		}
-		chainInfo, err := chain.InfoFromProto(protoInfo)
-		if err != nil {
-			time.Sleep(10 * time.Millisecond)
-			continue
-		}
-		hash = chainInfo.Hash()
-		break
-	}
-	if hash == nil {
-		t.Fatal("could not use server after 3 attempts.")
-	}
-
-	listener, err := net.Listen("tcp", ":0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	server := http.Server{Handler: handler}
-	go server.Serve(listener)
-	return listener.Addr().String(), hash, func() {
-		server.Shutdown(ctx)
-		cancel()
-	}
-}
 func TestHTTPClient(t *testing.T) {
-	addr, hash, cancel := withServer(t, true)
+	addr, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, true)
 	defer cancel()
 
-	httpClient, err := NewHTTPClient("http://"+addr, hash, http.DefaultTransport)
+	httpClient, err := NewHTTPClient("http://"+addr, chainInfo.Hash(), http.DefaultTransport)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,10 +41,10 @@ func TestHTTPClient(t *testing.T) {
 }
 
 func TestHTTPGetLatest(t *testing.T) {
-	addr, hash, cancel := withServer(t, false)
+	addr, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
-	httpClient, err := NewHTTPClient("http://"+addr, hash, http.DefaultTransport)
+	httpClient, err := NewHTTPClient("http://"+addr, chainInfo.Hash(), http.DefaultTransport)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,10 +69,10 @@ func TestHTTPGetLatest(t *testing.T) {
 }
 
 func TestHTTPWatch(t *testing.T) {
-	addr, hash, cancel := withServer(t, false)
+	addr, chainInfo, cancel := mock.NewMockHTTPPublicServer(t, false)
 	defer cancel()
 
-	httpClient, err := NewHTTPClient("http://"+addr, hash, http.DefaultTransport)
+	httpClient, err := NewHTTPClient("http://"+addr, chainInfo.Hash(), http.DefaultTransport)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/test/mock/httpserver.go
+++ b/client/test/mock/httpserver.go
@@ -10,13 +10,14 @@ import (
 	"github.com/drand/drand/chain"
 	dhttp "github.com/drand/drand/http"
 	"github.com/drand/drand/protobuf/drand"
+	"github.com/drand/drand/test/mock"
 	"google.golang.org/grpc"
 )
 
 // NewMockHTTPPublicServer creates a mock drand HTTP server for testing.
 func NewMockHTTPPublicServer(t *testing.T, badSecondRound bool) (string, *chain.Info, context.CancelFunc) {
 	t.Helper()
-	l, s := NewMockGRPCPublicServer(":0", badSecondRound)
+	l, s := mock.NewMockGRPCPublicServer(":0", badSecondRound)
 	lAddr := l.Addr()
 	go l.Start()
 

--- a/cmd/relay-gossip/client/client.go
+++ b/cmd/relay-gossip/client/client.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/drand/drand/chain"
-	"github.com/drand/drand/client"
 	dclient "github.com/drand/drand/client"
 	"github.com/drand/drand/cmd/relay-gossip/lp2p"
 	"github.com/drand/drand/protobuf/drand"
@@ -189,7 +188,7 @@ func (c *Client) Sub(ch chan drand.PublicRandResponse) UnsubFunc {
 }
 
 // Watch implements the dclient.Watcher interface
-func (c *Client) Watch(ctx context.Context) <-chan client.Result {
+func (c *Client) Watch(ctx context.Context) <-chan dclient.Result {
 	innerCh := make(chan drand.PublicRandResponse)
 	outerCh := make(chan dclient.Result)
 	end := c.Sub(innerCh)

--- a/cmd/relay-gossip/client/relayclient_test.go
+++ b/cmd/relay-gossip/client/relayclient_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 
 	"github.com/drand/drand/chain"
+	"github.com/drand/drand/client/test/mock"
 	"github.com/drand/drand/cmd/relay-gossip/lp2p"
 	"github.com/drand/drand/cmd/relay-gossip/node"
 	dlog "github.com/drand/drand/log"
 	"github.com/drand/drand/test"
-	"github.com/drand/drand/test/mock"
 	bds "github.com/ipfs/go-ds-badger2"
 	ma "github.com/multiformats/go-multiaddr"
 )

--- a/cmd/relay-gossip/client/relayclient_test.go
+++ b/cmd/relay-gossip/client/relayclient_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 
 	"github.com/drand/drand/chain"
-	"github.com/drand/drand/client/test/mock"
+	cmock "github.com/drand/drand/client/test/mock"
 	"github.com/drand/drand/cmd/relay-gossip/lp2p"
 	"github.com/drand/drand/cmd/relay-gossip/node"
 	dlog "github.com/drand/drand/log"
 	"github.com/drand/drand/test"
+	"github.com/drand/drand/test/mock"
 	bds "github.com/ipfs/go-ds-badger2"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -79,7 +80,7 @@ func TestGRPCClient(t *testing.T) {
 }
 
 func TestHTTPClient(t *testing.T) {
-	addr, chainInfo, stop := mock.NewMockHTTPPublicServer(t, false)
+	addr, chainInfo, stop := cmock.NewMockHTTPPublicServer(t, false)
 	defer stop()
 
 	dataDir, err := ioutil.TempDir(os.TempDir(), "test-gossip-relay-node-datastore")

--- a/cmd/relay-gossip/main.go
+++ b/cmd/relay-gossip/main.go
@@ -68,8 +68,13 @@ var runCmd = &cli.Command{
 	Name: "run",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "connect",
-			Usage: "host:port to dial to a drand gRPC PI",
+			Name:    "grpc-connect",
+			Usage:   "host:port to dial to a drand gRPC API",
+			Aliases: []string{"connect"},
+		},
+		&cli.StringSliceFlag{
+			Name:  "http-connect",
+			Usage: "URL(s) of drand HTTP API(s) to relay",
 		},
 		&cli.StringFlag{
 			Name:  "store",
@@ -109,7 +114,8 @@ var runCmd = &cli.Command{
 			IdentityPath:    cctx.String(idFlag.Name),
 			CertPath:        cctx.String("cert"),
 			Insecure:        cctx.Bool("insecure"),
-			DrandPublicGRPC: cctx.String("connect"),
+			DrandPublicGRPC: cctx.String("grpc-connect"),
+			DrandPublicHTTP: cctx.StringSlice("http-connect"),
 		}
 		if _, err := node.NewGossipRelayNode(dlog.DefaultLogger, cfg); err != nil {
 			return err

--- a/cmd/relay-gossip/node/relaynode.go
+++ b/cmd/relay-gossip/node/relaynode.go
@@ -3,9 +3,11 @@ package node
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"time"
 
+	dclient "github.com/drand/drand/client"
 	"github.com/drand/drand/cmd/relay-gossip/lp2p"
 	"github.com/drand/drand/log"
 	"github.com/drand/drand/protobuf/drand"
@@ -31,6 +33,8 @@ type GossipRelayConfig struct {
 	CertPath        string
 	Insecure        bool
 	DrandPublicGRPC string
+	// DrandPublicHTTP are drand public HTTP API URLs to relay
+	DrandPublicHTTP []string
 }
 
 // GossipRelayNode is a gossip relay runtime.
@@ -107,7 +111,15 @@ func NewGossipRelayNode(l log.Logger, cfg *GossipRelayConfig) (*GossipRelayNode,
 		addrs:     addrs,
 		done:      make(chan struct{}),
 	}
-	go g.start(cfg.DrandPublicGRPC)
+
+	if cfg.DrandPublicGRPC != "" {
+		go g.startGRPC(cfg.DrandPublicGRPC)
+	} else if len(cfg.DrandPublicHTTP) > 0 {
+		go g.startHTTP(cfg.DrandPublicHTTP)
+	} else {
+		return nil, errors.New("missing gRPC or HTTP API addresses")
+	}
+
 	return g, nil
 }
 
@@ -142,7 +154,7 @@ func ParseMultiaddrSlice(peers []string) ([]ma.Multiaddr, error) {
 	return out, nil
 }
 
-func (g *GossipRelayNode) start(drandPublicGRPC string) {
+func (g *GossipRelayNode) startGRPC(drandPublicGRPC string) {
 	for {
 		select {
 		case <-g.done:
@@ -164,6 +176,47 @@ func (g *GossipRelayNode) start(drandPublicGRPC string) {
 				g.l.Warn(fmt.Sprintf("error while closing connection: %+v", err))
 			}
 			time.Sleep(5 * time.Second)
+		}
+	}
+}
+
+func (g *GossipRelayNode) startHTTP(urls []string) {
+	c, err := dclient.New(dclient.WithInsecureHTTPEndpoints(urls))
+	if err != nil {
+		g.l.Error("relaynode", "creating drand HTTP client", err)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := c.Watch(ctx)
+
+	for {
+		select {
+		case res, ok := <-ch:
+			if !ok {
+				return
+			}
+
+			randB, err := proto.Marshal(&drand.PublicRandResponse{
+				Round:      res.Round(),
+				Signature:  res.Signature(),
+				Randomness: res.Randomness(),
+			})
+			if err != nil {
+				g.l.Error("relaynode", "marshaling", err)
+				continue
+			}
+
+			err = g.t.Publish(ctx, randB)
+			if err != nil {
+				g.l.Error("relaynode", "publishing on pubsub", err)
+				continue
+			}
+
+			g.l.Info("relaynode", "Published randomness on pubsub", "round", res.Round())
+		case <-g.done:
+			return
 		}
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUn
 github.com/drand/bls12-381 v0.3.2 h1:RImU8Wckmx8XQx1tp1q04OV73J9Tj6mmpQLYDP7V1XE=
 github.com/drand/bls12-381 v0.3.2/go.mod h1:dtcLgPtYT38L3NO6mPDYH0nbpc5tjPassDqiniuAt4Y=
 github.com/drand/kyber v1.0.1-0.20200110225416-8de27ed8c0e2/go.mod h1:UpXoA0Upd1N9l4TvRPHr1qAUBBERj6JQ/mnKI3BPEmw=
+github.com/drand/kyber v1.0.1-0.20200502215402-daa30f0ec4f8 h1:YtYT6e0l93FNNWnsya5fu9CYouLtevAOqthplH75pcE=
+github.com/drand/kyber v1.0.1-0.20200502215402-daa30f0ec4f8/go.mod h1:x6KOpK7avKj0GJ4emhXFP5n7M7W7ChAPmnQh/OL6vRw=
 github.com/drand/kyber v1.0.2 h1:dHjtWJZJdn3zBBZ9pqLsLfcR9ScvDvSqzS1sWA8seao=
 github.com/drand/kyber v1.0.2/go.mod h1:x6KOpK7avKj0GJ4emhXFP5n7M7W7ChAPmnQh/OL6vRw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/test/mock/grpcserver.go
+++ b/test/mock/grpcserver.go
@@ -37,7 +37,7 @@ func newMockServer(d *Data) *Server {
 // ChainInfo implements net.Service
 func (s *Server) ChainInfo(context.Context, *drand.ChainInfoRequest) (*drand.ChainInfoPacket, error) {
 	return &drand.ChainInfoPacket{
-		Period:      1,
+		Period:      uint32(s.d.Period.Seconds()),
 		GenesisTime: int64(s.d.Genesis),
 		PublicKey:   s.d.Public,
 	}, nil
@@ -133,6 +133,7 @@ type Data struct {
 	PreviousSignature string
 	PreviousRound     int
 	Genesis           int64
+	Period            time.Duration
 	BadSecondRound    bool
 }
 
@@ -154,6 +155,7 @@ func generateMockData() *Data {
 	tshare := tbls.SigShare(tsig)
 	sig := tshare.Value()
 	publicBuff, _ := public.MarshalBinary()
+	period := time.Second
 	d := &Data{
 		secret:            secret,
 		Public:            publicBuff,
@@ -161,7 +163,8 @@ func generateMockData() *Data {
 		PreviousSignature: hex.EncodeToString(previous[:]),
 		PreviousRound:     int(prevRound),
 		Round:             round,
-		Genesis:           time.Now().Add(60 * 1969 * time.Second * -1).Unix(),
+		Genesis:           time.Now().Add(period * 1969 * -1).Unix(),
+		Period:            period,
 		BadSecondRound:    true,
 	}
 	return d
@@ -186,6 +189,7 @@ func nextMockData(d *Data) *Data {
 		PreviousRound:     d.Round,
 		Round:             d.Round + 1,
 		Genesis:           d.Genesis,
+		Period:            d.Period,
 		BadSecondRound:    d.BadSecondRound,
 	}
 }

--- a/test/mock/grpcserver.go
+++ b/test/mock/grpcserver.go
@@ -23,24 +23,26 @@ import (
 type Server struct {
 	addr string
 	*net.EmptyServer
-	l sync.Mutex
-	d *Data
+	l         sync.Mutex
+	d         *Data
+	chainInfo *drand.ChainInfoPacket
 }
 
 func newMockServer(d *Data) *Server {
 	return &Server{
 		EmptyServer: new(net.EmptyServer),
 		d:           d,
+		chainInfo: &drand.ChainInfoPacket{
+			Period:      uint32(d.Period.Seconds()),
+			GenesisTime: int64(d.Genesis),
+			PublicKey:   d.Public,
+		},
 	}
 }
 
 // ChainInfo implements net.Service
 func (s *Server) ChainInfo(context.Context, *drand.ChainInfoRequest) (*drand.ChainInfoPacket, error) {
-	return &drand.ChainInfoPacket{
-		Period:      uint32(s.d.Period.Seconds()),
-		GenesisTime: int64(s.d.Genesis),
-		PublicKey:   s.d.Public,
-	}, nil
+	return s.chainInfo, nil
 }
 
 // PublicRand implements net.Service

--- a/test/mock/grpcserver.go
+++ b/test/mock/grpcserver.go
@@ -37,7 +37,7 @@ func newMockServer(d *Data) *Server {
 // ChainInfo implements net.Service
 func (s *Server) ChainInfo(context.Context, *drand.ChainInfoRequest) (*drand.ChainInfoPacket, error) {
 	return &drand.ChainInfoPacket{
-		Period:      60,
+		Period:      1,
 		GenesisTime: int64(s.d.Genesis),
 		PublicKey:   s.d.Public,
 	}, nil
@@ -67,9 +67,14 @@ func (s *Server) PublicRand(c context.Context, in *drand.PublicRandRequest) (*dr
 func (s *Server) PublicRandStream(req *drand.PublicRandRequest, stream drand.Public_PublicRandStreamServer) error {
 	done := make(chan error, 1)
 
+	chainInfo, err := s.ChainInfo(context.Background(), &drand.ChainInfoRequest{})
+	if err != nil {
+		return err
+	}
+
 	go func() {
 		for {
-			ticker := time.NewTicker(time.Second)
+			ticker := time.NewTicker(time.Duration(chainInfo.Period) * time.Second)
 			defer ticker.Stop()
 			defer func() { done <- stream.Context().Err() }()
 			select {

--- a/test/mock/httpserver.go
+++ b/test/mock/httpserver.go
@@ -1,0 +1,64 @@
+package mock
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/drand/drand/chain"
+	dhttp "github.com/drand/drand/http"
+	"github.com/drand/drand/protobuf/drand"
+	"google.golang.org/grpc"
+)
+
+// NewMockHTTPPublicServer creates a mock drand HTTP server for testing.
+func NewMockHTTPPublicServer(t *testing.T, badSecondRound bool) (string, *chain.Info, context.CancelFunc) {
+	t.Helper()
+	l, s := NewMockGRPCPublicServer(":0", badSecondRound)
+	lAddr := l.Addr()
+	go l.Start()
+
+	conn, err := grpc.Dial(lAddr, grpc.WithInsecure())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := drand.NewPublicClient(conn)
+
+	handler, err := dhttp.New(ctx, client, "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var chainInfo *chain.Info
+	for i := 0; i < 3; i++ {
+		protoInfo, err := s.ChainInfo(ctx, &drand.ChainInfoRequest{})
+		if err != nil {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		chainInfo, err = chain.InfoFromProto(protoInfo)
+		if err != nil {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		break
+	}
+	if chainInfo == nil {
+		t.Fatal("could not use server after 3 attempts.")
+	}
+
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := http.Server{Handler: handler}
+	go server.Serve(listener)
+	return listener.Addr().String(), chainInfo, func() {
+		server.Shutdown(ctx)
+		cancel()
+	}
+}


### PR DESCRIPTION
This PR adds a `-http-connect` option that allows the gossip relay to connect with and be a relay for one or more drand HTTP API servers.

The original `-connect` option is renamed as `-grpc-connect` (but still has an alias for backward compatibility).

There is definitely a race bug somewhere in the blocking HTTP server as I'm occasionally getting the error: `ts="Tue, 26 May 2020 00:35:25 BST" call=cache.go:44 level=error polling_client="failed to watch" err=EOF`.