### PR TITLE
lint CI check still fails

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
+    - uses: actions/cache@v2
+      id: lint-dep-cache
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+    - name: Fetch Dependencies
+      run: go get ./...
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v1.2.1
       with:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -43,7 +43,7 @@ jobs:
       name: Save report
       run: |
         OUTPUT=$(cat report.md)
-        OUTPUT="${OUTPUT//'%'/'%25'}​【7,6 m】"
+        OUTPUT="${OUTPUT//'%'/'%25'}"
         OUTPUT="${OUTPUT//$'\n'/'%0A'}"
         OUTPUT="${OUTPUT//$'\r'/'%0D'}"
         echo "::set-output name=result::$OUTPUT"


### PR DESCRIPTION
it appears to time out fetching dependencies / not properly caching them internal to the golangci-lint action task. re-add the explicit `go get ./...` as a precursor step.