### PR TITLE
feat: optimizing client retry watch

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -57,7 +57,7 @@ func makeClient(cfg *clientConfig) (Client, error) {
 	var c Client
 	var err error
 	if len(cfg.clients) > 0 {
-		oc, err := newOptimizingClient(cfg.clients, 0, 0, 0)
+		oc, err := newOptimizingClient(cfg.clients, 0, 0, 0, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -146,7 +146,7 @@ func (oc *optimizingClient) testSpeed() {
 					break LOOP
 				}
 				if rr.err != nil {
-					oc.log.Error("optimizing_client", "endpoint temporarily down", "err", rr.err)
+					oc.log.Error("optimizing_client", "endpoint_temporarily_down_due_to", rr.err)
 				}
 				stats = append(stats, rr.stat)
 			case <-oc.done:

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -45,7 +45,7 @@ func newOptimizingClient(
 	clients []Client,
 	requestTimeout time.Duration,
 	requestConcurrency int,
-	speedTestInterval time.Duration,
+	speedTestInterval,
 	watchRetryInterval time.Duration,
 ) (*optimizingClient, error) {
 	if len(clients) == 0 {

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -216,9 +216,7 @@ LOOP:
 // get calls Get on the passed client and returns a requestResult or nil if the context was canceled.
 func get(ctx context.Context, client Client, round uint64) *requestResult {
 	start := time.Now()
-	fmt.Println("client.get start")
 	res, err := client.Get(ctx, round)
-	fmt.Println("client.get done")
 	rtt := time.Since(start)
 	var stat requestStat
 


### PR DESCRIPTION
This PR updates the optimizing client so that when a call to `Watch` on one of the clients fails, it is retried after a while.

It means that if we have gRPC and HTTP clients watching and the gRPC client fails, it can recover, instead of using the HTTP client for ever more.

Kinda more of a fix than a feature now I think about it...