### PR TITLE
fix: remove println

### DIFF
--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -283,9 +283,6 @@ func parallelGet(ctx context.Context, clients []Client, round uint64, timeout ti
 					rr := get(gctx, c, round)
 					cancel()
 					if rr != nil {
-						if rr.result != nil && rr.result.Round() != round {
-							fmt.Printf("got unexpected round back in OC get call %s\n", c)
-						}
 						results <- rr
 					}
 					token <- struct{}{}


### PR DESCRIPTION
I believe this was added while debugging locally and never removed.

When asking for **round 0** the following is erroneously printed:

```
got unexpected round back in OC get call HTTP("https://pl-us.testnet.drand.sh").(+verifier)
```