### PR TITLE
Allow Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/drand/drand
 
-go 1.14
+go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1


### PR DESCRIPTION
Go 1.14 didn't introduce any major changes that affect us so we might as
well allow Go 1.13