### PR TITLE
 Print transient client errors, identifying th…

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -55,11 +55,13 @@ func makeClient(cfg clientConfig) (Client, error) {
 	var c Client
 	var err error
 	if len(cfg.clients) > 0 {
-		c, err = NewOptimizingClient(cfg.clients, 0, 0, 0)
+		oc, err := newOptimizingClient(cfg.clients, 0, 0, 0)
 		if err != nil {
 			return nil, err
 		}
+		c = oc
 		trySetLog(c, cfg.log)
+		oc.Start()
 	} else {
 		c = EmptyClientWithInfo(cfg.chainInfo)
 	}

--- a/client/empty.go
+++ b/client/empty.go
@@ -17,6 +17,10 @@ type emptyClient struct {
 	i *chain.Info
 }
 
+func (m *emptyClient) String() string {
+	return "EmptyClient"
+}
+
 func (m *emptyClient) Info(ctx context.Context) (*chain.Info, error) {
 	return m.i, nil
 }

--- a/client/grpc/client.go
+++ b/client/grpc/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/drand/drand/chain"
@@ -16,7 +17,8 @@ import (
 )
 
 type grpcClient struct {
-	client drand.PublicClient
+	address string
+	client  drand.PublicClient
 }
 
 // New creates a drand client backed by a GRPC connection.
@@ -41,7 +43,7 @@ func New(address string, certPath string, insecure bool) (client.Client, error) 
 	if err != nil {
 		return nil, err
 	}
-	return &grpcClient{drand.NewPublicClient(conn)}, nil
+	return &grpcClient{address, drand.NewPublicClient(conn)}, nil
 }
 
 func asRD(r *drand.PublicRandResponse) *client.RandomData {
@@ -51,6 +53,11 @@ func asRD(r *drand.PublicRandResponse) *client.RandomData {
 		Sig:               r.Signature,
 		PreviousSignature: r.PreviousSignature,
 	}
+}
+
+// String returns the name of this client.
+func (g *grpcClient) String() string {
+	return fmt.Sprintf("GRPC(%q)", g.address)
 }
 
 // Get returns a the randomness at `round` or an error.

--- a/client/http/http.go
+++ b/client/http/http.go
@@ -130,6 +130,11 @@ func (h *httpClient) SetLog(l log.Logger) {
 	h.l = l
 }
 
+// String returns the name of this client.
+func (h *httpClient) String() string {
+	return fmt.Sprintf("HTTP(%q)", h.root)
+}
+
 // FetchGroupInfo attempts to initialize an httpClient when
 // it does not know the full group paramters for a drand group. The chain hash
 // is the hash of the chain info.

--- a/client/interface.go
+++ b/client/interface.go
@@ -10,6 +10,8 @@ import (
 
 // Client represents the drand Client interface.
 type Client interface {
+	// String returns the name of this client instance.
+	String() string
 	// Get returns a the randomness at `round` or an error.
 	// Requesting round = 0 will return randomness for the most
 	// recent known round, bounded at a minimum to the `RoundAt(time.Now())`

--- a/client/interface.go
+++ b/client/interface.go
@@ -10,8 +10,6 @@ import (
 
 // Client represents the drand Client interface.
 type Client interface {
-	// String returns the name of this client instance.
-	String() string
 	// Get returns a the randomness at `round` or an error.
 	// Requesting round = 0 will return randomness for the most
 	// recent known round, bounded at a minimum to the `RoundAt(time.Now())`

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -23,6 +23,10 @@ type MockClient struct {
 	Delay time.Duration
 }
 
+func (m *MockClient) String() string {
+	return "Mock"
+}
+
 // Get returns a the randomness at `round` or an error.
 func (m *MockClient) Get(ctx context.Context, round uint64) (Result, error) {
 	m.Lock()
@@ -121,6 +125,10 @@ func MockClientWithInfo(info *chain.Info) Client {
 
 type MockInfoClient struct {
 	i *chain.Info
+}
+
+func (m *MockInfoClient) String() string {
+	return "MockInfo"
 }
 
 func (m *MockInfoClient) Info(ctx context.Context) (*chain.Info, error) {

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -92,7 +92,7 @@ type optimizingClient struct {
 func (oc *optimizingClient) String() string {
 	names := make([]string, len(oc.clients))
 	for i, c := range oc.clients {
-		names[i] = c.String()
+		names[i] = fmt.Sprint(c)
 	}
 	return fmt.Sprintf("OptimizingClient(%s)", strings.Join(names, ", "))
 }

--- a/client/optimizing_test.go
+++ b/client/optimizing_test.go
@@ -72,10 +72,11 @@ func TestOptimizingGet(t *testing.T) {
 	c0.Delay = time.Millisecond * 100
 	c1.Delay = time.Millisecond
 
-	oc, err := NewOptimizingClient([]Client{c0, c1}, time.Second*5, 2, time.Minute*5)
+	oc, err := newOptimizingClient([]Client{c0, c1}, time.Second*5, 2, time.Minute*5)
 	if err != nil {
 		t.Fatal(err)
 	}
+	oc.Start()
 	defer closeClient(t, oc)
 
 	waitForSpeedTest(t, oc, time.Minute)
@@ -99,10 +100,11 @@ func TestOptimizingWatch(t *testing.T) {
 	c0.Delay = time.Millisecond * 100
 	c1.Delay = time.Millisecond
 
-	oc, err := NewOptimizingClient([]Client{c0, c1, c2}, time.Second*5, 2, time.Minute*5)
+	oc, err := newOptimizingClient([]Client{c0, c1, c2}, time.Second*5, 2, time.Minute*5)
 	if err != nil {
 		t.Fatal(err)
 	}
+	oc.Start()
 	defer closeClient(t, oc)
 
 	waitForSpeedTest(t, oc, time.Minute)
@@ -118,42 +120,36 @@ func TestOptimizingWatch(t *testing.T) {
 }
 
 func TestOptimizingRequiresClients(t *testing.T) {
-	_, err := NewOptimizingClient([]Client{}, 0, 0, 0)
+	_, err := newOptimizingClient([]Client{}, 0, 0, 0)
 	if err.Error() != "missing clients" {
 		t.Fatal("unexpected error", err)
 	}
 }
 
 func TestOptimizingIsLogging(t *testing.T) {
-	oc, err := NewOptimizingClient([]Client{&MockClient{}}, 0, 0, 0)
+	oc, err := newOptimizingClient([]Client{&MockClient{}}, 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	lc, ok := oc.(LoggingClient)
-	if !ok {
-		t.Fatal("expected implements LoggingClient")
-	}
-	lc.SetLog(log.DefaultLogger)
+	oc.SetLog(log.DefaultLogger)
 }
 
 func TestOptimizingIsCloser(t *testing.T) {
-	oc, err := NewOptimizingClient([]Client{&MockClient{}}, 0, 0, 0)
+	oc, err := newOptimizingClient([]Client{&MockClient{}}, 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	cc, ok := oc.(io.Closer)
-	if !ok {
-		t.Fatal("expected implements io.Closer")
-	}
-	cc.Close()
+	oc.Start()
+	oc.Close()
 }
 
 func TestOptimizingInfo(t *testing.T) {
 	chainInfo := fakeChainInfo()
-	oc, err := NewOptimizingClient([]Client{MockClientWithInfo(chainInfo)}, 0, 0, 0)
+	oc, err := newOptimizingClient([]Client{MockClientWithInfo(chainInfo)}, 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
+	oc.Start()
 	i, err := oc.Info(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -164,10 +160,11 @@ func TestOptimizingInfo(t *testing.T) {
 }
 
 func TestOptimizingRoundAt(t *testing.T) {
-	oc, err := NewOptimizingClient([]Client{&MockClient{}}, 0, 0, 0)
+	oc, err := newOptimizingClient([]Client{&MockClient{}}, 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
+	oc.Start()
 	r := oc.RoundAt(time.Now()) // mock client returns 0 always
 	if r != 0 {
 		t.Fatal("unexpected round", r)

--- a/core/drand_proxy.go
+++ b/core/drand_proxy.go
@@ -24,6 +24,11 @@ func Proxy(s drand.PublicServer) client.Client {
 	return &drandProxy{s}
 }
 
+// String returns the name of this proxy.
+func (d *drandProxy) String() string {
+	return "Proxy"
+}
+
 // Get returns randomness at a requested round
 func (d *drandProxy) Get(ctx context.Context, round uint64) (client.Result, error) {
 	resp, err := d.r.PublicRand(ctx, &drand.PublicRandRequest{Round: round})


### PR DESCRIPTION
Name client components, based on location in client hierarchy.
Print transient client errors.

I reviewed the optimizing client. At the moment both network and security-related client errors have the same effect: moving to the back of the queue. This is as desired (security errors can be transient too).

On the other hand, we had no way of informing the user of which of their HTTP dependencies is 
temporarily dysfunctional. So, I added code to log errors and attribute to specific clients.

Closes issue #516.
