### PR TITLE
Correcting the drand.love URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ client can use the `--tls-cert` flag to specify the server's certificate.
 
 ### Create a Drand deployment
 
-Consult full instructions at [DEPLOYMENT](https://beta.drand.love/operate/deploy/)
+Consult full instructions at [DEPLOYMENT](https://beta.drand.love/operator/deploy/)
 
 ### Fetching Public Randomness
 
@@ -270,12 +270,12 @@ Here is a list of all documentation related to drand:
   [slides](https://docs.google.com/presentation/d/1t2ysit78w0lsySwVbQOyWcSDnYxdOBPzY7K2P9UE1Ac/edit?usp=sharing)
   about drand or online [video](https://www.youtube.com/watch?v=ydwW2HFFxNI&list=PLhuBigpl7lqu6xWpiXtbEzJQtlMH1tqoG&index=3).
   - [A basic explainer of the cryptography behind drand](https://hackmd.io/@nikkolasg/HyUAgm234), 
-  - [Protocol Specification](https://beta.drand.love/concepts/specification/)
+  - [Protocol Specification](https://beta.drand.love/docs/specification/)
 - API documentation
   - [The client-side API documentation of drand](https://hackmd.io/@nikkolasg/HJ9lg5ZTE) 
 - DevOps/Deployment documentation
-  - [Deployment instructions](https://beta.drand.love/operate/deploy/)
-  - [Security Model](https://beta.drand.love/concepts/security-model/)
+  - [Deployment instructions](https://beta.drand.love/operator/deploy/)
+  - [Security Model](https://beta.drand.love/docs/security-model/)
 
 As well, here is a list of background readings w.r.t to the cryptography used in
 drand:


### PR DESCRIPTION
So that the specification and deployment documentation are correctly linked.