### PR TITLE
fix: remove audit/production warning banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/drand/drand)
 [![golang version](https://img.shields.io/badge/golang-%3E%3D1.14-orange.svg)](https://golang.org/)
 
-> ⚠️ `Disclaimer` ⚠️ 
-> **This software is considered experimental and has NOT received a third-party
-audit yet. Therefore, DO NOT USE it in production or for anything security
-critical at this point.**
-
 # Drand - A Distributed Randomness Beacon Daemon
 
 Drand (pronounced "dee-rand") is a distributed randomness beacon daemon written

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -47,8 +47,6 @@ const defaultPort = "8080"
 
 func banner() {
 	fmt.Fprintf(output, "drand %v (date %v, commit %v) by nikkolasg\n", version, buildDate, gitCommit)
-	s := "WARNING: this software has NOT received a full audit and must be used with caution and probably NOT in a production environment.\n"
-	fmt.Fprint(output, s)
 }
 
 var folderFlag = &cli.StringFlag{


### PR DESCRIPTION
drand received an audit and is now considered suitable for use in production environments