### PR TITLE
fix: watcher and aggregator

### DIFF
--- a/client/aggregator.go
+++ b/client/aggregator.go
@@ -57,12 +57,10 @@ func (c *watchAggregator) distribute(in <-chan Result, cancel context.CancelFunc
 		c.subscriberLock.Unlock()
 
 		var m Result
+		var ok bool
+
 		select {
-		case res, ok := <-in:
-			if !ok {
-				return
-			}
-			m = res
+		case m, ok = <-in:
 		case <-aCtx.Done():
 		}
 
@@ -71,7 +69,7 @@ func (c *watchAggregator) distribute(in <-chan Result, cancel context.CancelFunc
 		c.subscribers = c.subscribers[:0]
 
 		for _, s := range curr {
-			if s.ctx.Err() == nil {
+			if ok && s.ctx.Err() == nil {
 				c.subscribers = append(c.subscribers, s)
 				if m != nil {
 					select {

--- a/client/aggregator.go
+++ b/client/aggregator.go
@@ -83,5 +83,9 @@ func (c *watchAggregator) distribute(in <-chan Result, cancel context.CancelFunc
 			}
 		}
 		c.subscriberLock.Unlock()
+
+		if !ok {
+			return
+		}
 	}
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -126,7 +126,7 @@ func TestClientWithFailover(t *testing.T) {
 }
 
 func TestClientWithWatcher(t *testing.T) {
-	addr1, hash, cancel := withServer(t)
+	addr1, hash, cancel := withServer(t, false)
 	defer cancel()
 
 	results := []MockResult{

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -1,0 +1,38 @@
+package client
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/drand/drand/chain"
+	"github.com/drand/drand/test"
+)
+
+// fakeChainInfo creates a chain info object for use in tests.
+func fakeChainInfo() *chain.Info {
+	return &chain.Info{
+		Period:      time.Second,
+		GenesisTime: time.Now().Unix(),
+		PublicKey:   test.GenerateIDs(1)[0].Public.Key,
+	}
+}
+
+// nextResult reads the next result from the channel and fails the test if it closes before a value is read.
+func nextResult(t *testing.T, ch <-chan Result) Result {
+	r, ok := <-ch
+	if !ok {
+		t.Fatal("closed before result")
+	}
+	return r
+}
+
+// compareResults asserts that two results are the same.
+func compareResults(t *testing.T, a, b Result) {
+	if a.Round() != b.Round() {
+		t.Fatal("unexpected result round", a.Round(), b.Round())
+	}
+	if bytes.Compare(a.Randomness(), b.Randomness()) != 0 {
+		t.Fatal("unexpected result randomness", a.Randomness(), b.Randomness())
+	}
+}

--- a/client/watcher_test.go
+++ b/client/watcher_test.go
@@ -1,0 +1,81 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drand/drand/chain"
+)
+
+func TestWatcherWatch(t *testing.T) {
+	results := []MockResult{
+		{rnd: 1, rand: []byte{1}},
+		{rnd: 2, rand: []byte{2}},
+	}
+
+	ch := make(chan Result, len(results))
+	for i := range results {
+		ch <- &results[i]
+	}
+	close(ch)
+
+	ctor := func(chainInfo *chain.Info) (Watcher, error) {
+		return &MockClient{WatchCh: ch}, nil
+	}
+
+	w, err := newWatcherClient(nil, fakeChainInfo(), ctor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i := 0
+	for r := range w.Watch(context.Background()) {
+		compareResults(t, r, &results[i])
+		i++
+	}
+}
+
+func TestWatcherGet(t *testing.T) {
+	results := []MockResult{
+		{rnd: 1, rand: []byte{1}},
+		{rnd: 2, rand: []byte{2}},
+	}
+
+	cr := make([]MockResult, len(results))
+	copy(cr, results)
+
+	c := &MockClient{Results: cr}
+	ctor := func(chainInfo *chain.Info) (Watcher, error) {
+		return c, nil
+	}
+
+	w, err := newWatcherClient(c, fakeChainInfo(), ctor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, result := range results {
+		r, err := w.Get(context.Background(), 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		compareResults(t, r, &result)
+	}
+}
+
+func TestWatcherRoundAt(t *testing.T) {
+	c := &MockClient{}
+	ctor := func(chainInfo *chain.Info) (Watcher, error) {
+		return c, nil
+	}
+
+	w, err := newWatcherClient(c, fakeChainInfo(), ctor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if w.RoundAt(time.Now()) != 0 {
+		t.Fatal("unexpected RoundAt value")
+	}
+}


### PR DESCRIPTION
Adds tests and fixes for the watcher client and watch aggregator client.

1. The watcher client is now created after we have obtained `chainInfo` and it is now passed to the constructor. We never saw the issue because we currently ignore it with the gossipsub client.
1. The aggregator was not closing subscription channels when the source channel was closed.