### PR TITLE
happier health endpoint

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"time"
 
 	dhttp "github.com/drand/drand/http"
 	"github.com/drand/drand/log"
@@ -109,7 +110,14 @@ func Relay(c *cli.Context) error {
 		return err
 	}
 	fmt.Printf("Listening at %s\n", listener.Addr())
+	go checkHealth(listener.Addr())
 	return http.Serve(listener, handler)
+}
+
+func checkHealth(addr net.Addr) {
+	time.Sleep(10 * time.Millisecond)
+	client := http.Client{}
+	client.Get(fmt.Sprintf("http://%s/public/0", addr.String()))
 }
 
 func main() {

--- a/http/server.go
+++ b/http/server.go
@@ -316,6 +316,8 @@ func (h *handler) ChainInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) Health(w http.ResponseWriter, r *http.Request) {
+	h.startOnce.Do(h.start)
+
 	h.pendingLk.RLock()
 	lastSeen := h.latestRound
 	h.pendingLk.RUnlock()
@@ -323,6 +325,7 @@ func (h *handler) Health(w http.ResponseWriter, r *http.Request) {
 	info := h.getChainInfo(r.Context())
 
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-cache")
 	resp := make(map[string]uint64)
 	resp["current"] = lastSeen
 	resp["expected"] = 0


### PR DESCRIPTION
* set no-cache header on /health
* /health triggers establishment of the background thread if the relay isn't fully started yet
* the relay binary auto-triggers full startup.