### PR TITLE
attempt to stabilize regression ci check

### DIFF
--- a/demo/regression/main.go
+++ b/demo/regression/main.go
@@ -69,6 +69,7 @@ func testUpgrade(orch *lib.Orchestrator) (err error) {
 	orch.CheckNewBeacon(1)
 	orch.StartNode(1)
 	orch.WaitPeriod()
+	orch.WaitPeriod()
 	orch.CheckNewBeacon()
 
 	return nil
@@ -172,6 +173,7 @@ const reportTemplate = `
 {{.Upgrade}}
 ~~~
 {{- end}}
+
 `
 
 func setSignal(orch *lib.Orchestrator) {


### PR DESCRIPTION
currently the final "swap out one member" check seems to not be passing pretty regularly. lets see if waiting an extra period makes it more stable.