### PR TITLE
Refactoring of the chain/ package

### DIFF
--- a/chain/beacon/constants.go
+++ b/chain/beacon/constants.go
@@ -1,4 +1,4 @@
-package chain
+package beacon
 
 import "time"
 

--- a/chain/beacon/convert.go
+++ b/chain/beacon/convert.go
@@ -1,0 +1,22 @@
+package beacon
+
+import (
+	"github.com/drand/drand/chain"
+	proto "github.com/drand/drand/protobuf/drand"
+)
+
+func beaconToProto(b *chain.Beacon) *proto.BeaconPacket {
+	return &proto.BeaconPacket{
+		PreviousSig: b.PreviousSig,
+		Round:       b.Round,
+		Signature:   b.Signature,
+	}
+}
+
+func protoToBeacon(p *proto.BeaconPacket) *chain.Beacon {
+	return &chain.Beacon{
+		Round:       p.GetRound(),
+		Signature:   p.GetSignature(),
+		PreviousSig: p.GetPreviousSig(),
+	}
+}

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -1,4 +1,4 @@
-package chain
+package beacon
 
 import (
 	"context"
@@ -13,6 +13,7 @@ import (
 
 	//"github.com/benbjohnson/clock"
 
+	"github.com/drand/drand/chain"
 	"github.com/drand/drand/log"
 	proto "github.com/drand/drand/protobuf/drand"
 	"github.com/drand/kyber/share"
@@ -36,7 +37,7 @@ type Config struct {
 	Clock clock.Clock
 	// Callback to use when a new beacon is created - can be nil and new
 	// callbacks can be added afterwards to the beacon
-	Callback func(*Beacon)
+	Callback func(*chain.Beacon)
 }
 
 // Handler holds the logic to initiate, and react to the TBLS protocol. Each time
@@ -57,12 +58,12 @@ type Handler struct {
 	started   bool
 	stopped   bool
 	l         log.Logger
-	callbacks *CallbackStore
+	callbacks *chain.CallbackStore
 }
 
 // NewHandler returns a fresh handler ready to serve and create randomness
 // beacon
-func NewHandler(c net.ProtocolClient, s Store, conf *Config, l log.Logger) (*Handler, error) {
+func NewHandler(c net.ProtocolClient, s chain.Store, conf *Config, l log.Logger) (*Handler, error) {
 	if conf.Share == nil || conf.Group == nil {
 		return nil, errors.New("beacon: invalid configuration")
 	}
@@ -78,13 +79,13 @@ func NewHandler(c net.ProtocolClient, s Store, conf *Config, l log.Logger) (*Han
 	// genesis block at round 0, next block at round 1
 	// THIS is to change when one network wants to build on top of another
 	// network's chain. Note that if present it overwrites.
-	b := &Beacon{
+	b := &chain.Beacon{
 		Signature: conf.Group.GetGenesisSeed(),
 		Round:     0,
 	}
 	s.Put(b)
 	ticker := newTicker(conf.Clock, conf.Group.Period, conf.Group.GenesisTime)
-	callbacks := NewCallbackStore(s)
+	callbacks := chain.NewCallbackStore(s)
 	chain := newChainStore(logger, c, safe, callbacks, ticker)
 	handler := &Handler{
 		conf:      conf,
@@ -109,7 +110,7 @@ func (h *Handler) ProcessPartialBeacon(c context.Context, p *proto.PartialBeacon
 	addr := peer.Addr.String()
 	h.l.Debug("received", "request", "from", addr, "round", p.GetRound())
 
-	nextRound, _ := NextRound(h.conf.Clock.Now().Unix(), h.conf.Group.Period, h.conf.Group.GenesisTime)
+	nextRound, _ := chain.NextRound(h.conf.Clock.Now().Unix(), h.conf.Group.Period, h.conf.Group.GenesisTime)
 	currentRound := nextRound - 1
 
 	// we allow one round off in the future because of small clock drifts
@@ -120,7 +121,7 @@ func (h *Handler) ProcessPartialBeacon(c context.Context, p *proto.PartialBeacon
 		return nil, fmt.Errorf("invalid round: %d instead of %d", p.GetRound(), currentRound)
 	}
 
-	msg := Message(p.GetRound(), p.GetPreviousSig())
+	msg := chain.Message(p.GetRound(), p.GetPreviousSig())
 	info, err := h.safe.GetInfo(p.GetRound())
 	if err != nil {
 		h.l.Error("process_partial", addr, "no_info_for_round", p.GetRound())
@@ -147,7 +148,7 @@ func (h *Handler) ProcessPartialBeacon(c context.Context, p *proto.PartialBeacon
 }
 
 // Store returns the store associated with this beacon handler
-func (h *Handler) Store() Store {
+func (h *Handler) Store() chain.Store {
 	return h.chain
 }
 
@@ -163,7 +164,7 @@ func (h *Handler) Start() error {
 		h.l.Error("genesis_time", "past", "call", "catchup")
 		return errors.New("beacon: genesis time already passed. Call Catchup()")
 	}
-	_, tTime := NextRound(h.conf.Clock.Now().Unix(), h.conf.Group.Period, h.conf.Group.GenesisTime)
+	_, tTime := chain.NextRound(h.conf.Clock.Now().Unix(), h.conf.Group.Period, h.conf.Group.GenesisTime)
 	h.l.Info("beacon", "start")
 	go h.run(tTime)
 	return nil
@@ -176,7 +177,7 @@ func (h *Handler) Start() error {
 // next upcoming round.
 func (h *Handler) Catchup() {
 	h.chain.RunSync(context.Background())
-	_, tTime := NextRound(h.conf.Clock.Now().Unix(), h.conf.Group.Period, h.conf.Group.GenesisTime)
+	_, tTime := chain.NextRound(h.conf.Clock.Now().Unix(), h.conf.Group.Period, h.conf.Group.GenesisTime)
 	go h.run(tTime)
 }
 
@@ -189,8 +190,8 @@ func (h *Handler) Catchup() {
 // defined, best to use streaming.
 func (h *Handler) Transition(prevGroup *key.Group) error {
 	targetTime := h.conf.Group.TransitionTime
-	tRound := CurrentRound(targetTime, h.conf.Group.Period, h.conf.Group.GenesisTime)
-	tTime := TimeOfRound(h.conf.Group.Period, h.conf.Group.GenesisTime, tRound)
+	tRound := chain.CurrentRound(targetTime, h.conf.Group.Period, h.conf.Group.GenesisTime)
+	tTime := chain.TimeOfRound(h.conf.Group.Period, h.conf.Group.GenesisTime, tRound)
 	if tTime != targetTime {
 		h.l.Fatal("transition_time", "invalid_offset", "expected_time", tTime, "got_time", targetTime)
 		return nil
@@ -207,8 +208,8 @@ func (h *Handler) Transition(prevGroup *key.Group) error {
 // TransitionNewGroup begins transition the crypto share to a new group
 func (h *Handler) TransitionNewGroup(newShare *key.Share, newGroup *key.Group) {
 	targetTime := newGroup.TransitionTime
-	tRound := CurrentRound(targetTime, h.conf.Group.Period, h.conf.Group.GenesisTime)
-	tTime := TimeOfRound(h.conf.Group.Period, h.conf.Group.GenesisTime, tRound)
+	tRound := chain.CurrentRound(targetTime, h.conf.Group.Period, h.conf.Group.GenesisTime)
+	tTime := chain.TimeOfRound(h.conf.Group.Period, h.conf.Group.GenesisTime, tRound)
 	if tTime != targetTime {
 		h.l.Fatal("transition_time", "invalid_offset", "expected_time", tTime, "got_time", targetTime)
 		return
@@ -269,7 +270,7 @@ func (h *Handler) run(startTime int64) {
 	}
 }
 
-func (h *Handler) broadcastNextPartial(current roundInfo, upon *Beacon) {
+func (h *Handler) broadcastNextPartial(current roundInfo, upon *chain.Beacon) {
 	ctx := context.Background()
 	previousSig := upon.Signature
 	round := upon.Round + 1
@@ -291,7 +292,7 @@ func (h *Handler) broadcastNextPartial(current roundInfo, upon *Beacon) {
 		h.l.Error("no_share", round, "BUG", h.safe.String())
 		return
 	}
-	msg := Message(round, previousSig)
+	msg := chain.Message(round, previousSig)
 	currSig, err := key.Scheme.Sign(info.share.PrivateShare(), msg)
 	if err != nil {
 		h.l.Fatal("beacon_round", "err creating signature", "err", err, "round", round)
@@ -354,7 +355,7 @@ func (h *Handler) StopAt(stopTime int64) error {
 }
 
 // AddCallback registers a handler to be notified with new beacons
-func (h *Handler) AddCallback(fn func(*Beacon)) {
+func (h *Handler) AddCallback(fn func(*chain.Beacon)) {
 	h.callbacks.AddCallback(fn)
 }
 
@@ -410,7 +411,7 @@ func (c *cryptoSafe) SetInfo(share *key.Share, id *key.Node, group *key.Group) {
 	}
 	if group.TransitionTime != 0 {
 		time := group.TransitionTime
-		info.startAt = CurrentRound(time, group.Period, group.GenesisTime)
+		info.startAt = chain.CurrentRound(time, group.Period, group.GenesisTime)
 	} else {
 		// group started at genesis time
 		info.startAt = 0

--- a/chain/beacon/ticker.go
+++ b/chain/beacon/ticker.go
@@ -1,8 +1,9 @@
-package chain
+package beacon
 
 import (
 	"time"
 
+	"github.com/drand/drand/chain"
 	clock "github.com/jonboulle/clockwork"
 )
 
@@ -48,7 +49,7 @@ func (t *ticker) Stop() {
 }
 
 func (t *ticker) CurrentRound() uint64 {
-	return CurrentRound(t.clock.Now().Unix(), t.period, t.genesis)
+	return chain.CurrentRound(t.clock.Now().Unix(), t.period, t.genesis)
 }
 
 // Start will sleep until the next upcoming round and start sending out the
@@ -59,7 +60,7 @@ func (t *ticker) Start() {
 	// still sleeping until the next time
 	go func() {
 		now := t.clock.Now().Unix()
-		_, ttime := NextRound(now, t.period, t.genesis)
+		_, ttime := chain.NextRound(now, t.period, t.genesis)
 		if ttime > now {
 			t.clock.Sleep(time.Duration(ttime-now) * time.Second)
 		}
@@ -101,7 +102,7 @@ func (t *ticker) Start() {
 		}
 		select {
 		case nt := <-chanTime:
-			tround = CurrentRound(nt.Unix(), t.period, t.genesis)
+			tround = chain.CurrentRound(nt.Unix(), t.period, t.genesis)
 			ttime = nt.Unix()
 			sendTicks = true
 		case newChan := <-t.newCh:

--- a/chain/beacon_test.go
+++ b/chain/beacon_test.go
@@ -1,16 +1,10 @@
 package chain
 
 import (
-	"bytes"
-	"math"
 	"testing"
-	"time"
 
 	"github.com/drand/drand/key"
-	"github.com/drand/drand/test"
 	"github.com/drand/kyber/util/random"
-	clock "github.com/jonboulle/clockwork"
-	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkVerifyBeacon(b *testing.B) {
@@ -31,99 +25,4 @@ func BenchmarkVerifyBeacon(b *testing.B) {
 			panic(err)
 		}
 	}
-}
-
-func TestChainNextRound(t *testing.T) {
-	clock := clock.NewFakeClock()
-	// start in one second
-	genesis := clock.Now().Add(1 * time.Second).Unix()
-	period := 2 * time.Second
-	// move to genesis round
-	// genesis block is fixed, first round happens at genesis time
-	clock.Advance(1 * time.Second)
-	round, roundTime := NextRound(clock.Now().Unix(), period, genesis)
-	require.Equal(t, uint64(2), round)
-	expTime := genesis + int64(period.Seconds())
-	require.Equal(t, expTime, roundTime)
-
-	time1 := TimeOfRound(period, genesis, 2)
-	require.Equal(t, expTime, time1)
-
-	// move to one second
-	clock.Advance(1 * time.Second)
-	nround, nroundTime := NextRound(clock.Now().Unix(), period, genesis)
-	require.Equal(t, round, nround)
-	require.Equal(t, roundTime, nroundTime)
-
-	// move to next round
-	clock.Advance(1 * time.Second)
-	round, roundTime = NextRound(clock.Now().Unix(), period, genesis)
-	require.Equal(t, round, uint64(3))
-	expTime2 := genesis + int64(period.Seconds())*2
-	require.Equal(t, expTime2, roundTime)
-
-	time2 := TimeOfRound(period, genesis, 3)
-	require.Equal(t, expTime2, time2)
-}
-
-func TestChainInfo(t *testing.T) {
-	_, g1 := test.BatchIdentities(5)
-	c1 := NewChainInfo(g1)
-	require.NotNil(t, c1)
-	h1 := c1.Hash()
-	require.NotNil(t, h1)
-	fake := &key.Group{
-		Period:      g1.Period,
-		GenesisTime: g1.GenesisTime,
-		PublicKey:   g1.PublicKey,
-	}
-	c12 := NewChainInfo(fake)
-	h12 := c12.Hash()
-	require.Equal(t, h1, h12)
-	require.Equal(t, c1, c12)
-
-	_, g2 := test.BatchIdentities(5)
-	c2 := NewChainInfo(g2)
-	h2 := c2.Hash()
-	require.NotEqual(t, h1, h2)
-	require.NotEqual(t, c1, c2)
-
-	var c1Buff bytes.Buffer
-	var c12Buff bytes.Buffer
-	var c2Buff bytes.Buffer
-	err := c1.ToJSON(&c1Buff)
-	require.NoError(t, err)
-	err = c12.ToJSON(&c12Buff)
-	require.NoError(t, err)
-	require.Equal(t, c1Buff.Bytes(), c12Buff.Bytes())
-
-	err = c2.ToJSON(&c2Buff)
-	require.NoError(t, err)
-	require.NotEqual(t, c1Buff.Bytes(), c2Buff.Bytes())
-
-	n, err := InfoFromJSON(bytes.NewBuffer([]byte{}))
-	require.Nil(t, n)
-	require.Error(t, err)
-	c13, err := InfoFromJSON(&c1Buff)
-	require.NoError(t, err)
-	require.NotNil(t, c13)
-	require.True(t, c1.Equal(c13))
-}
-
-func TestTimeOverflow(t *testing.T) {
-	start := time.Date(2020, 01, 01, 0, 0, 0, 0, time.UTC).Unix()
-	period := time.Second
-
-	smallRound := TimeOfRound(period, start, 1024)
-	largeRound := TimeOfRound(period, start, math.MaxInt32)
-
-	if largeRound < smallRound {
-		t.Fatal("future rounds should not allow previous times.")
-	}
-
-	overflowRound := TimeOfRound(period, start, math.MaxInt64)
-	if overflowRound < smallRound {
-		t.Fatal("future rounds should not allow previous times.")
-	}
-
 }

--- a/chain/boltdb/store.go
+++ b/chain/boltdb/store.go
@@ -1,0 +1,197 @@
+package boltdb
+
+import (
+	"errors"
+	"path"
+	"sync"
+
+	"github.com/drand/drand/chain"
+	"github.com/drand/drand/log"
+	bolt "go.etcd.io/bbolt"
+)
+
+// boldStore implements the Store interface using the kv storage boltdb (native
+// golang implementation). Internally, Beacons are stored as JSON-encoded in the
+// db file.
+type boltStore struct {
+	sync.Mutex
+	db  *bolt.DB
+	len int
+}
+
+var beaconBucket = []byte("beacons")
+
+// BoltFileName is the name of the file boltdb writes to
+const BoltFileName = "drand.db"
+
+// NewBoltStore returns a Store implementation using the boltdb storage engine.
+func NewBoltStore(folder string, opts *bolt.Options) (chain.Store, error) {
+	dbPath := path.Join(folder, BoltFileName)
+	db, err := bolt.Open(dbPath, 0660, opts)
+	if err != nil {
+		return nil, err
+	}
+	var baseLen = 0
+	// create the bucket already
+	err = db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists(beaconBucket)
+		if err != nil {
+			return err
+		}
+		baseLen += bucket.Stats().KeyN
+		return nil
+	})
+
+	return &boltStore{
+		db:  db,
+		len: baseLen,
+	}, err
+}
+
+func (b *boltStore) Len() int {
+	var length = 0
+	b.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(beaconBucket)
+		length = bucket.Stats().KeyN
+		return nil
+	})
+	return length
+}
+
+func (b *boltStore) Close() {
+	if err := b.db.Close(); err != nil {
+		log.DefaultLogger.Debug("boltdb", "close", "err", err)
+	}
+}
+
+// Put implements the Store interface. WARNING: It does NOT verify that this
+// beacon is not already saved in the database or not.
+func (b *boltStore) Put(beacon *chain.Beacon) error {
+	err := b.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(beaconBucket)
+		key := chain.RoundToBytes(beacon.Round)
+		buff, err := beacon.Marshal()
+		if err != nil {
+			return err
+		}
+		return bucket.Put(key, buff)
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// ErrNoBeaconSaved is the error returned when no beacon have been saved in the
+// database yet.
+var ErrNoBeaconSaved = errors.New("beacon not found in database")
+
+// Last returns the last beacon signature saved into the db
+func (b *boltStore) Last() (*chain.Beacon, error) {
+	var beacon *chain.Beacon
+	err := b.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(beaconBucket)
+		cursor := bucket.Cursor()
+		_, v := cursor.Last()
+		if v == nil {
+			return ErrNoBeaconSaved
+		}
+		b := &chain.Beacon{}
+		if err := b.Unmarshal(v); err != nil {
+			return err
+		}
+		beacon = b
+		return nil
+	})
+	return beacon, err
+}
+
+// Get returns the beacon saved at this round
+func (b *boltStore) Get(round uint64) (*chain.Beacon, error) {
+	var beacon *chain.Beacon
+	err := b.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(beaconBucket)
+		v := bucket.Get(chain.RoundToBytes(round))
+		if v == nil {
+			return ErrNoBeaconSaved
+		}
+		b := &chain.Beacon{}
+		if err := b.Unmarshal(v); err != nil {
+			return err
+		}
+		beacon = b
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return beacon, err
+}
+
+func (b *boltStore) Del(round uint64) error {
+	return b.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(beaconBucket)
+		return bucket.Delete(chain.RoundToBytes(round))
+	})
+}
+
+func (b *boltStore) Cursor(fn func(chain.Cursor)) {
+	b.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(beaconBucket)
+		c := bucket.Cursor()
+		fn(&boltCursor{Cursor: c})
+		return nil
+	})
+}
+
+type boltCursor struct {
+	*bolt.Cursor
+}
+
+func (c *boltCursor) First() *chain.Beacon {
+	k, v := c.Cursor.First()
+	if k == nil {
+		return nil
+	}
+	b := new(chain.Beacon)
+	if err := b.Unmarshal(v); err != nil {
+		return nil
+	}
+	return b
+}
+
+func (c *boltCursor) Next() *chain.Beacon {
+	k, v := c.Cursor.Next()
+	if k == nil {
+		return nil
+	}
+	b := new(chain.Beacon)
+	if err := b.Unmarshal(v); err != nil {
+		return nil
+	}
+	return b
+}
+
+func (c *boltCursor) Seek(round uint64) *chain.Beacon {
+	k, v := c.Cursor.Seek(chain.RoundToBytes(round))
+	if k == nil {
+		return nil
+	}
+	b := new(chain.Beacon)
+	if err := b.Unmarshal(v); err != nil {
+		return nil
+	}
+	return b
+}
+
+func (c *boltCursor) Last() *chain.Beacon {
+	k, v := c.Cursor.Last()
+	if k == nil {
+		return nil
+	}
+	b := new(chain.Beacon)
+	if err := b.Unmarshal(v); err != nil {
+		return nil
+	}
+	return b
+}

--- a/chain/boltdb/store_test.go
+++ b/chain/boltdb/store_test.go
@@ -1,4 +1,4 @@
-package chain
+package boltdb
 
 import (
 	"os"
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/drand/drand/chain"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,13 +18,13 @@ func TestStoreBoltOrder(t *testing.T) {
 	store, err := NewBoltStore(path, nil)
 	require.NoError(t, err)
 
-	b1 := &Beacon{
+	b1 := &chain.Beacon{
 		PreviousSig: []byte("a magnificent signature"),
 		Round:       145,
 		Signature:   []byte("one signature to"),
 	}
 
-	b2 := &Beacon{
+	b2 := &chain.Beacon{
 		PreviousSig: []byte("is not worth an invalid one"),
 		Round:       146,
 		Signature:   []byte("govern them all"),
@@ -61,13 +62,13 @@ func TestStoreBolt(t *testing.T) {
 
 	require.Equal(t, 0, store.Len())
 
-	b1 := &Beacon{
+	b1 := &chain.Beacon{
 		PreviousSig: sig1,
 		Round:       145,
 		Signature:   sig2,
 	}
 
-	b2 := &Beacon{
+	b2 := &chain.Beacon{
 		PreviousSig: sig2,
 		Round:       146,
 		Signature:   sig1,
@@ -90,11 +91,11 @@ func TestStoreBolt(t *testing.T) {
 	require.NoError(t, store.Put(b1))
 
 	doneCh := make(chan bool)
-	callback := func(b *Beacon) {
+	callback := func(b *chain.Beacon) {
 		require.Equal(t, b1, b)
 		doneCh <- true
 	}
-	cbStore := NewCallbackStore(store)
+	cbStore := chain.NewCallbackStore(store)
 	cbStore.AddCallback(callback)
 	go cbStore.Put(b1)
 	select {
@@ -109,8 +110,8 @@ func TestStoreBolt(t *testing.T) {
 	store.Put(b1)
 	store.Put(b2)
 
-	store.Cursor(func(c Cursor) {
-		expecteds := []*Beacon{b1, b2}
+	store.Cursor(func(c chain.Cursor) {
+		expecteds := []*chain.Beacon{b1, b2}
 		i := 0
 		for b := c.First(); b != nil; b = c.Next() {
 			require.True(t, expecteds[i].Equal(b))
@@ -121,7 +122,7 @@ func TestStoreBolt(t *testing.T) {
 		require.Nil(t, unknown)
 	})
 
-	store.Cursor(func(c Cursor) {
+	store.Cursor(func(c chain.Cursor) {
 		lb2 := c.Last()
 		require.NotNil(t, lb2)
 		require.Equal(t, b2, lb2)

--- a/chain/convert.go
+++ b/chain/convert.go
@@ -12,22 +12,6 @@ import (
 	proto "github.com/drand/drand/protobuf/drand"
 )
 
-func beaconToProto(b *Beacon) *proto.BeaconPacket {
-	return &proto.BeaconPacket{
-		PreviousSig: b.PreviousSig,
-		Round:       b.Round,
-		Signature:   b.Signature,
-	}
-}
-
-func protoToBeacon(p *proto.BeaconPacket) *Beacon {
-	return &Beacon{
-		Round:       p.GetRound(),
-		Signature:   p.GetSignature(),
-		PreviousSig: p.GetPreviousSig(),
-	}
-}
-
 // InfoFromProto returns a Info from the protocol description
 func InfoFromProto(p *proto.ChainInfoPacket) (*Info, error) {
 	public := key.KeyGroup.Point()

--- a/chain/info.go
+++ b/chain/info.go
@@ -1,0 +1,46 @@
+package chain
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"time"
+
+	"github.com/drand/drand/key"
+	"github.com/drand/kyber"
+)
+
+// Info represents the public information that is necessary for a client to
+// very any beacon present in a randomness chain.
+type Info struct {
+	PublicKey   kyber.Point   `json:"public_key"`
+	Period      time.Duration `json:"period"`
+	GenesisTime int64         `json:"genesis_time"`
+}
+
+// NewChainInfo makes a chain Info from a group
+func NewChainInfo(g *key.Group) *Info {
+	return &Info{
+		Period:      g.Period,
+		PublicKey:   g.PublicKey.Key(),
+		GenesisTime: g.GenesisTime,
+	}
+}
+
+// Hash returns the canonical hash representing the chain information. A hash is
+// consistent throughout the entirety of a chain, regardless of the network
+// composition, the actual nodes, generating the randomness.
+func (c *Info) Hash() []byte {
+	h := sha256.New()
+	binary.Write(h, binary.BigEndian, uint32(c.Period.Seconds()))
+	binary.Write(h, binary.BigEndian, int64(c.GenesisTime))
+	buff, _ := c.PublicKey.MarshalBinary()
+	h.Write(buff)
+	return h.Sum(nil)
+}
+
+// Equal indicates if two Chain Info objects are equivalent
+func (c *Info) Equal(c2 *Info) bool {
+	return c.GenesisTime == c2.GenesisTime &&
+		c.Period == c2.Period &&
+		c.PublicKey.Equal(c2.PublicKey)
+}

--- a/chain/info_test.go
+++ b/chain/info_test.go
@@ -1,0 +1,54 @@
+package chain
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/drand/drand/key"
+	"github.com/drand/drand/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChainInfo(t *testing.T) {
+	_, g1 := test.BatchIdentities(5)
+	c1 := NewChainInfo(g1)
+	require.NotNil(t, c1)
+	h1 := c1.Hash()
+	require.NotNil(t, h1)
+	fake := &key.Group{
+		Period:      g1.Period,
+		GenesisTime: g1.GenesisTime,
+		PublicKey:   g1.PublicKey,
+	}
+	c12 := NewChainInfo(fake)
+	h12 := c12.Hash()
+	require.Equal(t, h1, h12)
+	require.Equal(t, c1, c12)
+
+	_, g2 := test.BatchIdentities(5)
+	c2 := NewChainInfo(g2)
+	h2 := c2.Hash()
+	require.NotEqual(t, h1, h2)
+	require.NotEqual(t, c1, c2)
+
+	var c1Buff bytes.Buffer
+	var c12Buff bytes.Buffer
+	var c2Buff bytes.Buffer
+	err := c1.ToJSON(&c1Buff)
+	require.NoError(t, err)
+	err = c12.ToJSON(&c12Buff)
+	require.NoError(t, err)
+	require.Equal(t, c1Buff.Bytes(), c12Buff.Bytes())
+
+	err = c2.ToJSON(&c2Buff)
+	require.NoError(t, err)
+	require.NotEqual(t, c1Buff.Bytes(), c2Buff.Bytes())
+
+	n, err := InfoFromJSON(bytes.NewBuffer([]byte{}))
+	require.Nil(t, n)
+	require.Error(t, err)
+	c13, err := InfoFromJSON(&c1Buff)
+	require.NoError(t, err)
+	require.NotNil(t, c13)
+	require.True(t, c1.Equal(c13))
+}

--- a/chain/store.go
+++ b/chain/store.go
@@ -3,12 +3,7 @@ package chain
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
-	"path"
 	"sync"
-
-	"github.com/drand/drand/log"
-	bolt "go.etcd.io/bbolt"
 )
 
 // store contains all the definitions and implementation of the logic that
@@ -40,192 +35,6 @@ type Cursor interface {
 	Next() *Beacon
 	Seek(round uint64) *Beacon
 	Last() *Beacon
-}
-
-// boldStore implements the Store interface using the kv storage boltdb (native
-// golang implementation). Internally, Beacons are stored as JSON-encoded in the
-// db file.
-type boltStore struct {
-	sync.Mutex
-	db  *bolt.DB
-	len int
-}
-
-var beaconBucket = []byte("beacons")
-
-// BoltFileName is the name of the file boltdb writes to
-const BoltFileName = "drand.db"
-
-// NewBoltStore returns a Store implementation using the boltdb storage engine.
-func NewBoltStore(folder string, opts *bolt.Options) (Store, error) {
-	dbPath := path.Join(folder, BoltFileName)
-	db, err := bolt.Open(dbPath, 0660, opts)
-	if err != nil {
-		return nil, err
-	}
-	var baseLen = 0
-	// create the bucket already
-	err = db.Update(func(tx *bolt.Tx) error {
-		bucket, err := tx.CreateBucketIfNotExists(beaconBucket)
-		if err != nil {
-			return err
-		}
-		baseLen += bucket.Stats().KeyN
-		return nil
-	})
-
-	return &boltStore{
-		db:  db,
-		len: baseLen,
-	}, err
-}
-
-func (b *boltStore) Len() int {
-	var length = 0
-	b.db.View(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(beaconBucket)
-		length = bucket.Stats().KeyN
-		return nil
-	})
-	return length
-}
-
-func (b *boltStore) Close() {
-	if err := b.db.Close(); err != nil {
-		log.DefaultLogger.Debug("boltdb", "close", "err", err)
-	}
-}
-
-// Put implements the Store interface. WARNING: It does NOT verify that this
-// beacon is not already saved in the database or not.
-func (b *boltStore) Put(beacon *Beacon) error {
-	err := b.db.Update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(beaconBucket)
-		key := roundToBytes(beacon.Round)
-		buff, err := beacon.Marshal()
-		if err != nil {
-			return err
-		}
-		return bucket.Put(key, buff)
-	})
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// ErrNoBeaconSaved is the error returned when no beacon have been saved in the
-// database yet.
-var ErrNoBeaconSaved = errors.New("beacon not found in database")
-
-// Last returns the last beacon signature saved into the db
-func (b *boltStore) Last() (*Beacon, error) {
-	var beacon *Beacon
-	err := b.db.View(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(beaconBucket)
-		cursor := bucket.Cursor()
-		_, v := cursor.Last()
-		if v == nil {
-			return ErrNoBeaconSaved
-		}
-		b := &Beacon{}
-		if err := b.Unmarshal(v); err != nil {
-			return err
-		}
-		beacon = b
-		return nil
-	})
-	return beacon, err
-}
-
-// Get returns the beacon saved at this round
-func (b *boltStore) Get(round uint64) (*Beacon, error) {
-	var beacon *Beacon
-	err := b.db.View(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(beaconBucket)
-		v := bucket.Get(roundToBytes(round))
-		if v == nil {
-			return ErrNoBeaconSaved
-		}
-		b := &Beacon{}
-		if err := b.Unmarshal(v); err != nil {
-			return err
-		}
-		beacon = b
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return beacon, err
-}
-
-func (b *boltStore) Del(round uint64) error {
-	return b.db.Update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(beaconBucket)
-		return bucket.Delete(roundToBytes(round))
-	})
-}
-
-func (b *boltStore) Cursor(fn func(Cursor)) {
-	b.db.View(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(beaconBucket)
-		c := bucket.Cursor()
-		fn(&boltCursor{Cursor: c})
-		return nil
-	})
-}
-
-type boltCursor struct {
-	*bolt.Cursor
-}
-
-func (c *boltCursor) First() *Beacon {
-	k, v := c.Cursor.First()
-	if k == nil {
-		return nil
-	}
-	b := new(Beacon)
-	if err := b.Unmarshal(v); err != nil {
-		return nil
-	}
-	return b
-}
-
-func (c *boltCursor) Next() *Beacon {
-	k, v := c.Cursor.Next()
-	if k == nil {
-		return nil
-	}
-	b := new(Beacon)
-	if err := b.Unmarshal(v); err != nil {
-		return nil
-	}
-	return b
-}
-
-func (c *boltCursor) Seek(round uint64) *Beacon {
-	k, v := c.Cursor.Seek(roundToBytes(round))
-	if k == nil {
-		return nil
-	}
-	b := new(Beacon)
-	if err := b.Unmarshal(v); err != nil {
-		return nil
-	}
-	return b
-}
-
-func (c *boltCursor) Last() *Beacon {
-	k, v := c.Cursor.Last()
-	if k == nil {
-		return nil
-	}
-	b := new(Beacon)
-	if err := b.Unmarshal(v); err != nil {
-		return nil
-	}
-	return b
 }
 
 // CallbackStore keeps a list of functions to notify on new beacons
@@ -266,7 +75,7 @@ func (c *CallbackStore) AddCallback(fn func(*Beacon)) {
 	c.cbs = append(c.cbs, fn)
 }
 
-func roundToBytes(r uint64) []byte {
+func RoundToBytes(r uint64) []byte {
 	var buff bytes.Buffer
 	binary.Write(&buff, binary.BigEndian, r)
 	return buff.Bytes()

--- a/chain/time.go
+++ b/chain/time.go
@@ -1,0 +1,47 @@
+package chain
+
+import (
+	"math"
+	"time"
+)
+
+// TimeOfRound is returning the time the current round should happen
+func TimeOfRound(period time.Duration, genesis int64, round uint64) int64 {
+	if round == 0 {
+		return genesis
+	}
+
+	periodBits := math.Log2(float64(period))
+	if round > (math.MaxUint64 >> int(periodBits)) {
+		return math.MaxInt64
+	}
+	delta := (round - 1) * uint64(period.Seconds())
+
+	// - 1 because genesis time is for 1st round already
+	return genesis + int64(delta)
+}
+
+// CurrentRound calculates the active round at `now`
+func CurrentRound(now int64, period time.Duration, genesis int64) uint64 {
+	nextRound, _ := NextRound(now, period, genesis)
+	if nextRound <= 1 {
+		return nextRound
+	}
+	return nextRound - 1
+}
+
+// NextRound returns the next upcoming round and its UNIX time given the genesis
+// time and the period.
+// round at time genesis = round 1. Round 0 is fixed.
+func NextRound(now int64, period time.Duration, genesis int64) (uint64, int64) {
+	if now < genesis {
+		return 1, genesis
+	}
+	fromGenesis := now - genesis
+	// we take the time from genesis divided by the periods in seconds, that
+	// gives us the number of periods since genesis. We add +1 since we want the
+	// next round. We also add +1 because round 1 starts at genesis time.
+	nextRound := uint64(math.Floor(float64(fromGenesis)/period.Seconds())) + 1
+	nextTime := genesis + int64(nextRound*uint64(period.Seconds()))
+	return nextRound + 1, nextTime
+}

--- a/chain/time_test.go
+++ b/chain/time_test.go
@@ -1,0 +1,61 @@
+package chain
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	clock "github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimeOverflow(t *testing.T) {
+	start := time.Date(2020, 01, 01, 0, 0, 0, 0, time.UTC).Unix()
+	period := time.Second
+
+	smallRound := TimeOfRound(period, start, 1024)
+	largeRound := TimeOfRound(period, start, math.MaxInt32)
+
+	if largeRound < smallRound {
+		t.Fatal("future rounds should not allow previous times.")
+	}
+
+	overflowRound := TimeOfRound(period, start, math.MaxInt64)
+	if overflowRound < smallRound {
+		t.Fatal("future rounds should not allow previous times.")
+	}
+
+}
+
+func TestChainNextRound(t *testing.T) {
+	clock := clock.NewFakeClock()
+	// start in one second
+	genesis := clock.Now().Add(1 * time.Second).Unix()
+	period := 2 * time.Second
+	// move to genesis round
+	// genesis block is fixed, first round happens at genesis time
+	clock.Advance(1 * time.Second)
+	round, roundTime := NextRound(clock.Now().Unix(), period, genesis)
+	require.Equal(t, uint64(2), round)
+	expTime := genesis + int64(period.Seconds())
+	require.Equal(t, expTime, roundTime)
+
+	time1 := TimeOfRound(period, genesis, 2)
+	require.Equal(t, expTime, time1)
+
+	// move to one second
+	clock.Advance(1 * time.Second)
+	nround, nroundTime := NextRound(clock.Now().Unix(), period, genesis)
+	require.Equal(t, round, nround)
+	require.Equal(t, roundTime, nroundTime)
+
+	// move to next round
+	clock.Advance(1 * time.Second)
+	round, roundTime = NextRound(clock.Now().Unix(), period, genesis)
+	require.Equal(t, round, uint64(3))
+	expTime2 := genesis + int64(period.Seconds())*2
+	require.Equal(t, expTime2, roundTime)
+
+	time2 := TimeOfRound(period, genesis, 3)
+	require.Equal(t, expTime2, time2)
+}

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -20,7 +20,7 @@ import (
 	gonet "net"
 
 	"github.com/BurntSushi/toml"
-	"github.com/drand/drand/chain"
+	"github.com/drand/drand/chain/boltdb"
 	"github.com/drand/drand/core"
 	"github.com/drand/drand/fs"
 	"github.com/drand/drand/key"
@@ -658,7 +658,7 @@ func deleteBeaconCmd(c *cli.Context) error {
 		return fmt.Errorf("given round not valid: %d", sr)
 	}
 	startRound := uint64(sr)
-	store, err := chain.NewBoltStore(conf.DBFolder(), conf.BoltOptions())
+	store, err := boltdb.NewBoltStore(conf.DBFolder(), conf.BoltOptions())
 	if err != nil {
 		return fmt.Errorf("invalid bolt store creation: %s", err)
 	}

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/drand/drand/chain"
+	"github.com/drand/drand/chain/boltdb"
 	"github.com/drand/drand/core"
 	"github.com/drand/drand/fs"
 	"github.com/drand/drand/key"
@@ -35,7 +36,7 @@ func TestDeleteBeacon(t *testing.T) {
 	var opt = core.WithConfigFolder(tmp)
 	conf := core.NewConfig(opt)
 	fs.CreateSecureFolder(conf.DBFolder())
-	store, err := chain.NewBoltStore(conf.DBFolder(), conf.BoltOptions())
+	store, err := boltdb.NewBoltStore(conf.DBFolder(), conf.BoltOptions())
 	require.NoError(t, err)
 	store.Put(&chain.Beacon{
 		Round:     1,
@@ -66,7 +67,7 @@ func TestDeleteBeacon(t *testing.T) {
 	args := []string{"drand", "util", "del-beacon", "--folder", tmp, "3"}
 	app := CLI()
 	require.NoError(t, app.Run(args))
-	store, err = chain.NewBoltStore(conf.DBFolder(), conf.BoltOptions())
+	store, err = boltdb.NewBoltStore(conf.DBFolder(), conf.BoltOptions())
 	require.NoError(t, err)
 
 	// try to fetch round 3 and 4 - it should now fail

--- a/core/drand_public.go
+++ b/core/drand_public.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/drand/drand/chain"
+	"github.com/drand/drand/chain/beacon"
 	"github.com/drand/drand/entropy"
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/protobuf/drand"
@@ -104,7 +105,7 @@ func (d *Drand) PublicRand(c context.Context, in *drand.PublicRandRequest) (*dra
 }
 
 func (d *Drand) PublicRandStream(req *drand.PublicRandRequest, stream drand.Public_PublicRandStreamServer) error {
-	var b *chain.Handler
+	var b *beacon.Handler
 	d.state.Lock()
 	if d.beacon == nil {
 		return errors.New("beacon has not started on this node yet")

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.14
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/boltdb/bolt v1.3.1
 	github.com/drand/bls12-381 v0.3.2
 	github.com/drand/kyber v1.0.2
 	github.com/go-kit/kit v0.10.0

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/boltdb/bolt v1.3.1
 	github.com/drand/bls12-381 v0.3.2
 	github.com/drand/kyber v1.0.2
 	github.com/go-kit/kit v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,6 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
-github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
 github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btcd v0.0.0-20190824003749-130ea5bddde3/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
+github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
+github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
 github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btcd v0.0.0-20190824003749-130ea5bddde3/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=


### PR DESCRIPTION
This breaks down the `chain/` package into
- `chain/` : contains static definitions and helpers (beacon, chain info, store..)
- `chain/beacon/` contains the protocol's logic of the random beacon
- `chain/boltdb` contains the implementation of the store using boltdb

Unfortunately, the goal of removing dependency on grpc is not trivially done. The problem is that `protobuf/` compiled files depends on gRPC. We would need to make maybe an intermediate drand  representation, and/or make a package "convert" explicitely. Note that I'm not sure this goal is worth the complexity: from what I see now, only the client side of the HTTP relay will benefit from that but all the rest HTTP server, gossipsub will still have to import protobuf (and hence gRPC), so ... I'm not 100% sold on the benefit given the downsides.
But let's iterate if we find a good way to do that.

Question: I hesitated to create a package `chain/store` and `chain/store/boltdb` - it kinda makes sense but didn't feel like the most urgent thing to do. Any thoughts ?

Probably need https://github.com/drand/drand/pull/508 merged before.