### PR TITLE
feat: relay s3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-unit test-integration demo deploy-local linter install build
+.PHONY: test test-unit test-integration demo deploy-local linter install build client drand relay-http relay-gossip relay-s3
 
 test: test-unit test-integration
 
@@ -55,5 +55,3 @@ drand-relay-gossip: relay-gossip
 relay-s3:
 	go build -o drand-relay-s3 -mod=readonly -ldflags "-X github.com/drand/drand/cmd/relay-s3.version=`git describe --tags` -X github.com/drand/drand/cmd/relay-s3.buildDate=`date -u +%d/%m/%Y@%H:%M:%S` -X github.com/drand/drand/cmd/relay-s3.gitCommit=`git rev-parse HEAD`" ./cmd/relay-s3
 drand-relay-s3: relay-s3
-
-.PHONY: client drand relay-http relay-gossip relay-s3

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,9 @@ relay-gossip:
 	go build -o drand-relay-gossip -mod=readonly -ldflags "-X github.com/drand/drand/cmd/relay-gossip.version=`git describe --tags` -X github.com/drand/drand/cmd/relay-gossip.buildDate=`date -u +%d/%m/%Y@%H:%M:%S` -X github.com/drand/drand/cmd/relay-gossip.gitCommit=`git rev-parse HEAD`" ./cmd/relay-gossip
 drand-relay-gossip: relay-gossip
 
-.PHONY: client drand relay-http relay-gossip
+# create the "drand-relay-s3" binary in the current folder
+relay-s3:
+	go build -o drand-relay-s3 -mod=readonly -ldflags "-X github.com/drand/drand/cmd/relay-s3.version=`git describe --tags` -X github.com/drand/drand/cmd/relay-s3.buildDate=`date -u +%d/%m/%Y@%H:%M:%S` -X github.com/drand/drand/cmd/relay-s3.gitCommit=`git rev-parse HEAD`" ./cmd/relay-s3
+drand-relay-s3: relay-s3
+
+.PHONY: client drand relay-http relay-gossip relay-s3

--- a/cmd/relay-s3/README.md
+++ b/cmd/relay-s3/README.md
@@ -1,0 +1,24 @@
+# relay-s3
+
+## Credentials
+
+Ensure AWS credentials file is in `~/.aws/credentials` - it should look like:
+
+```
+[default]
+aws_access_key_id=AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+## CORS
+
+Ensure you setup your s3 bucket with the following CORS configuration:
+
+```xml
+<CORSConfiguration>
+ <CORSRule>
+   <AllowedOrigin>*</AllowedOrigin>
+   <AllowedMethod>GET</AllowedMethod>
+ </CORSRule>
+</CORSConfiguration>
+```

--- a/cmd/relay-s3/README.md
+++ b/cmd/relay-s3/README.md
@@ -4,16 +4,24 @@ A drand relay that writes randomness rounds to an AWS S3 bucket.
 
 ## Usage
 
-```console
+```sh
 drand-relay-s3 run [arguments...]
 ```
 
-Note: at minimum you'll need to specify a S3 bucket name and either a HTTP or GRPC drand endpoint to relay from.
+Note: at minimum you'll need to specify a S3 bucket name and either a HTTP, gRPC or libp2p pubsub drand endpoint to relay from.
 
-### Example
+**Example**
 
-```console
-drand-relay-s3 run -chain 138a324aa6540f93d0dad002aa89454b1bec2b6e948682cde6bd4db40f4b7c9b -u http://pl-us.testnet.drand.sh -b drand-testnet -r eu-west-2
+```sh
+drand-relay-s3 run -hash 138a324aa6540f93d0dad002aa89454b1bec2b6e948682cde6bd4db40f4b7c9b -url http://pl-us.testnet.drand.sh -bucket drand-testnet -region eu-west-2
+```
+
+### Sync bucket with randomness chain
+
+The `sync` command will ensure the AWS S3 bucket is fully sync'd with the randomness chain. i.e. it ensures all randomness rounds to date (and generated during the sync) are uploaded to the S3 bucket. This may take a while, but if you need to stop you can start it again from a specific round number using the `-begin` flag.
+
+```sh
+drand-relay-s3 sync [arguments...]
 ```
 
 ## Prerequesites

--- a/cmd/relay-s3/README.md
+++ b/cmd/relay-s3/README.md
@@ -1,6 +1,24 @@
 # relay-s3
 
-## Credentials
+A drand relay that writes randomness rounds to an AWS S3 bucket.
+
+## Usage
+
+```console
+drand-relay-s3 run [arguments...]
+```
+
+Note: at minimum you'll need to specify a S3 bucket name and either a HTTP or GRPC drand endpoint to relay from.
+
+### Example
+
+```console
+drand-relay-s3 run -chain 138a324aa6540f93d0dad002aa89454b1bec2b6e948682cde6bd4db40f4b7c9b -u http://pl-us.testnet.drand.sh -b drand-testnet -r eu-west-2
+```
+
+## Prerequesites
+
+### Credentials
 
 Ensure AWS credentials file is in `~/.aws/credentials` - it should look like:
 
@@ -10,9 +28,9 @@ aws_access_key_id=AKIAIOSFODNN7EXAMPLE
 aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 ```
 
-## CORS
+### S3 bucket
 
-Ensure you setup your s3 bucket with the following CORS configuration:
+Ensure you have an S3 bucket ready with _public access_ enabled. The credentials in `~/.aws/credentials` should have write access to it. Make sure the following CORS configuration is applied to allow web applications to request randomness:
 
 ```xml
 <CORSConfiguration>

--- a/cmd/relay-s3/main.go
+++ b/cmd/relay-s3/main.go
@@ -75,9 +75,7 @@ var runCmd = &cli.Command{
 		}
 
 		upr := s3manager.NewUploader(sess)
-		ctx := context.Background()
-
-		watch(ctx, c, upr, cctx.String(bucketFlag.Name))
+		watch(context.Background(), c, upr, cctx.String(bucketFlag.Name))
 		return nil
 	},
 }

--- a/cmd/relay-s3/main.go
+++ b/cmd/relay-s3/main.go
@@ -63,6 +63,11 @@ var runCmd = &cli.Command{
 			Required: true,
 		},
 		&cli.StringFlag{
+			Name:    "region",
+			Usage:   "name of the AWS region to use",
+			Aliases: []string{"r"},
+		},
+		&cli.StringFlag{
 			Name:    "grpc-connect",
 			Usage:   "host:port to dial to a drand gRPC API",
 			Aliases: []string{"connect", "c"},
@@ -93,10 +98,14 @@ var runCmd = &cli.Command{
 		}
 
 		sess := session.Must(session.NewSession(&aws.Config{Region: aws.String(cctx.String("region"))}))
+		_, err := sess.Config.Credentials.Get() // check credentials have been set
+		if err != nil {
+			return err
+		}
+
 		uploader := s3manager.NewUploader(sess)
 
 		var w client.Watcher
-		var err error
 
 		if len(cctx.StringSlice("http-connect")) > 0 {
 			w, err = newHTTPWatcher(cctx.StringSlice("http-connect"))

--- a/cmd/relay-s3/main.go
+++ b/cmd/relay-s3/main.go
@@ -178,9 +178,6 @@ var syncCmd = &cli.Command{
 			rnd = r.Round()
 		}
 
-		// upload new rounds while we're syncing
-		go watch(ctx, c, upr, buc)
-
 		for ; rnd > 0; rnd-- {
 			// TODO: check if bucket already has this round
 			r, err := c.Get(ctx, rnd)

--- a/cmd/relay-s3/main.go
+++ b/cmd/relay-s3/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/drand/drand/metrics"
+	"github.com/drand/drand/metrics/pprof"
+	cli "github.com/urfave/cli/v2"
+)
+
+// Automatically set through -ldflags
+// Example: go install -ldflags "-X main.version=`git describe --tags` -X main.buildDate=`date -u +%d/%m/%Y@%H:%M:%S` -X main.gitCommit=`git rev-parse HEAD`"
+var (
+	version   = "master"
+	gitCommit = "none"
+	buildDate = "unknown"
+)
+
+func main() {
+	app := &cli.App{
+		Name:    "drand-relay-s3",
+		Version: version,
+		Usage:   "AWS S3 relay for randomness beacon",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "chain-hash",
+				Required: true,
+				Aliases:  []string{"h"},
+			},
+		},
+		Commands: []*cli.Command{runCmd},
+	}
+	cli.VersionPrinter = func(c *cli.Context) {
+		fmt.Printf("drand AWS S3 relay %v (date %v, commit %v)\n", version, buildDate, gitCommit)
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		fmt.Printf("error: %+v\n", err)
+		os.Exit(1)
+	}
+}
+
+var runCmd = &cli.Command{
+	Name: "run",
+	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:  "grpc-connect",
+			Usage: "host:port to dial to a drand gRPC API",
+		},
+		&cli.StringSliceFlag{
+			Name:  "http-connect",
+			Usage: "URL(s) of drand HTTP API(s) to relay",
+		},
+		&cli.StringFlag{
+			Name:  "cert",
+			Usage: "file containing GRPC transport credentials of peer",
+		},
+		&cli.BoolFlag{
+			Name:  "insecure",
+			Usage: "allow insecure connection",
+		},
+		&cli.StringFlag{
+			Name:  "metrics",
+			Usage: "local host:port to bind a metrics servlet (optional)",
+		},
+	},
+
+	Action: func(cctx *cli.Context) error {
+		if cctx.IsSet("metrics") {
+			metricsListener := metrics.Start(cctx.String("metrics"), pprof.WithProfile(), nil)
+			defer metricsListener.Close()
+		}
+
+		sess := session.Must(session.NewSession())
+		uploader := s3manager.NewUploader(sess)
+
+		f, err := os.Open(filename)
+		if err != nil {
+			return fmt.Errorf("failed to open file %q, %v", filename, err)
+		}
+
+		// Upload the file to S3.
+		result, err := uploader.Upload(&s3manager.UploadInput{
+			Bucket: aws.String(myBucket),
+			Key:    aws.String(myString),
+			Body:   f,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to upload file, %v", err)
+		}
+		fmt.Printf("file uploaded to, %s\n", aws.StringValue(result.Location))
+	},
+}
+
+func workRelay() {
+
+}

--- a/cmd/relay-s3/main.go
+++ b/cmd/relay-s3/main.go
@@ -146,7 +146,8 @@ var syncCmd = &cli.Command{
 		regionFlag,
 		&cli.Uint64Flag{
 			Name:  "begin",
-			Usage: "Sync backwards from this round number. A value of 0 will sync from the latest round",
+			Usage: "Begin syncing from this round number to the latest round.",
+			Value: 1,
 		},
 	),
 
@@ -169,16 +170,7 @@ var syncCmd = &cli.Command{
 		upr := s3manager.NewUploader(sess)
 		ctx := context.Background()
 
-		rnd := cctx.Uint64("begin")
-		r, err := c.Get(ctx, 0)
-		if err != nil {
-			return fmt.Errorf("getting latest round: %w", err)
-		}
-		if rnd == 0 || rnd > r.Round() {
-			rnd = r.Round()
-		}
-
-		for ; rnd > 0; rnd-- {
+		for rnd := cctx.Uint64("begin"); rnd <= c.RoundAt(time.Now()); rnd++ {
 			// TODO: check if bucket already has this round
 			r, err := c.Get(ctx, rnd)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/aws/aws-sdk-go v1.32.11
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/drand/kyber v1.1.1
 	github.com/drand/kyber-bls12381 v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,5 @@ require (
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 	google.golang.org/genproto v0.0.0-20200608115520-7c474a2e3482 // indirect
 	google.golang.org/grpc v1.29.1
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200617041141-9a465503579e // indirect
 	google.golang.org/protobuf v1.24.0
 )

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,6 @@ github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6l
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0 h1:0xphMHGMLBrPMfxR2AmVjZKcMEESEgWF8Kru94BNByk=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.31.7 h1:TCA+pXKvzDMA3vVqhK21cCy5GarC8pTQb/DrVOWI3iY=
-github.com/aws/aws-sdk-go v1.31.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.32.11 h1:1nYF+Tfccn/hnAZsuwPPMSCVUVnx3j6LKOpx/WhgH0A=
 github.com/aws/aws-sdk-go v1.32.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
@@ -968,8 +966,6 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200617041141-9a465503579e h1:580RpKFLO8Xra4cgj3UmFukvMmMosqUNse1x6E6hwL8=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200617041141-9a465503579e/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/go.sum
+++ b/go.sum
@@ -31,7 +31,12 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aryann/difflib v0.0.0-20170710044230-e206f873d14a/go.mod h1:DAHtR1m6lCRdSC2Tm3DSWRPvIPr6xNKyeHdqDQSQT+A=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
+github.com/aws/aws-sdk-go v1.27.0 h1:0xphMHGMLBrPMfxR2AmVjZKcMEESEgWF8Kru94BNByk=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.31.7 h1:TCA+pXKvzDMA3vVqhK21cCy5GarC8pTQb/DrVOWI3iY=
+github.com/aws/aws-sdk-go v1.31.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.32.11 h1:1nYF+Tfccn/hnAZsuwPPMSCVUVnx3j6LKOpx/WhgH0A=
+github.com/aws/aws-sdk-go v1.32.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
 github.com/benbjohnson/clock v1.0.1 h1:lVM1R/o5khtrr7t3qAr+sS6uagZOP+7iprc7gS3V9CE=
@@ -140,6 +145,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logfmt/logfmt v0.5.0 h1:TrB8swr/68K7m9CcGut2g3UOihhbcbiMAYiuTXdEih4=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/godbus/dbus v0.0.0-20190402143921-271e53dc4968/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
@@ -304,7 +310,10 @@ github.com/jbenet/goprocess v0.1.4 h1:DRGOFReOMqqDNXwW70QkacFW0YN9QnwLV0Vqk+3oU0
 github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.1.1-0.20190114141812-62fb9bc030d1 h1:qBCV/RLV02TSfQa7tFmxTihnG+u+7JXByOkhlkR5rmQ=
 github.com/jonboulle/clockwork v0.1.1-0.20190114141812-62fb9bc030d1/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=


### PR DESCRIPTION
This PR adds a CLI program that relays drand randomness to an AWS S3 bucket.

Check out the demo here:
https://youtu.be/YSxOpakChnk

Future PRs:

* Update `/public/latest` when new round is uploaded
* Add `/info` information at startup if not exists

Nice to have:

* [x] Command to backfill any missed randomness in the bucket

resolves #351 