### PR TITLE
test: old verified result

### DIFF
--- a/client/verify_test.go
+++ b/client/verify_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/drand/drand/client/test/result/mock"
 )
 
-func TestVerify(t *testing.T) {
-	info, results := mock.VerifiableResults(3)
+func mockClientWithVerifiableResults(n int) (client.Client, []mock.Result, error) {
+	info, results := mock.VerifiableResults(n)
 	mc := client.MockClient{Results: results, StrictRounds: true}
 	c, err := client.Wrap(
 		[]client.Client{client.MockClientWithInfo(info), &mc},
@@ -18,6 +18,14 @@ func TestVerify(t *testing.T) {
 		client.WithVerifiedResult(&results[0]),
 		client.WithFullChainVerification(),
 	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return c, results, nil
+}
+
+func TestVerify(t *testing.T) {
+	c, results, err := mockClientWithVerifiableResults(3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,14 +39,7 @@ func TestVerify(t *testing.T) {
 }
 
 func TestVerifyWithOldVerifiedResult(t *testing.T) {
-	info, results := mock.VerifiableResults(5)
-	mc := client.MockClient{Results: results, StrictRounds: true}
-	c, err := client.Wrap(
-		[]client.Client{client.MockClientWithInfo(info), &mc},
-		client.WithChainInfo(info),
-		client.WithVerifiedResult(&results[0]),
-		client.WithFullChainVerification(),
-	)
+	c, results, err := mockClientWithVerifiableResults(5)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/verify_test.go
+++ b/client/verify_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestVerify(t *testing.T) {
-	info, results := mock.VerifiableResults(3)
+	info, results := mock.VerifiableResults(10)
 	mc := client.MockClient{Results: results, StrictRounds: true}
 	c, err := client.Wrap(
 		[]client.Client{client.MockClientWithInfo(info), &mc},
@@ -27,5 +27,27 @@ func TestVerify(t *testing.T) {
 	}
 	if res.Round() != results[1].Round() {
 		t.Fatal("expected to get result.", results[1].Round(), res.Round(), fmt.Sprintf("%v", c))
+	}
+}
+
+func TestVerifyWithOldVerifiedResult(t *testing.T) {
+	info, results := mock.VerifiableResults(5)
+	mc := client.MockClient{Results: results, StrictRounds: true}
+	c, err := client.Wrap(
+		[]client.Client{client.MockClientWithInfo(info), &mc},
+		client.WithChainInfo(info),
+		client.WithVerifiedResult(&results[0]),
+		client.WithFullChainVerification(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// should automatically load rounds 1, 2 and 3 to verify 4
+	res, err := c.Get(context.Background(), results[4].Round())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Round() != results[4].Round() {
+		t.Fatal("expected to get result.", results[4].Round(), res.Round(), fmt.Sprintf("%v", c))
 	}
 }

--- a/client/verify_test.go
+++ b/client/verify_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestVerify(t *testing.T) {
-	info, results := mock.VerifiableResults(10)
+	info, results := mock.VerifiableResults(3)
 	mc := client.MockClient{Results: results, StrictRounds: true}
 	c, err := client.Wrap(
 		[]client.Client{client.MockClientWithInfo(info), &mc},


### PR DESCRIPTION
Just adds a test to increase coverage that runs the code path that has to get intermediate rounds between point of trust and requested round.