### PR TITLE
fix: follow chain nil pointer

### DIFF
--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -440,8 +440,8 @@ func TestDrandFollowChain(tt *testing.T) {
 		var goon = true
 		for goon {
 			select {
-			case p := <-progress:
-				if p.Current == exp {
+			case p, ok := <-progress:
+				if ok && p.Current == exp {
 					// success
 					fmt.Printf("\n\nSUCCESSSSSS\n\n")
 					goon = false


### PR DESCRIPTION
Since both the out and err channels can close at the same time there's a possibility go will select a closed out channel when there's an error.