### PR TITLE
fix: race detected on transport read/write for default transport

### DIFF
--- a/client/http/http.go
+++ b/client/http/http.go
@@ -85,7 +85,7 @@ func ForURLs(urls []string, chainHash []byte) []client.Client {
 
 // Instruments an HTTP client around a transport
 func instrumentClient(url string, transport nhttp.RoundTripper) *nhttp.Client {
-	client := nhttp.DefaultClient
+	client := &nhttp.Client{}
 	urlLabel := prometheus.Labels{"url": url}
 
 	trace := &promhttp.InstrumentTrace{


### PR DESCRIPTION
When creating multiple clients we can race read/write to `DefaultClient.transport`.

`DefaultClient` is just `&Client` so instead of using the same one we create a new default one each time we call `instrumentClient`.