### PR TITLE
creation of http client should include all urls

### DIFF
--- a/client/http/http.go
+++ b/client/http/http.go
@@ -56,13 +56,23 @@ func NewWithInfo(url string, info *chain.Info, transport nhttp.RoundTripper) (cl
 func ForURLs(urls []string, chainHash []byte) []client.Client {
 	clients := make([]client.Client, 0)
 	var info *chain.Info
+	skipped := make([]string, 0)
 	for _, u := range urls {
 		if info == nil {
 			if c, err := New(u, chainHash, nil); err == nil {
 				info, err = c.Info(context.Background())
 				clients = append(clients, c)
+			} else {
+				skipped = append(skipped, u)
 			}
 		} else {
+			if c, err := NewWithInfo(u, info, nil); err == nil {
+				clients = append(clients, c)
+			}
+		}
+	}
+	if info != nil {
+		for _, u := range skipped {
 			if c, err := NewWithInfo(u, info, nil); err == nil {
 				clients = append(clients, c)
 			}

--- a/client/http/http.go
+++ b/client/http/http.go
@@ -56,7 +56,7 @@ func NewWithInfo(url string, info *chain.Info, transport nhttp.RoundTripper) (cl
 func ForURLs(urls []string, chainHash []byte) []client.Client {
 	clients := make([]client.Client, 0)
 	var info *chain.Info
-	skipped := make([]string, 0)
+	skipped := []string{}
 	for _, u := range urls {
 		if info == nil {
 			if c, err := New(u, chainHash, nil); err == nil {

--- a/client/http/http_test.go
+++ b/client/http/http_test.go
@@ -70,6 +70,16 @@ func TestHTTPGetLatest(t *testing.T) {
 	}
 }
 
+func TestForURLsCreation(t *testing.T) {
+	addr, chainInfo, cancel, _ := mock.NewMockHTTPPublicServer(t, false)
+	defer cancel()
+
+	clients := ForURLs([]string{"http://invalid.domain/", "http://"+addr}, chainInfo.Hash())
+	if len(clients) != 2 {
+		t.Fatal("expect both urls returned.")
+	}
+}
+
 func TestHTTPWatch(t *testing.T) {
 	addr, chainInfo, cancel, _ := mock.NewMockHTTPPublicServer(t, false)
 	defer cancel()

--- a/client/http/metric.go
+++ b/client/http/metric.go
@@ -11,8 +11,8 @@ import (
 )
 
 // MeasureHeartbeats periodically tracks latency observed on a set of HTTP clients
-func MeasureHeartbeats(ctx context.Context, c []client.Client) *HttpHealthMetrics {
-	m := &HttpHealthMetrics{
+func MeasureHeartbeats(ctx context.Context, c []client.Client) *HealthMetrics {
+	m := &HealthMetrics{
 		next:    0,
 		clients: c,
 	}
@@ -20,8 +20,8 @@ func MeasureHeartbeats(ctx context.Context, c []client.Client) *HttpHealthMetric
 	return m
 }
 
-// HttpHealthMetrics is a measurement task around HTTP clients
-type HttpHealthMetrics struct {
+// HealthMetrics is a measurement task around HTTP clients
+type HealthMetrics struct {
 	next    int
 	clients []client.Client
 }
@@ -29,7 +29,7 @@ type HttpHealthMetrics struct {
 // HTTPHeartbeatInterval is the duration between liveness heartbeats sent to an HTTP API.
 const HTTPHeartbeatInterval = 10 * time.Second
 
-func (c *HttpHealthMetrics) startObserve(ctx context.Context) {
+func (c *HealthMetrics) startObserve(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
previously, failures to retrieve group info at startup would cause URLs to be skipped from later use.
fix #515