### PR TITLE
Fixing deadline time on CI 

### DIFF
--- a/cmd/relay-gossip/client/relayclient_test.go
+++ b/cmd/relay-gossip/client/relayclient_test.go
@@ -90,11 +90,6 @@ func TestGRPCClient(t *testing.T) {
 	}
 	svc.(mock.MockService).EmitRand(true)
 	cancel()
-	select {
-	case <-ch:
-	case <-time.After(10 * time.Second):
-		t.Fatal("timeout")
-	}
 }
 
 func TestHTTPClient(t *testing.T) {
@@ -149,11 +144,6 @@ func TestHTTPClient(t *testing.T) {
 	}
 	emit(true)
 	cancel()
-	select {
-	case <-ch:
-	case <-time.After(10 * time.Second):
-		t.Fatal("timeout")
-	}
 }
 
 func newTestClient(name string, relayMultiaddr []ma.Multiaddr, info *chain.Info) (*Client, error) {

--- a/cmd/relay-gossip/client/relayclient_test.go
+++ b/cmd/relay-gossip/client/relayclient_test.go
@@ -90,7 +90,10 @@ func TestGRPCClient(t *testing.T) {
 	}
 	svc.(mock.MockService).EmitRand(true)
 	cancel()
-	for range ch {
+	select {
+	case <-ch:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout")
 	}
 }
 
@@ -140,13 +143,16 @@ func TestHTTPClient(t *testing.T) {
 			} else {
 				fmt.Print(r)
 			}
-		case <-time.After(2 * time.Second):
+		case <-time.After(10 * time.Second):
 			t.Fatal("timeout.")
 		}
 	}
 	emit(true)
 	cancel()
-	for range ch {
+	select {
+	case <-ch:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout")
 	}
 }
 

--- a/cmd/relay-gossip/client/relayclient_test.go
+++ b/cmd/relay-gossip/client/relayclient_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/drand/drand/chain"
+	"github.com/drand/drand/client"
 	cmock "github.com/drand/drand/client/test/mock"
 	"github.com/drand/drand/cmd/relay-gossip/lp2p"
 	"github.com/drand/drand/cmd/relay-gossip/node"
@@ -90,6 +91,21 @@ func TestGRPCClient(t *testing.T) {
 	}
 	svc.(mock.MockService).EmitRand(true)
 	cancel()
+	drain(t, ch, 10*time.Second)
+}
+
+func drain(t *testing.T, ch <-chan client.Result, timeout time.Duration) {
+
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+		case <-time.After(timeout):
+			t.Fatal("timed out closing channel.")
+		}
+	}
 }
 
 func TestHTTPClient(t *testing.T) {
@@ -144,6 +160,7 @@ func TestHTTPClient(t *testing.T) {
 	}
 	emit(true)
 	cancel()
+	drain(t, ch, 10*time.Second)
 }
 
 func newTestClient(name string, relayMultiaddr []ma.Multiaddr, info *chain.Info) (*Client, error) {

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -181,12 +181,13 @@ func TestHTTPHealth(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("startup of the server on 1st request should happen")
 	}
-
 	push(false)
+	// give some time for http server to get it
+	time.Sleep(30 * time.Millisecond)
 	resp, _ = http.Get(fmt.Sprintf("http://%s/health", listener.Addr().String()))
 	if resp.StatusCode != http.StatusOK {
 		var buf [100]byte
 		resp.Body.Read(buf[:])
-		t.Fatalf("after start server expected to be healthy relatively quickly. %v", string(buf[:]))
+		t.Fatalf("after start server expected to be healthy relatively quickly. %v - %v", string(buf[:]), resp.StatusCode)
 	}
 }


### PR DESCRIPTION
This PR tries to put explicit timeouts on some tests so that circleCI outputs which tests faileds / took longer than expected