### PR TITLE
feat: optimizing client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -72,7 +72,7 @@ func makeClient(cfg clientConfig) (Client, error) {
 	}
 
 	if len(restClients) > 1 {
-		c, err = NewPrioritizingClient(restClients, cfg.chainHash, cfg.chainInfo)
+		c, err = NewOptimizingClient(restClients, cfg.chainInfo, cfg.rttTTL)
 		if err != nil {
 			return nil, err
 		}
@@ -153,6 +153,8 @@ type clientConfig struct {
 	autoWatch bool
 	// prometheus is an interface to a Prometheus system
 	prometheus prometheus.Registerer
+	// rttTTL is the time a RTT sample will live before it is tested again.
+	rttTTL time.Duration
 }
 
 // Option is an option configuring a client.
@@ -274,6 +276,18 @@ func WithAutoWatch() Option {
 func WithPrometheus(r prometheus.Registerer) Option {
 	return func(cfg *clientConfig) error {
 		cfg.prometheus = r
+		return nil
+	}
+}
+
+// WithRoundTripTTL is the time a RTT sample will live before it is tested
+// again. Calls to `.Get` are timed so that when multiple endpoints are
+// available the fastest one can be used. Sample round trip times live for a
+// certain period before they are reset. This allows a slow or unavailable
+// client to recover and become the fastest.
+func WithRoundTripTTL(t time.Duration) Option {
+	return func(cfg *clientConfig) error {
+		cfg.rttTTL = t
 		return nil
 	}
 }

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -15,6 +15,8 @@ import (
 type MockClient struct {
 	WatchCh chan Result
 	Results []MockResult
+	// Delay causes results to be delivered after this period of time has passed.
+	Delay time.Duration
 }
 
 // Get returns a the randomness at `round` or an error.
@@ -24,6 +26,14 @@ func (m *MockClient) Get(ctx context.Context, round uint64) (Result, error) {
 	}
 	r := m.Results[0]
 	m.Results = m.Results[1:]
+	if m.Delay > 0 {
+		t := time.NewTimer(m.Delay)
+		select {
+		case <-t.C:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
 	return &r, nil
 }
 

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -16,14 +16,14 @@ import (
 const defaultTTL = time.Minute * 5
 
 // NewOptimizingClient creates a drand client that measures the speed of clients
-// and uses the fastest one. Speeds are measured as the optimising client is
+// and uses the fastest one. Speeds are measured as the optimizing client is
 // used, so there is no background routine and no additional calls to other
 // clients.
 //
 // A speed measurement lives for a certain period before it is reset. The next
 // call to `.Get` will then attempt to use a reset client even if it was
 // previously considered to be slower. Pass a value > 0 for `rttTTL` to
-// customise the period - it defaults to 5 minutes.
+// customize the period - it defaults to 5 minutes.
 //
 // If a client fails to return a value it'll be attempted from the next fastest
 // client. Failed clients are given a large RTT and are moved to the back of the

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -1,0 +1,146 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/drand/drand/chain"
+	"github.com/drand/drand/log"
+)
+
+// defaultTTL is the time a RTT sample will live before it is tested again.
+const defaultTTL = time.Minute * 5
+
+// NewOptimizingClient creates a drand client that measures the speed of clients
+// and uses the fastest one. Speeds are measured as the optimising client is
+// used, so there is no background routine and no additional calls to other
+// clients.
+//
+// A speed measurement lives for a certain period before it is reset. The next
+// call to `.Get` will then attempt to use a reset client even if it was
+// previously considered to be slower. Pass a value > 0 for `rttTTL` to
+// customise the period - it defaults to 5 minutes.
+//
+// If a client fails to return a value it'll be attempted from the next fastest
+// client. Failed clients are given a large RTT and are moved to the back of the
+// list. This RTT expires as usual and allows failed clients to be re-introduced
+// and become the fastest again. i.e. failed clients are not taken out of the
+// list, just considered to be very slow.
+func NewOptimizingClient(clients []Client, chainInfo *chain.Info, rttTTL time.Duration) (Client, error) {
+	if len(clients) == 0 {
+		return nil, errors.New("missing clients")
+	}
+	if chainInfo == nil {
+		return nil, errors.New("missing chain info")
+	}
+	stats := make([]*clientStat, len(clients))
+	now := time.Now()
+	for i, c := range clients {
+		stats[i] = &clientStat{client: c, rtt: 0, ts: now}
+	}
+	if rttTTL <= 0 {
+		rttTTL = defaultTTL
+	}
+	return &optimizingClient{stats: stats, rttTTL: rttTTL, chainInfo: chainInfo, log: log.DefaultLogger}, nil
+}
+
+type optimizingClient struct {
+	sync.RWMutex
+	stats     []*clientStat
+	rttTTL    time.Duration
+	chainInfo *chain.Info
+	log       log.Logger
+}
+
+type clientStat struct {
+	client Client
+	rtt    time.Duration
+	ts     time.Time
+}
+
+// SetLog configures the client log output
+func (oc *optimizingClient) SetLog(l log.Logger) {
+	oc.log = l
+}
+
+// Get returns a the randomness at `round` or an error.
+func (oc *optimizingClient) Get(ctx context.Context, round uint64) (res Result, err error) {
+	oc.RLock()
+	// take a copy of the current client stats so we iterate over a stable slice
+	currStats := make([]*clientStat, len(oc.stats))
+	copy(currStats, oc.stats)
+	oc.RUnlock()
+
+	nextStats := []*clientStat{}
+	for _, s := range currStats {
+		start := time.Now()
+		res, err = s.client.Get(ctx, round)
+		rtt := time.Now().Sub(start)
+
+		// client failure, set a large RTT so it is sent to the back of the list
+		if err != nil {
+			rtt = math.MaxInt64
+		}
+
+		nextStats = append(nextStats, &clientStat{s.client, rtt, start})
+
+		if err == nil {
+			break
+		}
+
+		// context deadline hit
+		if ctx.Err() != nil {
+			return
+		}
+	}
+
+	oc.updateStats(nextStats)
+	return
+}
+
+func (oc *optimizingClient) updateStats(samples []*clientStat) {
+	oc.Lock()
+	defer oc.Unlock()
+
+	// update the round trip times with new samples
+	for _, next := range samples {
+		for _, curr := range oc.stats {
+			if curr.client == next.client {
+				if curr.ts.Before(next.ts) {
+					curr.rtt = next.rtt
+					curr.ts = next.ts
+				}
+				break
+			}
+		}
+	}
+
+	// update expired round trip times
+	now := time.Now()
+	for _, curr := range oc.stats {
+		if now.Sub(curr.ts) >= oc.rttTTL {
+			curr.rtt = 0
+			curr.ts = now
+		}
+	}
+
+	// sort by fastest
+	sort.Slice(oc.stats, func(i, j int) bool {
+		return oc.stats[i].rtt < oc.stats[j].rtt
+	})
+}
+
+// Watch returns new randomness as it becomes available.
+func (oc *optimizingClient) Watch(ctx context.Context) <-chan Result {
+	return pollingWatcher(ctx, oc, oc.chainInfo, oc.log)
+}
+
+// RoundAt will return the most recent round of randomness that will be available
+// at time for the current client.
+func (oc *optimizingClient) RoundAt(time time.Time) uint64 {
+	return oc.stats[0].client.RoundAt(time)
+}

--- a/client/optimizing_test.go
+++ b/client/optimizing_test.go
@@ -1,0 +1,121 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drand/drand/chain"
+	"github.com/drand/drand/log"
+)
+
+func expectRound(t *testing.T, res Result, r uint64) {
+	t.Helper()
+	if res.Round() != r {
+		t.Fatalf("expected round %v, got %v", r, res.Round())
+	}
+}
+
+func TestOptimizingGet(t *testing.T) {
+	c0 := MockClientWithResults(0, 3)
+	c1 := MockClientWithResults(3, 5)
+
+	c0.Delay = time.Millisecond * 100
+	c1.Delay = time.Millisecond
+
+	oc, err := NewOptimizingClient([]Client{c0, c1}, &chain.Info{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectRound(t, latestResult(t, oc), 0) // round 0 from c0
+	expectRound(t, latestResult(t, oc), 3) // round 3 from c1
+	expectRound(t, latestResult(t, oc), 4) // round 4 from c1
+	expectRound(t, latestResult(t, oc), 1) // c1 error (no results left), round 1 from c0
+	expectRound(t, latestResult(t, oc), 2) // round 2 from c0
+}
+
+func TestOptimizingWatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c0 := MockClientWithResults(0, 3)
+	c1 := MockClientWithResults(3, 5)
+
+	c0.Delay = time.Millisecond * 100
+	c1.Delay = time.Millisecond
+
+	oc, err := NewOptimizingClient([]Client{c0, c1}, fakeChainInfo(), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ch := oc.Watch(ctx)
+
+	expectRound(t, nextResult(t, ch), 0) // round 0 from c0
+	expectRound(t, nextResult(t, ch), 3) // round 3 from c1
+	expectRound(t, nextResult(t, ch), 4) // round 4 from c1
+	expectRound(t, nextResult(t, ch), 1) // c1 error (no results left), round 1 from c0
+	expectRound(t, nextResult(t, ch), 2) // round 2 from c0
+}
+
+func TestOptimizingRTTExpiry(t *testing.T) {
+	c0 := MockClientWithResults(0, 3)
+	c1 := MockClientWithResults(3, 6)
+
+	c0.Delay = time.Millisecond * 100
+	c1.Delay = time.Millisecond
+
+	rttTTL := time.Second
+
+	oc, err := NewOptimizingClient([]Client{c0, c1}, &chain.Info{}, rttTTL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectRound(t, latestResult(t, oc), 0) // round 0 from c0
+	expectRound(t, latestResult(t, oc), 3) // round 3 from c1
+
+	time.Sleep(rttTTL) // wait for c0's RTT to expire
+
+	expectRound(t, latestResult(t, oc), 4) // round 4 from c1 (clears expired RTT)
+	expectRound(t, latestResult(t, oc), 1) // round 1 from c0
+	expectRound(t, latestResult(t, oc), 5) // round 5 from c1 (is still faster)
+}
+
+func TestOptimizingRequiresClients(t *testing.T) {
+	_, err := NewOptimizingClient([]Client{}, &chain.Info{}, 0)
+	if err.Error() != "missing clients" {
+		t.Fatal("unexpected error", err)
+	}
+}
+
+func TestOptimizingRequiresChainInfo(t *testing.T) {
+	_, err := NewOptimizingClient([]Client{&MockClient{}}, nil, 0)
+	if err.Error() != "missing chain info" {
+		t.Fatal("unexpected error", err)
+	}
+}
+
+func TestOptimizingIsLogging(t *testing.T) {
+	oc, err := NewOptimizingClient([]Client{&MockClient{}}, &chain.Info{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lc, ok := oc.(LoggingClient)
+	if !ok {
+		t.Fatal("expected implements LoggingClient")
+	}
+	lc.SetLog(log.DefaultLogger)
+}
+
+func TestOptimizingRoundAt(t *testing.T) {
+	oc, err := NewOptimizingClient([]Client{&MockClient{}}, &chain.Info{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := oc.RoundAt(time.Now()) // mock client returns 0 always
+	if r != 0 {
+		t.Fatal("unexpected round", r)
+	}
+}

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -16,6 +17,14 @@ func fakeChainInfo() *chain.Info {
 		GenesisTime: time.Now().Unix(),
 		PublicKey:   test.GenerateIDs(1)[0].Public.Key,
 	}
+}
+
+func latestResult(t *testing.T, c Client) Result {
+	r, err := c.Get(context.Background(), 0)
+	if err != nil {
+		t.Fatal("getting latest result", err)
+	}
+	return r
 }
 
 // nextResult reads the next result from the channel and fails the test if it closes before a value is read.


### PR DESCRIPTION
Here's a proposal for a client combiner that prioritizes fast clients - I've called it "optimizing client"!

It measures the speed of clients and uses the fastest one. Speeds are measured as the optimizing client is used, so there is no background routine and no additional calls to other clients.

A speed measurement lives for a certain period before it is reset. The next call to `.Get` will then attempt to use a reset client even if it was previously considered to be slower. Pass a value > 0 for `rttTTL` to customize the period - it defaults to 5 minutes.

If a client fails to return a value it'll be attempted from the next fastest client. Failed clients are given a large RTT and are moved to the back of the list. This RTT expires as usual and allows failed clients to be re-introduced and become the fastest again. i.e. failed clients are not taken out of the list, just considered to be very slow.