### PR TITLE
fix: retry auto watch

### DIFF
--- a/client/aggregator.go
+++ b/client/aggregator.go
@@ -115,14 +115,13 @@ func (c *watchAggregator) Watch(ctx context.Context) <-chan Result {
 func (c *watchAggregator) distribute(in <-chan Result, cancel context.CancelFunc) {
 	defer cancel()
 	for {
-		aCtx := context.Background()
 		c.subscriberLock.Lock()
 		if len(c.subscribers) == 0 {
 			c.subscriberLock.Unlock()
 			c.log.Warn("watch_aggregator", "no subscribers to distribute results to")
 			return
 		}
-		aCtx = c.subscribers[0].ctx
+		aCtx := c.subscribers[0].ctx
 		c.subscriberLock.Unlock()
 
 		var m Result

--- a/client/aggregator.go
+++ b/client/aggregator.go
@@ -29,9 +29,6 @@ func newWatchAggregator(c Client, autoWatch bool, autoWatchRetry time.Duration) 
 		log:            log.DefaultLogger(),
 		subscribers:    make([]subscriber, 0),
 	}
-	if autoWatch {
-		aggregator.startAutoWatch()
-	}
 	return aggregator
 }
 
@@ -49,6 +46,14 @@ type watchAggregator struct {
 
 	subscriberLock sync.Mutex
 	subscribers    []subscriber
+}
+
+// Start initiates auto watching if configured to do so.
+// SetLog should not be called after Start.
+func (c *watchAggregator) Start() {
+	if c.autoWatch {
+		c.startAutoWatch()
+	}
 }
 
 // SetLog configures the client log output

--- a/client/aggregator_test.go
+++ b/client/aggregator_test.go
@@ -17,7 +17,7 @@ func TestAggregatorClose(t *testing.T) {
 		},
 	}
 
-	ac := newWatchAggregator(c, true)
+	ac := newWatchAggregator(c, true, 0)
 
 	err := ac.Close() // should cancel the autoWatch and close the underlying client
 	if err != nil {

--- a/client/cache_test.go
+++ b/client/cache_test.go
@@ -83,7 +83,7 @@ func TestCacheWatch(t *testing.T) {
 		t.Fatal(err)
 	}
 	cache, _ := NewCachingClient(m, arcCache)
-	c := newWatchAggregator(cache, false)
+	c := newWatchAggregator(cache, false, 0)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	r1 := c.Watch(ctx)

--- a/client/client.go
+++ b/client/client.go
@@ -98,7 +98,7 @@ func makeClient(cfg *clientConfig) (Client, error) {
 
 	oc.Start()
 
-	c = newWatchAggregator(c, cfg.autoWatch)
+	c = newWatchAggregator(c, cfg.autoWatch, cfg.autoWatchRetry)
 	trySetLog(c, cfg.log)
 
 	return attachMetrics(cfg, c)
@@ -153,6 +153,9 @@ type clientConfig struct {
 	// autoWatch causes the client to start watching immediately in the background so that new randomness
 	// is proactively fetched and added to the cache.
 	autoWatch bool
+	// autoWatchRetry specifies the time after which the watch channel
+	// created by the autoWatch is re-opened when no context error occurred.
+	autoWatchRetry time.Duration
 	// prometheus is an interface to a Prometheus system
 	prometheus prometheus.Registerer
 }
@@ -286,6 +289,16 @@ func WithWatcher(wc WatcherCtor) Option {
 func WithAutoWatch() Option {
 	return func(cfg *clientConfig) error {
 		cfg.autoWatch = true
+		return nil
+	}
+}
+
+// WithAutoWatchRetry specifies the time after which the watch channel
+// created by the autoWatch is re-opened when no context error occurred.
+// Set to a negative value to disable retrying auto watch.
+func WithAutoWatchRetry(interval time.Duration) Option {
+	return func(cfg *clientConfig) error {
+		cfg.autoWatchRetry = interval
 		return nil
 	}
 }

--- a/client/client.go
+++ b/client/client.go
@@ -98,8 +98,11 @@ func makeClient(cfg *clientConfig) (Client, error) {
 
 	oc.Start()
 
-	c = newWatchAggregator(c, cfg.autoWatch, cfg.autoWatchRetry)
+	wa := newWatchAggregator(c, cfg.autoWatch, cfg.autoWatchRetry)
+	c = wa
 	trySetLog(c, cfg.log)
+
+	wa.Start()
 
 	return attachMetrics(cfg, c)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -237,6 +237,71 @@ func TestClientAutoWatch(t *testing.T) {
 	_ = c.Close()
 }
 
+func TestClientAutoWatchRetry(t *testing.T) {
+	info, results := mock.VerifiableResults(5)
+	resC := make(chan client.Result)
+	defer close(resC)
+
+	// done is closed after all resuls have been written to resC
+	done := make(chan struct{})
+
+	// Returns a channel that yields the verifiable results above
+	watchF := func(ctx context.Context) <-chan client.Result {
+		go func() {
+			for i := 0; i < len(results); i++ {
+				select {
+				case resC <- &results[i]:
+				case <-ctx.Done():
+					return
+				}
+			}
+			<-time.After(time.Second)
+			close(done)
+		}()
+		return resC
+	}
+
+	var failer client.MockClient
+	failer = client.MockClient{
+		WatchF: func(ctx context.Context) <-chan client.Result {
+			// First call returns a closed channel
+			ch := make(chan client.Result)
+			close(ch)
+			// Second call returns a channel that writes results
+			failer.WatchF = watchF
+			return ch
+		},
+	}
+
+	c, err := client.New(
+		client.From(&failer, client.MockClientWithInfo(info)),
+		client.WithChainInfo(info),
+		client.WithAutoWatch(),
+		client.WithAutoWatchRetry(time.Second),
+		client.WithCacheSize(len(results)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	// Wait for all the results to be consumed by the autoWatch
+	select {
+	case <-done:
+	case <-time.After(time.Minute):
+		t.Fatal("timed out waiting for results to be consumed")
+	}
+
+	// We should be able to retrieve all the results from the cache.
+	for _, res := range results {
+		r, err := c.Get(context.Background(), res.Round())
+		if err != nil {
+			t.Fatal(err)
+		}
+		compareResults(t, &res, r)
+	}
+}
+
 // compareResults asserts that two results are the same.
 func compareResults(t *testing.T, a, b client.Result) {
 	t.Helper()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -293,12 +293,12 @@ func TestClientAutoWatchRetry(t *testing.T) {
 	}
 
 	// We should be able to retrieve all the results from the cache.
-	for _, res := range results {
-		r, err := c.Get(context.Background(), res.Round())
+	for i := range results {
+		r, err := c.Get(context.Background(), results[i].Round())
 		if err != nil {
 			t.Fatal(err)
 		}
-		compareResults(t, &res, r)
+		compareResults(t, &results[i], r)
 	}
 }
 

--- a/client/test/result/mock/result.go
+++ b/client/test/result/mock/result.go
@@ -80,7 +80,7 @@ func roundToBytes(r int) []byte {
 	return buff.Bytes()
 }
 
-//VerifiableResults creates a set of results that will pass a `chain.Verify` check.
+// VerifiableResults creates a set of results that will pass a `chain.Verify` check.
 func VerifiableResults(count int) (*chain.Info, []Result) {
 	secret := key.KeyGroup.Scalar().Pick(random.New())
 	public := key.KeyGroup.Point().Mul(secret, nil)


### PR DESCRIPTION
The optimizing client will retry failed clients but if _all_ of them fail and are put in backoff then the watch channel will be closed. If this happens then the auto watch will stop forever and there's no way to restart without creating a new client.

This PR changes the auto watch functionality so that if the auto watch channel gets closed, then it is re-opened after 30s. It adds `WithAutoWatchRetry(time.Duration)` option to allow people to customise or disable it.

Maybe this should be a separate client? It's not really tied to the aggregator anymore.