### PR TITLE
fix: cache for latest value

### DIFF
--- a/client/cache.go
+++ b/client/cache.go
@@ -35,7 +35,7 @@ func (c *cachingClient) Get(ctx context.Context, round uint64) (res Result, err 
 	}
 	val, err := c.Client.Get(ctx, round)
 	if err == nil && val != nil {
-		c.cache.Add(round, val)
+		c.cache.Add(val.Round(), val)
 	}
 	return val, err
 }

--- a/client/cache_test.go
+++ b/client/cache_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/drand/drand/log"
@@ -51,6 +50,7 @@ func TestCacheGetLatest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	r0, e := c.Get(context.Background(), 0)
 	if e != nil {
 		t.Fatal(e)
@@ -59,7 +59,7 @@ func TestCacheGetLatest(t *testing.T) {
 	if e != nil {
 		t.Fatal(e)
 	}
-	fmt.Println(r0, r1)
+
 	if r0.Round() == r1.Round() {
 		t.Fatal("cached result for latest")
 	}

--- a/client/cache_test.go
+++ b/client/cache_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/drand/drand/log"
@@ -41,6 +42,26 @@ func TestCacheGet(t *testing.T) {
 	}
 	if len(m.Results) != 2 {
 		t.Fatalf("unexpected cache size. %d", len(m.Results))
+	}
+}
+
+func TestCacheGetLatest(t *testing.T) {
+	m := MockClientWithResults(1, 3)
+	c, err := NewCachingClient(m, 2, log.DefaultLogger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r0, e := c.Get(context.Background(), 0)
+	if e != nil {
+		t.Fatal(e)
+	}
+	r1, e := c.Get(context.Background(), 0)
+	if e != nil {
+		t.Fatal(e)
+	}
+	fmt.Println(r0, r1)
+	if r0.Round() == r1.Round() {
+		t.Fatal("cached result for latest")
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -22,7 +22,7 @@ func TestClientConstraints(t *testing.T) {
 		t.Fatal("Client needs root of trust unless insecure specified explicitly")
 	}
 
-	addr, _, cancel := withServer(t)
+	addr, _, cancel := withServer(t, false)
 	defer cancel()
 
 	if _, e := New(WithInsecureHTTPEndpoints([]string{"http://" + addr})); e != nil {
@@ -31,9 +31,9 @@ func TestClientConstraints(t *testing.T) {
 }
 
 func TestClientMultiple(t *testing.T) {
-	addr1, hash, cancel := withServer(t)
+	addr1, hash, cancel := withServer(t, false)
 	defer cancel()
-	addr2, _, cancel2 := withServer(t)
+	addr2, _, cancel2 := withServer(t, false)
 	defer cancel2()
 
 	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1, "http://" + addr2}), WithChainHash(hash))
@@ -67,19 +67,19 @@ func TestClientWithChainInfo(t *testing.T) {
 }
 
 func TestClientCache(t *testing.T) {
-	addr1, hash, cancel := withServer(t)
+	addr1, hash, cancel := withServer(t, false)
 	defer cancel()
 
 	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1}), WithChainHash(hash), WithCacheSize(1))
 	if e != nil {
 		t.Fatal(e)
 	}
-	_, e = c.Get(context.Background(), 0)
+	r0, e := c.Get(context.Background(), 0)
 	if e != nil {
 		t.Fatal(e)
 	}
 	cancel()
-	_, e = c.Get(context.Background(), 0)
+	_, e = c.Get(context.Background(), r0.Round())
 	if e != nil {
 		t.Fatal(e)
 	}
@@ -92,7 +92,7 @@ func TestClientCache(t *testing.T) {
 }
 
 func TestClientWithoutCache(t *testing.T) {
-	addr1, hash, cancel := withServer(t)
+	addr1, hash, cancel := withServer(t, false)
 	defer cancel()
 
 	c, e := New(WithHTTPEndpoints([]string{"http://" + addr1}), WithChainHash(hash), WithCacheSize(0))
@@ -111,7 +111,7 @@ func TestClientWithoutCache(t *testing.T) {
 }
 
 func TestClientWithFailover(t *testing.T) {
-	addr1, hash, cancel := withServer(t)
+	addr1, hash, cancel := withServer(t, false)
 	defer cancel()
 
 	// ensure a client with failover can be created successfully without error

--- a/client/http.go
+++ b/client/http.go
@@ -153,7 +153,14 @@ func (r *RandomData) Randomness() []byte {
 
 // Get returns a the randomness at `round` or an error.
 func (h *httpClient) Get(ctx context.Context, round uint64) (Result, error) {
-	randResponse, err := h.client.Get(fmt.Sprintf("%s/public/%d", h.root, round))
+	var url string
+	if round == 0 {
+		url = fmt.Sprintf("%s/public/latest", h.root)
+	} else {
+		url = fmt.Sprintf("%s/public/%d", h.root, round)
+	}
+
+	randResponse, err := h.client.Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -14,9 +14,9 @@ import (
 	"google.golang.org/grpc"
 )
 
-func withServer(t *testing.T) (string, []byte, context.CancelFunc) {
+func withServer(t *testing.T, badSecondRound bool) (string, []byte, context.CancelFunc) {
 	t.Helper()
-	l, s := mock.NewMockGRPCPublicServer(":0", false)
+	l, s := mock.NewMockGRPCPublicServer(":0", badSecondRound)
 	lAddr := l.Addr()
 	go l.Start()
 
@@ -65,7 +65,7 @@ func withServer(t *testing.T) (string, []byte, context.CancelFunc) {
 	}
 }
 func TestHTTPClient(t *testing.T) {
-	addr, hash, cancel := withServer(t)
+	addr, hash, cancel := withServer(t, true)
 	defer cancel()
 
 	httpClient, err := NewHTTPClient("http://"+addr, hash, http.DefaultTransport)
@@ -96,7 +96,7 @@ func TestHTTPClient(t *testing.T) {
 }
 
 func TestHTTPGetLatest(t *testing.T) {
-	addr, hash, cancel := withServer(t)
+	addr, hash, cancel := withServer(t, false)
 	defer cancel()
 
 	httpClient, err := NewHTTPClient("http://"+addr, hash, &http.Client{})
@@ -124,7 +124,7 @@ func TestHTTPGetLatest(t *testing.T) {
 }
 
 func TestHTTPWatch(t *testing.T) {
-	addr, hash, cancel := withServer(t)
+	addr, hash, cancel := withServer(t, false)
 	defer cancel()
 
 	httpClient, err := NewHTTPClient("http://"+addr, hash, http.DefaultTransport)

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -99,7 +99,7 @@ func TestHTTPGetLatest(t *testing.T) {
 	addr, hash, cancel := withServer(t, false)
 	defer cancel()
 
-	httpClient, err := NewHTTPClient("http://"+addr, hash, &http.Client{})
+	httpClient, err := NewHTTPClient("http://"+addr, hash, http.DefaultTransport)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -95,6 +95,34 @@ func TestHTTPClient(t *testing.T) {
 	}
 }
 
+func TestHTTPGetLatest(t *testing.T) {
+	addr, hash, cancel := withServer(t)
+	defer cancel()
+
+	httpClient, err := NewHTTPClient("http://"+addr, hash, &http.Client{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	r0, err := httpClient.Get(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	r1, err := httpClient.Get(ctx, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r1.Round() != r0.Round()+1 {
+		t.Fatal("expected round progression")
+	}
+}
+
 func TestHTTPWatch(t *testing.T) {
 	addr, hash, cancel := withServer(t)
 	defer cancel()

--- a/test/mock/grpcserver.go
+++ b/test/mock/grpcserver.go
@@ -49,7 +49,7 @@ func (s *Server) PublicRand(c context.Context, in *drand.PublicRandRequest) (*dr
 	defer s.l.Unlock()
 	prev := decodeHex(s.d.PreviousSignature)
 	signature := decodeHex(s.d.Signature)
-	if s.d.BadSecondRound && in.GetRound() == uint64(s.d.Round+1) {
+	if s.d.BadSecondRound && in.GetRound() == uint64(s.d.Round) {
 		signature = []byte{0x01, 0x02, 0x03}
 	}
 	randomness := sha256Hash(signature)
@@ -162,6 +162,7 @@ func generateMockData() *Data {
 	return d
 }
 
+// nextMockData generates a valid Data for the next round when given the current round data.
 func nextMockData(d *Data) *Data {
 	previous := decodeHex(d.PreviousSignature)
 	msg := sha256Hash(append(previous[:], roundToBytes(d.Round+1)...))

--- a/test/mock/grpcserver.go
+++ b/test/mock/grpcserver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/net"
 	"github.com/drand/drand/protobuf/drand"
+	"github.com/drand/kyber"
 	"github.com/drand/kyber/share"
 	"github.com/drand/kyber/sign/tbls"
 	"github.com/drand/kyber/util/random"
@@ -33,7 +34,7 @@ func newMockServer(d *Data) *Server {
 	}
 }
 
-// Group implements net.Service
+// ChainInfo implements net.Service
 func (s *Server) ChainInfo(context.Context, *drand.ChainInfoRequest) (*drand.ChainInfoPacket, error) {
 	return &drand.ChainInfoPacket{
 		Period:      60,
@@ -58,7 +59,7 @@ func (s *Server) PublicRand(c context.Context, in *drand.PublicRandRequest) (*dr
 		Signature:         signature,
 		Randomness:        randomness,
 	}
-	s.d.Round++
+	s.d = nextMockData(s.d)
 	return &resp, nil
 }
 
@@ -120,6 +121,7 @@ func decodeHex(s string) []byte {
 
 // Data of signing
 type Data struct {
+	secret            kyber.Scalar
 	Public            []byte
 	Signature         string
 	Round             int
@@ -148,6 +150,7 @@ func generateMockData() *Data {
 	sig := tshare.Value()
 	publicBuff, _ := public.MarshalBinary()
 	d := &Data{
+		secret:            secret,
 		Public:            publicBuff,
 		Signature:         hex.EncodeToString(sig),
 		PreviousSignature: hex.EncodeToString(previous[:]),
@@ -157,6 +160,28 @@ func generateMockData() *Data {
 		BadSecondRound:    true,
 	}
 	return d
+}
+
+func nextMockData(d *Data) *Data {
+	previous := decodeHex(d.PreviousSignature)
+	msg := sha256Hash(append(previous[:], roundToBytes(d.Round+1)...))
+	sshare := share.PriShare{I: 0, V: d.secret}
+	tsig, err := key.Scheme.Sign(&sshare, msg)
+	if err != nil {
+		panic(err)
+	}
+	tshare := tbls.SigShare(tsig)
+	sig := tshare.Value()
+	return &Data{
+		secret:            d.secret,
+		Public:            d.Public,
+		Signature:         hex.EncodeToString(sig),
+		PreviousSignature: hex.EncodeToString(previous[:]),
+		PreviousRound:     d.Round,
+		Round:             d.Round + 1,
+		Genesis:           d.Genesis,
+		BadSecondRound:    d.BadSecondRound,
+	}
 }
 
 // NewMockGRPCPublicServer creates a listener that provides valid single-node randomness.


### PR DESCRIPTION
A `Get` with round = 0 implies we want the latest round, not the genesis round. This PR changes the HTTP client to request from `/public/latest` when round 0 is requested and `/public/{n}` otherwise. It also updates the caching client cache key so that a result is stored against it's round number as specified in the result, not against the round number requested (which could be 0!).