### PR TITLE
feat: add Close method to client

### DIFF
--- a/client/aggregator.go
+++ b/client/aggregator.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"io"
 	"sync"
 
 	"github.com/drand/drand/log"
@@ -109,11 +108,7 @@ func (c *watchAggregator) distribute(in <-chan Result, cancel context.CancelFunc
 }
 
 func (c *watchAggregator) Close() error {
-	var err error
-	cc, ok := c.Client.(io.Closer)
-	if ok {
-		err = cc.Close()
-	}
+	err := c.Client.Close()
 	if c.cancelAutoWatch != nil {
 		c.cancelAutoWatch()
 	}

--- a/client/aggregator_test.go
+++ b/client/aggregator_test.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestAggregatorClose(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	c := &MockClient{
+		WatchCh: make(chan Result),
+		CloseF: func() error {
+			wg.Done()
+			return nil
+		},
+	}
+
+	ac := newWatchAggregator(c, true)
+
+	err := ac.Close() // should cancel the autoWatch and close the underlying client
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg.Wait() // wait for underlying client to close
+}

--- a/client/cache.go
+++ b/client/cache.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"io"
 
 	"github.com/drand/drand/log"
 
@@ -107,9 +106,5 @@ func (c *cachingClient) Watch(ctx context.Context) <-chan Result {
 }
 
 func (c *cachingClient) Close() error {
-	cc, ok := c.Client.(io.Closer)
-	if ok {
-		return cc.Close()
-	}
-	return nil
+	return c.Client.Close()
 }

--- a/client/cache.go
+++ b/client/cache.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"io"
 
 	"github.com/drand/drand/log"
 
@@ -103,4 +104,12 @@ func (c *cachingClient) Watch(ctx context.Context) <-chan Result {
 		close(out)
 	}()
 	return out
+}
+
+func (c *cachingClient) Close() error {
+	cc, ok := c.Client.(io.Closer)
+	if ok {
+		return cc.Close()
+	}
+	return nil
 }

--- a/client/cache_test.go
+++ b/client/cache_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"io"
 	"sync"
 	"testing"
 
@@ -124,12 +123,7 @@ func TestCacheClose(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cc, ok := ca.(io.Closer)
-	if !ok {
-		t.Fatal("not an io.Closer")
-	}
-
-	err = cc.Close() // should close the underlying client
+	err = ca.Close() // should close the underlying client
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/empty.go
+++ b/client/empty.go
@@ -40,3 +40,7 @@ func (m *emptyClient) Watch(ctx context.Context) <-chan Result {
 	close(ch)
 	return ch
 }
+
+func (m *emptyClient) Close() error {
+	return nil
+}

--- a/client/empty_test.go
+++ b/client/empty_test.go
@@ -60,4 +60,8 @@ func TestEmptyClient(t *testing.T) {
 	if len(rs) > 0 {
 		t.Fatal("unexpected results in watch channel", rs)
 	}
+
+	if err := c.Close(); err != nil {
+		t.Fatal("unexpected error closing client", err)
+	}
 }

--- a/client/grpc/client.go
+++ b/client/grpc/client.go
@@ -22,6 +22,7 @@ const grpcDefaultTimeout = 5 * time.Second
 type grpcClient struct {
 	address string
 	client  drand.PublicClient
+	conn    *grpc.ClientConn
 	l       log.Logger
 }
 
@@ -47,7 +48,7 @@ func New(address, certPath string, insecure bool) (client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &grpcClient{address, drand.NewPublicClient(conn), log.DefaultLogger()}, nil
+	return &grpcClient{address, drand.NewPublicClient(conn), conn, log.DefaultLogger()}, nil
 }
 
 func asRD(r *drand.PublicRandResponse) *client.RandomData {
@@ -128,4 +129,9 @@ func (g *grpcClient) RoundAt(t time.Time) uint64 {
 // SetLog configures the client log output
 func (g *grpcClient) SetLog(l log.Logger) {
 	g.l = l
+}
+
+// Close tears down the gRPC connection and all underlying connections.
+func (g *grpcClient) Close() error {
+	return g.conn.Close()
 }

--- a/client/grpc/client_test.go
+++ b/client/grpc/client_test.go
@@ -3,7 +3,6 @@ package grpc
 import (
 	"bytes"
 	"context"
-	"io"
 	"sync"
 	"testing"
 	"time"
@@ -85,12 +84,7 @@ func TestClientClose(t *testing.T) {
 		wg.Done()
 	}()
 
-	cc, ok := c.(io.Closer)
-	if !ok {
-		t.Fatal("not an io.Closer")
-	}
-
-	err = cc.Close()
+	err = c.Close()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/http/http.go
+++ b/client/http/http.go
@@ -224,3 +224,8 @@ func (h *httpClient) Info(ctx context.Context) (*chain.Info, error) {
 func (h *httpClient) RoundAt(t time.Time) uint64 {
 	return chain.CurrentRound(t.Unix(), h.chainInfo.Period, h.chainInfo.GenesisTime)
 }
+
+func (h *httpClient) Close() error {
+	h.client.CloseIdleConnections()
+	return nil
+}

--- a/client/http/http.go
+++ b/client/http/http.go
@@ -186,14 +186,15 @@ func (h *httpClient) FetchChainInfo(chainHash []byte) (*chain.Info, error) {
 			h.l.Warn("http_client", "instantiated without trustroot", "chainHash", hex.EncodeToString(chainInfo.Hash()))
 		}
 		if chainHash != nil && !bytes.Equal(chainInfo.Hash(), chainHash) {
-			resC <- httpInfoResponse{nil, fmt.Errorf("%s does not advertise the expected drand group (%x vs %x)", h.root, chainInfo.Hash(), chainHash)}
+			err := fmt.Errorf("%s does not advertise the expected drand group (%x vs %x)", h.root, chainInfo.Hash(), chainHash)
+			resC <- httpInfoResponse{nil, err}
 			return
 		}
 		resC <- httpInfoResponse{chainInfo, nil}
 	}()
 
 	select {
-	case res, _ := <-resC:
+	case res := <-resC:
 		if res.err != nil {
 			return nil, res.err
 		}
@@ -265,7 +266,7 @@ func (h *httpClient) Get(ctx context.Context, round uint64) (client.Result, erro
 	}()
 
 	select {
-	case res, _ := <-resC:
+	case res := <-resC:
 		if res.err != nil {
 			return nil, res.err
 		}

--- a/client/http/http.go
+++ b/client/http/http.go
@@ -18,6 +18,8 @@ import (
 	json "github.com/nikkolasg/hexjson"
 )
 
+var errClientClosed = fmt.Errorf("client closed")
+
 // New creates a new client pointing to an HTTP endpoint
 func New(url string, chainHash []byte, transport nhttp.RoundTripper) (client.Client, error) {
 	if transport == nil {
@@ -27,6 +29,7 @@ func New(url string, chainHash []byte, transport nhttp.RoundTripper) (client.Cli
 		root:   url,
 		client: instrumentClient(url, transport),
 		l:      log.DefaultLogger(),
+		done:   make(chan struct{}),
 	}
 	chainInfo, err := c.FetchChainInfo(chainHash)
 	if err != nil {
@@ -48,6 +51,7 @@ func NewWithInfo(url string, info *chain.Info, transport nhttp.RoundTripper) (cl
 		chainInfo: info,
 		client:    instrumentClient(url, transport),
 		l:         log.DefaultLogger(),
+		done:      make(chan struct{}),
 	}
 	return c, nil
 }
@@ -123,6 +127,7 @@ type httpClient struct {
 	client    *nhttp.Client
 	chainInfo *chain.Info
 	l         log.Logger
+	done      chan struct{}
 }
 
 // SetLog configures the client log output
@@ -135,6 +140,11 @@ func (h *httpClient) String() string {
 	return fmt.Sprintf("HTTP(%q)", h.root)
 }
 
+type httpInfoResponse struct {
+	chainInfo *chain.Info
+	err       error
+}
+
 // FetchGroupInfo attempts to initialize an httpClient when
 // it does not know the full group parameters for a drand group. The chain hash
 // is the hash of the chain info.
@@ -143,33 +153,64 @@ func (h *httpClient) FetchChainInfo(chainHash []byte) (*chain.Info, error) {
 		return h.chainInfo, nil
 	}
 
-	infoBody, err := h.client.Get(fmt.Sprintf("%s/info", h.root))
-	if err != nil {
-		return nil, err
-	}
-	defer infoBody.Body.Close()
+	resC := make(chan httpInfoResponse, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	chainInfo, err := chain.InfoFromJSON(infoBody.Body)
-	if err != nil {
-		return nil, err
-	}
+	go func() {
+		req, err := nhttp.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/info", h.root), nil)
+		if err != nil {
+			resC <- httpInfoResponse{nil, fmt.Errorf("creating request: %w", err)}
+			return
+		}
 
-	if chainInfo.PublicKey == nil {
-		return nil, fmt.Errorf("group does not have a valid key for validation")
-	}
+		infoBody, err := h.client.Do(req)
+		if err != nil {
+			resC <- httpInfoResponse{nil, fmt.Errorf("doing request: %w", err)}
+			return
+		}
+		defer infoBody.Body.Close()
 
-	if chainHash == nil {
-		h.l.Warn("http_client", "instantiated without trustroot", "chainHash", hex.EncodeToString(chainInfo.Hash()))
+		chainInfo, err := chain.InfoFromJSON(infoBody.Body)
+		if err != nil {
+			resC <- httpInfoResponse{nil, fmt.Errorf("decoding response: %w", err)}
+			return
+		}
+
+		if chainInfo.PublicKey == nil {
+			resC <- httpInfoResponse{nil, fmt.Errorf("group does not have a valid key for validation")}
+			return
+		}
+
+		if chainHash == nil {
+			h.l.Warn("http_client", "instantiated without trustroot", "chainHash", hex.EncodeToString(chainInfo.Hash()))
+		}
+		if chainHash != nil && !bytes.Equal(chainInfo.Hash(), chainHash) {
+			resC <- httpInfoResponse{nil, fmt.Errorf("%s does not advertise the expected drand group (%x vs %x)", h.root, chainInfo.Hash(), chainHash)}
+			return
+		}
+		resC <- httpInfoResponse{chainInfo, nil}
+	}()
+
+	select {
+	case res, _ := <-resC:
+		if res.err != nil {
+			return nil, res.err
+		}
+		return res.chainInfo, nil
+	case <-h.done:
+		return nil, errClientClosed
 	}
-	if chainHash != nil && !bytes.Equal(chainInfo.Hash(), chainHash) {
-		return nil, fmt.Errorf("%s does not advertise the expected drand group (%x vs %x)", h.root, chainInfo.Hash(), chainHash)
-	}
-	return chainInfo, nil
 }
 
 // Implement textMarshaller
 func (h *httpClient) MarshalText() ([]byte, error) {
 	return json.Marshal(h)
+}
+
+type httpGetResponse struct {
+	result client.Result
+	err    error
 }
 
 // Get returns a the randomness at `round` or an error.
@@ -181,37 +222,81 @@ func (h *httpClient) Get(ctx context.Context, round uint64) (client.Result, erro
 		url = fmt.Sprintf("%s/public/%d", h.root, round)
 	}
 
-	randResponse, err := h.client.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer randResponse.Body.Close()
+	resC := make(chan httpGetResponse, 1)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-	randResp := client.RandomData{}
-	if err := json.NewDecoder(randResponse.Body).Decode(&randResp); err != nil {
-		return nil, err
-	}
-	if len(randResp.Sig) == 0 || len(randResp.PreviousSignature) == 0 {
-		return nil, fmt.Errorf("insufficient response")
-	}
+	go func() {
+		req, err := nhttp.NewRequestWithContext(ctx, "GET", url, nil)
+		if err != nil {
+			resC <- httpGetResponse{nil, fmt.Errorf("creating request: %w", err)}
+			return
+		}
 
-	b := chain.Beacon{
-		PreviousSig: randResp.PreviousSignature,
-		Round:       randResp.Rnd,
-		Signature:   randResp.Sig,
-	}
-	if err := chain.VerifyBeacon(h.chainInfo.PublicKey, &b); err != nil {
-		h.l.Warn("http_client", "failed to verify value", "err", err)
-		return nil, err
-	}
-	randResp.Random = chain.RandomnessFromSignature(randResp.Sig)
+		randResponse, err := h.client.Do(req)
+		if err != nil {
+			resC <- httpGetResponse{nil, fmt.Errorf("doing request: %w", err)}
+			return
+		}
+		defer randResponse.Body.Close()
 
-	return &randResp, nil
+		randResp := client.RandomData{}
+		if err := json.NewDecoder(randResponse.Body).Decode(&randResp); err != nil {
+			resC <- httpGetResponse{nil, fmt.Errorf("decoding response: %w", err)}
+			return
+		}
+		if len(randResp.Sig) == 0 || len(randResp.PreviousSignature) == 0 {
+			resC <- httpGetResponse{nil, fmt.Errorf("insufficient response")}
+			return
+		}
+
+		b := chain.Beacon{
+			PreviousSig: randResp.PreviousSignature,
+			Round:       randResp.Rnd,
+			Signature:   randResp.Sig,
+		}
+		if err := chain.VerifyBeacon(h.chainInfo.PublicKey, &b); err != nil {
+			h.l.Warn("http_client", "failed to verify value", "err", err)
+			resC <- httpGetResponse{nil, fmt.Errorf("verifying beacon: %w", err)}
+			return
+		}
+		randResp.Random = chain.RandomnessFromSignature(randResp.Sig)
+		resC <- httpGetResponse{&randResp, nil}
+	}()
+
+	select {
+	case res, _ := <-resC:
+		if res.err != nil {
+			return nil, res.err
+		}
+		return res.result, nil
+	case <-h.done:
+		return nil, errClientClosed
+	}
 }
 
 // Watch returns new randomness as it becomes available.
 func (h *httpClient) Watch(ctx context.Context) <-chan client.Result {
-	return client.PollingWatcher(ctx, h, h.chainInfo, h.l)
+	out := make(chan client.Result)
+	go func() {
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		defer close(out)
+
+		in := client.PollingWatcher(ctx, h, h.chainInfo, h.l)
+		for {
+			select {
+			case res, ok := <-in:
+				if !ok {
+					return
+				}
+				out <- res
+			case <-h.done:
+				return
+			}
+		}
+	}()
+	return out
 }
 
 // Info returns information about the chain.
@@ -226,6 +311,7 @@ func (h *httpClient) RoundAt(t time.Time) uint64 {
 }
 
 func (h *httpClient) Close() error {
+	close(h.done)
 	h.client.CloseIdleConnections()
 	return nil
 }

--- a/client/http/http_test.go
+++ b/client/http/http_test.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"sync"
 	"testing"
@@ -128,12 +127,7 @@ func TestHTTPClientClose(t *testing.T) {
 		wg.Done()
 	}()
 
-	cc, ok := httpClient.(io.Closer)
-	if !ok {
-		t.Fatal("not an io.Closer")
-	}
-
-	err = cc.Close()
+	err = httpClient.Close()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/interface.go
+++ b/client/interface.go
@@ -28,7 +28,7 @@ type Client interface {
 
 	// Close will halt the client and any background processes it runs.
 	// In-flight Get, Watch and Info requests _may_ be canceled but this is
-	// implementation dependent. Behaviour for usage of the client after Close
+	// implementation dependent. Behavior for usage of the client after Close
 	// is called is undefined.
 	// TODO: maybe this should be part of the interface?
 	// Close() error

--- a/client/interface.go
+++ b/client/interface.go
@@ -25,6 +25,13 @@ type Client interface {
 	// RoundAt will return the most recent round of randomness that will be available
 	// at time for the current client.
 	RoundAt(time time.Time) uint64
+
+	// Close will halt the client and any background processes it runs.
+	// In-flight Get, Watch and Info requests _may_ be canceled but this is
+	// implementation dependent. Behaviour for usage of the client after Close
+	// is called is undefined.
+	// TODO: maybe this should be part of the interface?
+	// Close() error
 }
 
 // Result represents the randomness for a single drand round.

--- a/client/interface.go
+++ b/client/interface.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/drand/drand/chain"
@@ -26,12 +27,10 @@ type Client interface {
 	// at time for the current client.
 	RoundAt(time time.Time) uint64
 
-	// Close will halt the client and any background processes it runs.
-	// In-flight Get, Watch and Info requests _may_ be canceled but this is
-	// implementation dependent. Behavior for usage of the client after Close
-	// is called is undefined.
-	// TODO: maybe this should be part of the interface?
-	// Close() error
+	// Close will halt the client, any background processes it runs and any
+	// in-flight Get, Watch or Info requests. Behavior for usage of the client
+	// after Close is called is undefined.
+	io.Closer
 }
 
 // Result represents the randomness for a single drand round.

--- a/client/metric.go
+++ b/client/metric.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"io"
 	"time"
 
 	"github.com/drand/drand/chain"
@@ -46,11 +45,7 @@ func (c *watchLatencyMetricClient) startObserve(ctx context.Context) {
 }
 
 func (c *watchLatencyMetricClient) Close() error {
-	var err error
-	cc, ok := c.Client.(io.Closer)
-	if ok {
-		err = cc.Close()
-	}
+	err := c.Client.Close()
 	c.cancel()
 	return err
 }

--- a/client/metric_test.go
+++ b/client/metric_test.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"io"
+	"sync"
+	"testing"
+)
+
+func TestMetricClose(t *testing.T) {
+	chainInfo := fakeChainInfo()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	c := &MockClient{
+		WatchCh: make(chan Result),
+		CloseF: func() error {
+			wg.Done()
+			return nil
+		},
+	}
+
+	mc := newWatchLatencyMetricClient(c, chainInfo)
+	cc, ok := mc.(io.Closer)
+	if !ok {
+		t.Fatal("not an io.Closer")
+	}
+
+	err := cc.Close() // should close the underlying client
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg.Wait() // wait for underlying client to close
+}

--- a/client/metric_test.go
+++ b/client/metric_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"io"
 	"sync"
 	"testing"
 )
@@ -20,12 +19,8 @@ func TestMetricClose(t *testing.T) {
 	}
 
 	mc := newWatchLatencyMetricClient(c, chainInfo)
-	cc, ok := mc.(io.Closer)
-	if !ok {
-		t.Fatal("not an io.Closer")
-	}
 
-	err := cc.Close() // should close the underlying client
+	err := mc.Close() // should close the underlying client
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -125,3 +125,7 @@ func (m *MockInfoClient) Watch(ctx context.Context) <-chan Result {
 	close(ch)
 	return ch
 }
+
+func (m *MockInfoClient) Close() error {
+	return nil
+}

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -20,6 +20,9 @@ type MockClient struct {
 	// passed. Note that if the context is canceled a result is still consumed
 	// from Results.
 	Delay time.Duration
+	// CloseF is a function to call when the Close function is called on the
+	// mock client.
+	CloseF func() error
 }
 
 func (m *MockClient) String() string {
@@ -73,6 +76,14 @@ func (m *MockClient) Info(ctx context.Context) (*chain.Info, error) {
 // RoundAt will return the most recent round of randomness
 func (m *MockClient) RoundAt(_ time.Time) uint64 {
 	return 0
+}
+
+// Close calls the optional CloseF function.
+func (m *MockClient) Close() error {
+	if m.CloseF != nil {
+		return m.CloseF()
+	}
+	return nil
 }
 
 // ClientWithResults returns a client on which `Get` works `m-n` times.

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"sort"
 	"strings"
@@ -431,8 +432,16 @@ func (oc *optimizingClient) RoundAt(t time.Time) uint64 {
 	return oc.clients[0].RoundAt(t)
 }
 
-// Close stops the background speed tests and closes the client for further use.
+// Close stops the background speed tests and closes the client and it's
+// underlying clients for further use.
 func (oc *optimizingClient) Close() error {
+	var err error
+	for _, c := range oc.clients {
+		cc, ok := c.(io.Closer)
+		if ok {
+			err = cc.Close()
+		}
+	}
 	close(oc.done)
-	return nil
+	return err
 }

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"sort"
 	"strings"
@@ -437,10 +436,7 @@ func (oc *optimizingClient) RoundAt(t time.Time) uint64 {
 func (oc *optimizingClient) Close() error {
 	var err error
 	for _, c := range oc.clients {
-		cc, ok := c.(io.Closer)
-		if ok {
-			err = cc.Close()
-		}
+		err = c.Close()
 	}
 	close(oc.done)
 	return err

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/log"
+	"github.com/hashicorp/go-multierror"
 )
 
 const (
@@ -434,10 +435,10 @@ func (oc *optimizingClient) RoundAt(t time.Time) uint64 {
 // Close stops the background speed tests and closes the client and it's
 // underlying clients for further use.
 func (oc *optimizingClient) Close() error {
-	var err error
+	var errs *multierror.Error
 	for _, c := range oc.clients {
-		err = c.Close()
+		errs = multierror.Append(errs, c.Close())
 	}
 	close(oc.done)
-	return err
+	return errs.ErrorOrNil()
 }

--- a/client/optimizing_test.go
+++ b/client/optimizing_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"io"
 	"sync"
 	"testing"
 	"time"
@@ -57,11 +56,7 @@ func expectRound(t *testing.T, res Result, r uint64) {
 
 func closeClient(t *testing.T, c Client) {
 	t.Helper()
-	cl, ok := c.(io.Closer)
-	if !ok {
-		t.Fatal("client is not an io.Closer")
-	}
-	err := cl.Close()
+	err := c.Close()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/watcher.go
+++ b/client/watcher.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"io"
 )
 
 type watcherClient struct {
@@ -11,4 +12,17 @@ type watcherClient struct {
 
 func (c *watcherClient) Watch(ctx context.Context) <-chan Result {
 	return c.watcher.Watch(ctx)
+}
+
+func (c *watcherClient) Close() error {
+	var err error
+	cw, ok := c.watcher.(io.Closer)
+	if ok {
+		err = cw.Close()
+	}
+	cc, ok := c.Client.(io.Closer)
+	if ok {
+		err = cc.Close()
+	}
+	return err
 }

--- a/client/watcher.go
+++ b/client/watcher.go
@@ -20,8 +20,8 @@ func (c *watcherClient) Close() error {
 	var errs *multierror.Error
 	cw, ok := c.watcher.(io.Closer)
 	if ok {
-		errs = multierror.Append(cw.Close())
+		errs = multierror.Append(errs, cw.Close())
 	}
-	errs = multierror.Append(c.Client.Close())
+	errs = multierror.Append(errs, c.Client.Close())
 	return errs.ErrorOrNil()
 }

--- a/client/watcher_test.go
+++ b/client/watcher_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -59,4 +60,25 @@ func TestWatcherRoundAt(t *testing.T) {
 	if w.RoundAt(time.Now()) != 0 {
 		t.Fatal("unexpected RoundAt value")
 	}
+}
+
+func TestWatcherClose(t *testing.T) {
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	closeF := func() error {
+		wg.Done()
+		return nil
+	}
+
+	w := &MockClient{CloseF: closeF}
+	c := &MockClient{CloseF: closeF}
+
+	wc := &watcherClient{c, w}
+	err := wc.Close() // should close the underlying client AND watcher
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg.Wait() // wait for underlying client AND watcher to close
 }

--- a/core/drand_proxy.go
+++ b/core/drand_proxy.go
@@ -77,6 +77,10 @@ func (d *drandProxy) RoundAt(t time.Time) uint64 {
 	return chain.CurrentRound(t.Unix(), info.Period, info.GenesisTime)
 }
 
+func (d *drandProxy) Close() error {
+	return nil
+}
+
 // streamProxy directly relays mesages of the PublicRandResponse stream.
 type streamProxy struct {
 	ctx      context.Context

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.14.6
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/ipfs/go-cid v0.0.6-0.20200501230655-7c82f3b81c00 // indirect
 	github.com/ipfs/go-datastore v0.4.4

--- a/go.sum
+++ b/go.sum
@@ -220,11 +220,14 @@ github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfm
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
+github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=

--- a/lp2p/relaynode_test.go
+++ b/lp2p/relaynode_test.go
@@ -39,6 +39,10 @@ func (c *mockClient) RoundAt(time time.Time) uint64 {
 	return 0
 }
 
+func (c *mockClient) Close() error {
+	return nil
+}
+
 // toRandomDataChain converts the mock results into a chain of client.RandomData
 // objects. Note that you do not get back the first result.
 func toRandomDataChain(results ...mock.Result) []client.RandomData {


### PR DESCRIPTION
This PR adds ~~an optional~~ a `Close` method for clients that have things to close, or have underlying clients that might have things to close :)

The _main_ idea is to be able to terminate any running background processes that the client (or it's underlying clients) creates that would not otherwise be able to be killed externally.

To discuss:

* ~~Should we just add `Close` to the interface? It would remove a bunch of conditionals!~~
    * Yes! Done.
* ~~With gRPC, closing the connection will actually also terminate any in-flight `Get`, `Watch` or `Info` requests. With HTTP it's not that easy, we'd have to add some more complicated code to track connections. So for that reason I've kinda left the semantics for `Close` to be that `Get`, `Watch` or `Info` requests _may_ be terminated, at the client's discretion, but it doesn't sit super comfortably with me and would love some opinions here.~~
    * Calling `Close` will terminate any in-flight `Get`, `Watch` or `Info` requests for all clients.

resolves https://github.com/drand/drand/issues/469