### PR TITLE
fix: argument pairs so error message is logged

### DIFF
--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -137,7 +137,7 @@ func (oc *optimizingClient) testSpeed() {
 					break LOOP
 				}
 				if rr.err != nil {
-					oc.log.Error("optimizing_client", "endpoint_temporarily_down_due_to", rr.err)
+					oc.log.Error("optimizing_client", "endpoint temporarily down", "err", rr.err)
 				}
 				stats = append(stats, rr.stat)
 			case <-oc.done:


### PR DESCRIPTION
This was previously appearing in the logs as:

```
ts="Wed, 17 Jun 2020 12:06:14 BST" call=optimizing.go:143 level=error optimizing_client=endpoint_temporarily_down_due_to
```