### PR TITLE
cleanup 'drand.dkgInfo' field after reshare attempt completes or fails.

### DIFF
--- a/core/drand_control.go
+++ b/core/drand_control.go
@@ -143,13 +143,14 @@ func (d *Drand) runDKG(leader bool, group *key.Group, timeout uint32, randomness
 	}
 
 	d.state.Lock()
-	d.dkgInfo = &dkgInfo{
+	dkgInfo := &dkgInfo{
 		target: group,
 		board:  board,
 		phaser: phaser,
 		conf:   config,
 		proto:  dkgProto,
 	}
+	d.dkgInfo = dkgInfo
 	if leader {
 		d.dkgInfo.started = true
 	}
@@ -165,9 +166,15 @@ func (d *Drand) runDKG(leader bool, group *key.Group, timeout uint32, randomness
 	finalGroup, err := d.WaitDKG()
 	if err != nil {
 		d.log.Error("init_dkg", err)
+		d.state.Lock()
+		if d.dkgInfo == dkgInfo {
+			d.dkgInfo = nil
+		}
+		d.state.Unlock()
 		return nil, fmt.Errorf("drand: %v", err)
 	}
 	d.state.Lock()
+	d.dkgInfo = nil
 	d.dkgDone = true
 	d.state.Unlock()
 	d.log.Info("init_dkg", "dkg_done", "starting_beacon_time", finalGroup.GenesisTime, "now", d.opts.clock.Now().Unix())
@@ -258,6 +265,11 @@ func (d *Drand) runResharing(leader bool, oldGroup, newGroup *key.Group, timeout
 	d.log.Info("dkg_reshare", "wait_dkg_end")
 	finalGroup, err := d.WaitDKG()
 	if err != nil {
+		d.state.Lock()
+		if d.dkgInfo == info {
+			d.dkgInfo = nil
+		}
+		d.state.Unlock()
 		return nil, fmt.Errorf("drand: err during DKG: %v", err)
 	}
 	d.log.Info("dkg_reshare", "finished", "leader", leader)

--- a/core/drand_control.go
+++ b/core/drand_control.go
@@ -168,12 +168,14 @@ func (d *Drand) runDKG(leader bool, group *key.Group, timeout uint32, randomness
 		d.log.Error("init_dkg", err)
 		d.state.Lock()
 		if d.dkgInfo == dkgInfo {
+			d.dkgInfo.board.stop()
 			d.dkgInfo = nil
 		}
 		d.state.Unlock()
 		return nil, fmt.Errorf("drand: %v", err)
 	}
 	d.state.Lock()
+	d.dkgInfo.board.stop()
 	d.dkgInfo = nil
 	d.dkgDone = true
 	d.state.Unlock()
@@ -267,6 +269,7 @@ func (d *Drand) runResharing(leader bool, oldGroup, newGroup *key.Group, timeout
 	if err != nil {
 		d.state.Lock()
 		if d.dkgInfo == info {
+			d.dkgInfo.board.stop()
 			d.dkgInfo = nil
 		}
 		d.state.Unlock()


### PR DESCRIPTION
fix #679