### PR TITLE
common log interface so that gossip logger can be set

### DIFF
--- a/client/cache.go
+++ b/client/cache.go
@@ -60,11 +60,11 @@ func (*nilCache) TryGet(_ uint64) Result {
 
 // NewCachingClient is a meta client that stores an LRU cache of
 // recently fetched random values.
-func NewCachingClient(client Client, cache Cache, log log.Logger) (Client, error) {
+func NewCachingClient(client Client, cache Cache) (Client, error) {
 	return &cachingClient{
 		Client: client,
 		cache:  cache,
-		log:    log,
+		log:    log.DefaultLogger,
 	}, nil
 }
 
@@ -73,6 +73,11 @@ type cachingClient struct {
 
 	cache Cache
 	log   log.Logger
+}
+
+// SetLog configures the client log output
+func (c *cachingClient) SetLog(l log.Logger) {
+	c.log = l
 }
 
 // Get returns the randomness at `round` or an error.

--- a/client/cache_test.go
+++ b/client/cache_test.go
@@ -13,7 +13,7 @@ func TestCacheGet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := NewCachingClient(m, cache, log.DefaultLogger)
+	c, err := NewCachingClient(m, cache)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +54,7 @@ func TestCacheGetLatest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	c, err := NewCachingClient(m, cache, log.DefaultLogger)
+	c, err := NewCachingClient(m, cache)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestCacheWatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cache, _ := NewCachingClient(m, arcCache, log.DefaultLogger)
+	cache, _ := NewCachingClient(m, arcCache)
 	c := newWatchAggregator(cache, log.DefaultLogger)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/client/failover.go
+++ b/client/failover.go
@@ -19,7 +19,7 @@ const defaultFailoverGracePeriod = time.Second * 5
 // and not emit the intermediate values.
 //
 // If grace period is 0, it'll be set to 5s or the chain period / 2, whichever is smaller.
-func NewFailoverWatcher(core Client, chainInfo *chain.Info, gracePeriod time.Duration, l log.Logger) (Client, error) {
+func NewFailoverWatcher(core Client, chainInfo *chain.Info, gracePeriod time.Duration) (Client, error) {
 	if chainInfo == nil {
 		return nil, errors.New("missing chain info")
 	}
@@ -36,7 +36,7 @@ func NewFailoverWatcher(core Client, chainInfo *chain.Info, gracePeriod time.Dur
 		Client:      core,
 		chainInfo:   chainInfo,
 		gracePeriod: gracePeriod,
-		log:         l,
+		log:         log.DefaultLogger,
 	}, nil
 }
 
@@ -45,6 +45,11 @@ type failoverWatcher struct {
 	chainInfo   *chain.Info
 	gracePeriod time.Duration
 	log         log.Logger
+}
+
+// SetLog configures the client log output
+func (c *failoverWatcher) SetLog(l log.Logger) {
+	c.log = l
 }
 
 // Watch returns new randomness as it becomes available.

--- a/client/failover_test.go
+++ b/client/failover_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/drand/drand/chain"
-	"github.com/drand/drand/log"
 	"github.com/drand/drand/test"
 )
 
@@ -24,7 +23,7 @@ func TestFailover(t *testing.T) {
 
 	failC := make(chan Result, 1)
 	mockClient := &MockClient{WatchCh: failC, Results: results[1:3]}
-	failoverClient, _ := NewFailoverWatcher(mockClient, fakeChainInfo(), time.Millisecond*50, log.DefaultLogger)
+	failoverClient, _ := NewFailoverWatcher(mockClient, fakeChainInfo(), time.Millisecond*50)
 	watchC := failoverClient.Watch(ctx)
 
 	failC <- &results[0]
@@ -48,7 +47,7 @@ func TestFailoverDedupe(t *testing.T) {
 
 	failC := make(chan Result, 2)
 	mockClient := &MockClient{WatchCh: failC, Results: results[1:2]}
-	failoverClient, _ := NewFailoverWatcher(mockClient, fakeChainInfo(), time.Millisecond*50, log.DefaultLogger)
+	failoverClient, _ := NewFailoverWatcher(mockClient, fakeChainInfo(), time.Millisecond*50)
 	watchC := failoverClient.Watch(ctx)
 
 	failC <- &results[0]
@@ -69,7 +68,7 @@ func TestFailoverDefaultGrace(t *testing.T) {
 	results := []MockResult{{rnd: 1, rand: []byte{1}}}
 	failC := make(chan Result)
 	mockClient := &MockClient{WatchCh: failC, Results: results}
-	failoverClient, _ := NewFailoverWatcher(mockClient, fakeChainInfo(), 0, log.DefaultLogger)
+	failoverClient, _ := NewFailoverWatcher(mockClient, fakeChainInfo(), 0)
 	watchC := failoverClient.Watch(ctx)
 
 	compareResults(t, nextResult(t, watchC), &results[0])
@@ -88,7 +87,7 @@ func TestFailoverMaxGrace(t *testing.T) {
 		GenesisTime: time.Now().Unix() - 1,
 		PublicKey:   test.GenerateIDs(1)[0].Public.Key,
 	}
-	failoverClient, _ := NewFailoverWatcher(mockClient, chainInfo, 0, log.DefaultLogger)
+	failoverClient, _ := NewFailoverWatcher(mockClient, chainInfo, 0)
 	watchC := failoverClient.Watch(ctx)
 
 	now := time.Now()
@@ -127,7 +126,7 @@ func TestFailoverGetFail(t *testing.T) {
 
 	mockClient := &errOnGetClient{MockClient: MockClient{WatchCh: failC}, errC: getErrC, err: getErr}
 
-	failoverClient, _ := NewFailoverWatcher(mockClient, fakeChainInfo(), time.Millisecond*50, log.DefaultLogger)
+	failoverClient, _ := NewFailoverWatcher(mockClient, fakeChainInfo(), time.Millisecond*50)
 	watchC := failoverClient.Watch(ctx)
 
 	failC <- &results[0]
@@ -146,7 +145,7 @@ func TestFailoverGetFail(t *testing.T) {
 
 func TestFailoverMissingChainInfo(t *testing.T) {
 	mockClient := &MockClient{}
-	_, err := NewFailoverWatcher(mockClient, nil, 0, log.DefaultLogger)
+	_, err := NewFailoverWatcher(mockClient, nil, 0)
 	if err == nil {
 		t.Fatal("expected error")
 	}

--- a/client/http.go
+++ b/client/http.go
@@ -90,6 +90,11 @@ type httpClient struct {
 	l         log.Logger
 }
 
+// SetLog configures the client log output
+func (h *httpClient) SetLog(l log.Logger) {
+	h.l = l
+}
+
 // FetchGroupInfo attempts to initialize an httpClient when
 // it does not know the full group paramters for a drand group. The chain hash
 // is the hash of the chain info.

--- a/client/interface.go
+++ b/client/interface.go
@@ -24,7 +24,7 @@ type Client interface {
 
 // LoggingClient sets the logger for use by clients that suppport it
 type LoggingClient interface {
-	SetLog(l log.Logger)
+	SetLog(log.Logger)
 }
 
 // Result represents the randomness for a single drand round.

--- a/client/interface.go
+++ b/client/interface.go
@@ -3,6 +3,8 @@ package client
 import (
 	"context"
 	"time"
+
+	"github.com/drand/drand/log"
 )
 
 // Client represents the drand Client interface.
@@ -18,6 +20,11 @@ type Client interface {
 	// RoundAt will return the most recent round of randomness that will be available
 	// at time for the current client.
 	RoundAt(time time.Time) uint64
+}
+
+// LoggingClient sets the logger for use by clients that suppport it
+type LoggingClient interface {
+	SetLog(l log.Logger)
 }
 
 // Result represents the randomness for a single drand round.

--- a/client/prioritizing.go
+++ b/client/prioritizing.go
@@ -13,8 +13,8 @@ import (
 // in succession until an answer is found.
 // Get requests are sourced from get sub-clients.
 // Watches are achieved as a long-poll from the prioritized get sub-clients.
-func NewPrioritizingClient(clients []Client, chainHash []byte, chainInfo *chain.Info, log log.Logger) (Client, error) {
-	return &prioritizingClient{clients, chainHash, chainInfo, log}, nil
+func NewPrioritizingClient(clients []Client, chainHash []byte, chainInfo *chain.Info) (Client, error) {
+	return &prioritizingClient{clients, chainHash, chainInfo, log.DefaultLogger}, nil
 }
 
 type prioritizingClient struct {
@@ -22,6 +22,11 @@ type prioritizingClient struct {
 	chainHash []byte
 	chainInfo *chain.Info
 	log       log.Logger
+}
+
+// SetLog configures the client log output
+func (p *prioritizingClient) SetLog(l log.Logger) {
+	p.log = l
 }
 
 // Get returns a the randomness at `round` or an error.

--- a/client/prioritizing_test.go
+++ b/client/prioritizing_test.go
@@ -3,15 +3,13 @@ package client
 import (
 	"context"
 	"testing"
-
-	"github.com/drand/drand/log"
 )
 
 func TestPrioritizingGet(t *testing.T) {
 	c := MockClientWithResults(0, 5)
 	c2 := MockClientWithResults(6, 10)
 
-	p, err := NewPrioritizingClient([]Client{c, c2}, nil, nil, log.DefaultLogger)
+	p, err := NewPrioritizingClient([]Client{c, c2}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,14 +50,14 @@ func TestPrioritizingWatch(t *testing.T) {
 	c := MockClientWithResults(0, 5)
 	c2 := MockClientWithResults(6, 10)
 
-	p, _ := NewPrioritizingClient([]Client{c, c2}, nil, nil, log.DefaultLogger)
+	p, _ := NewPrioritizingClient([]Client{c, c2}, nil, nil)
 	ch := p.Watch(context.Background())
 	r, ok := <-ch
 	if r != nil || ok {
 		t.Fatal("watch should fail without group provided")
 	}
 
-	p, _ = NewPrioritizingClient([]Client{c, c2}, nil, fakeChainInfo(), log.DefaultLogger)
+	p, _ = NewPrioritizingClient([]Client{c, c2}, nil, fakeChainInfo())
 	ch = p.Watch(context.Background())
 	r, ok = <-ch
 	if r == nil || !ok {
@@ -74,7 +72,7 @@ func TestPrioritizingWatchFromClient(t *testing.T) {
 	c := MockClientWithResults(0, 5)
 	c2, _ := NewHTTPClientWithInfo("", fakeChainInfo(), nil)
 
-	p, _ := NewPrioritizingClient([]Client{c, c2}, nil, nil, log.DefaultLogger)
+	p, _ := NewPrioritizingClient([]Client{c, c2}, nil, nil)
 	ch := p.Watch(context.Background())
 	r, ok := <-ch
 	if r == nil || !ok {

--- a/cmd/relay-gossip/client/client.go
+++ b/cmd/relay-gossip/client/client.go
@@ -10,24 +10,19 @@ import (
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/client"
 	"github.com/drand/drand/cmd/relay-gossip/lp2p"
-	dlog "github.com/drand/drand/log"
+	"github.com/drand/drand/log"
 	"github.com/drand/drand/protobuf/drand"
 	"github.com/gogo/protobuf/proto"
-	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"golang.org/x/xerrors"
-)
-
-var (
-	log = logging.Logger("drand-client")
 )
 
 // Client is a concrete pubsub client implementation
 type Client struct {
 	cancel func()
 	latest uint64
-	log    dlog.Logger
+	log    log.Logger
 
 	subs struct {
 		sync.Mutex
@@ -36,7 +31,7 @@ type Client struct {
 }
 
 // SetLog configures the client log output
-func (c *Client) SetLog(l dlog.Logger) {
+func (c *Client) SetLog(l log.Logger) {
 	c.log = l
 }
 
@@ -115,7 +110,7 @@ func NewWithPubsub(ps *pubsub.PubSub, info *chain.Info, cache client.Cache) (*Cl
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &Client{
 		cancel: cancel,
-		log:    dlog.DefaultLogger,
+		log:    log.DefaultLogger,
 	}
 
 	chainHash := hex.EncodeToString(info.Hash())


### PR DESCRIPTION
note: this sets the log output directly emitted by the relay-gossip client,
but doesn't propagate through to the previously constructed `pubsub` object. I think that's probably an okay boundary