### PR TITLE
docs: gossip relay command usage message tweaks

### DIFF
--- a/cmd/relay-gossip/main.go
+++ b/cmd/relay-gossip/main.go
@@ -33,17 +33,19 @@ func main() {
 	app := &cli.App{
 		Name:    "drand-relay-gossip",
 		Version: version,
-		Usage:   "pubsub relay for randomness beacon",
+		Usage:   "Pubsub relay for drand randomness beacon",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:     "chain-hash",
+				Usage:    "Hash of the drand group chain (hex encoded)",
+				Aliases:  []string{"c"},
 				Required: true,
 			},
 		},
 		Commands: []*cli.Command{runCmd, clientCmd, idCmd},
 	}
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Printf("drand gossip relay %v (date %v, commit %v)\n", version, buildDate, gitCommit)
+		fmt.Printf("Drand gossip relay %v (date %v, commit %v)\n", version, buildDate, gitCommit)
 	}
 
 	err := app.Run(os.Args)
@@ -55,11 +57,12 @@ func main() {
 
 var peerWithFlag = &cli.StringSliceFlag{
 	Name:  "peer-with",
-	Usage: "list of peers to connect with",
+	Usage: "List of peers to connect with",
 }
 
 var runCmd = &cli.Command{
-	Name: "run",
+	Name:  "run",
+	Usage: "Starts a drand gossip relay process",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "grpc-connect",
@@ -72,25 +75,25 @@ var runCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:  "store",
-			Usage: "datastore directory",
+			Usage: "Datastore directory",
 			Value: "./datastore",
 		},
 		&cli.StringFlag{
 			Name:  "cert",
-			Usage: "file containing GRPC transport credentials of peer",
+			Usage: "File containing GRPC transport credentials of peer",
 		},
 		&cli.BoolFlag{
 			Name:  "insecure",
-			Usage: "allow insecure connection",
+			Usage: "Allow insecure connection",
 		},
 		&cli.StringFlag{
 			Name:  "listen",
-			Usage: "listen addr for libp2p",
+			Usage: "Listening address for libp2p",
 			Value: "/ip4/0.0.0.0/tcp/44544",
 		},
 		&cli.StringFlag{
 			Name:  "metrics",
-			Usage: "local host:port to bind a metrics servlet (optional)",
+			Usage: "Local host:port to bind a metrics servlet (optional)",
 		},
 		peerWithFlag, idFlag,
 	},
@@ -121,6 +124,7 @@ var runCmd = &cli.Command{
 
 var clientCmd = &cli.Command{
 	Name:  "client",
+	Usage: "Starts a drand gossip client and print out randomness as it is received",
 	Flags: []cli.Flag{peerWithFlag},
 	Action: func(cctx *cli.Context) error {
 		bootstrap, err := node.ParseMultiaddrSlice(cctx.StringSlice(peerWithFlag.Name))

--- a/cmd/relay-gossip/main.go
+++ b/cmd/relay-gossip/main.go
@@ -56,7 +56,7 @@ var chainHashFlag = &cli.StringFlag{
 
 var peerWithFlag = &cli.StringSliceFlag{
 	Name:  "peer-with",
-	Usage: "list of peer multiaddrs to direct connect with",
+	Usage: "peer multiaddr(s) to direct connect with",
 }
 
 var idFlag = &cli.StringFlag{
@@ -85,7 +85,7 @@ var runCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:  "cert",
-			Usage: "file containing gRPC transport credentials of peer",
+			Usage: "path to a file containing gRPC transport credentials of peer",
 		},
 		&cli.BoolFlag{
 			Name:  "insecure",

--- a/cmd/relay-gossip/main.go
+++ b/cmd/relay-gossip/main.go
@@ -37,7 +37,7 @@ func main() {
 		Commands: []*cli.Command{runCmd, clientCmd, idCmd},
 	}
 	cli.VersionPrinter = func(c *cli.Context) {
-		fmt.Printf("drand gossip relay %v (date %v, commit %v).\n", version, buildDate, gitCommit)
+		fmt.Printf("drand gossip relay %v (date %v, commit %v)\n", version, buildDate, gitCommit)
 	}
 
 	err := app.Run(os.Args)
@@ -71,7 +71,7 @@ var runCmd = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "grpc-connect",
-			Usage:   "host:port to dial to a drand GRPC API",
+			Usage:   "host:port to dial to a drand gRPC API",
 			Aliases: []string{"connect"},
 		},
 		&cli.StringSliceFlag{
@@ -85,11 +85,11 @@ var runCmd = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:  "cert",
-			Usage: "file containing GRPC transport credentials of peer",
+			Usage: "file containing gRPC transport credentials of peer",
 		},
 		&cli.BoolFlag{
 			Name:  "insecure",
-			Usage: "allow insecure GRPC connection",
+			Usage: "allow insecure gRPC connection",
 		},
 		&cli.StringFlag{
 			Name:  "listen",


### PR DESCRIPTION
Cleans up the usage documentation for the relay-gossip CLI command.

I've made the `--chain-hash` parameter NOT global, since it's only used by 2 of the 3 commands. It's also currently a _required_ parameter (will be fixed soon) which has the unfortunate consequence with this CLI library of not giving you access to `--help` for subcommands until it's set...and it also stops you from using the `peerid` subcommand even though it's not used here either.

Unfortunately it means this is a breaking change, since the position of the `--chain-hash` param needs to change to be _after_ the `run` or `client` subcommand instead of before.

---

`drand-relay-gossip --help` before:

```console
NAME:
   drand-relay-gossip - pubsub relay for randomness beacon

USAGE:
   drand-relay-gossip [global options] command [command options] [arguments...]

VERSION:
   master

COMMANDS:
   run      
   client   
   peerid   prints libp2p peerid
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --chain-hash value  
   --help, -h          show help (default: false)
   --version, -v       print the version (default: false)
```

`drand-relay-gossip --help` after:

```console
NAME:
   drand-relay-gossip - pubsub relay for drand randomness beacon

USAGE:
   drand-relay-gossip [global options] command [command options] [arguments...]

VERSION:
   master

COMMANDS:
   run      starts a drand gossip relay process
   client   starts a drand gossip client and prints out randomness as it is received
   peerid   prints the libp2p peer ID or creates one if it does not exist
   help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h     show help (default: false)
   --version, -v  print the version (default: false)
```

---

`drand-relay-gossip run --help` before:

```console
NAME:
   drand-relay-gossip run - 

USAGE:
   drand-relay-gossip run [command options] [arguments...]

OPTIONS:
   --grpc-connect value, --connect value  host:port to dial to a drand gRPC API
   --http-connect value                   URL(s) of drand HTTP API(s) to relay
   --store value                          datastore directory (default: "./datastore")
   --cert value                           file containing GRPC transport credentials of peer
   --insecure                             allow insecure connection (default: false)
   --listen value                         listen addr for libp2p (default: "/ip4/0.0.0.0/tcp/44544")
   --metrics value                        local host:port to bind a metrics servlet (optional)
   --peer-with value                      list of peers to connect with
   --identity value                       path to a file containing libp2p identity (default: "identity.key")
   --help, -h                             show help (default: false)
```

`drand-relay-gossip run --help` after:

```console
NAME:
   drand-relay-gossip run - starts a drand gossip relay process

USAGE:
   drand-relay-gossip run [command options] [arguments...]

OPTIONS:
   --grpc-connect value, --connect value  host:port to dial to a drand gRPC API
   --http-connect value                   URL(s) of drand HTTP API(s) to relay
   --store value                          datastore directory (default: "./datastore")
   --cert value                           path to a file containing gRPC transport credentials of peer
   --insecure                             allow insecure gRPC connection (default: false)
   --listen value                         listening address for libp2p (default: "/ip4/0.0.0.0/tcp/44544")
   --metrics value                        local host:port to bind a metrics servlet (optional)
   --chain-hash value, -c value           hash of the drand group chain (hex encoded)
   --peer-with value                      peer multiaddr(s) to direct connect with
   --identity value                       path to a file containing a libp2p identity (base64 encoded) (default: "identity.key")
   --help, -h                             show help (default: false)
```

---

`drand-relay-gossip client --help` before:

```console
NAME:
   drand-relay-gossip client - 

USAGE:
   drand-relay-gossip client [command options] [arguments...]

OPTIONS:
   --peer-with value  list of peers to connect with
   --help, -h         show help (default: false)
```

`drand-relay-gossip client --help` after:

```console
NAME:
   drand-relay-gossip client - starts a drand gossip client and prints out randomness as it is received

USAGE:
   drand-relay-gossip client [command options] [arguments...]

OPTIONS:
   --chain-hash value, -c value  hash of the drand group chain (hex encoded)
   --peer-with value             peer multiaddr(s) to direct connect with
   --help, -h                    show help (default: false)
```

---

`drand-relay-gossip peerid --help` before:

```console
error: Required flag "chain-hash" not set
```

`drand-relay-gossip peerid --help` after:

```console
NAME:
   drand-relay-gossip peerid - prints the libp2p peer ID or creates one if it does not exist

USAGE:
   drand-relay-gossip peerid [command options] [arguments...]

OPTIONS:
   --identity value  path to a file containing a libp2p identity (base64 encoded) (default: "identity.key")
   --help, -h        show help (default: false)
```

---

~~BREAKING CHANGE: `-chain-hash` is no longer a global parameter since it is only used by 2 of the 3 commands. It's currently required (to be changed soon) and so was preventing calls to `drand-relay-gossip peerid` without it being passed. This means that it now needs to be passed **after** the `run` or `client` subcommand.~~

Update: `-chain-hash` is a hidden global parameter. It is deprecated and will be removed in the near future.