### PR TITLE
Go-Releaser expects to run `go generate`, which now needs `protoc`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,16 @@ jobs:
         with:
           go-version: 1.14
       -
+        name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+      -
+        name: Install Protoc-gen-go
+        run: |
+          go get github.com/golang/protobuf/protoc-gen-go
+          go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
+      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
see: https://github.com/drand/drand/actions/runs/155887827