### PR TITLE
Import client docs

### DIFF
--- a/client/doc.go
+++ b/client/doc.go
@@ -1,0 +1,52 @@
+/*
+Package client provides transport-agnostic logic to retreive and verify
+randomness from drand, including retry, validation, caching and
+optimization features.
+
+Example:
+
+	import (
+		"context"
+		"encoding/hex"
+		"fmt"
+
+		"github.com/drand/drand/client"
+	)
+
+	var chainHash, _ = hex.DecodeString("8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce")
+
+	func main() {
+		c, err := client.New(
+			client.From(...), // see concrete client implementations
+			client.WithChainHash(chainHash),
+			)
+
+		// e.g. use the client to get the latest randomness round:
+		r := c.Get(context.Background(), 0)
+
+		fmt.Println(r.Round(), r.Randomness())
+	}
+
+
+The "From" option allows you to specify clients that work over particular
+transports. HTTP, gRPC and libp2p PubSub clients are provided. Note that you
+are not restricted to just one client. You can use multiple clients of the
+same type or of different types. The base client will periodically "speed
+test" it's clients, failover, cache results and aggregate calls to "Watch" to
+reduce requests.
+
+WARNING: When using the client you should use the "WithChainHash" or
+"WithChainInfo" option in order for your client to validate the randomness it
+receives is from the correct chain. You may use the "Insecurely" option to
+bypass this validation but it is not recommended.
+
+In an application that uses the drand client, the following options are likely
+to be needed/customized:
+
+	WithCacheSize() // should be set to something sensible for your application.
+	WithVerifiedResult() / WithFullChainVerification() // should be set for increased security if you have persistent state and expect to be following the chain.
+	WithAutoWatch() // will pre-load new results as they become available, adding them to the cache for speedy retreival when you need them.
+	WithPrometheus() // enables metrics reporting on speed and performance to a provided prometheus registry.
+
+*/
+package client

--- a/client/doc.go
+++ b/client/doc.go
@@ -1,5 +1,5 @@
 /*
-Package client provides transport-agnostic logic to retreive and verify
+Package client provides transport-agnostic logic to retrieve and verify
 randomness from drand, including retry, validation, caching and
 optimization features.
 

--- a/client/doc.go
+++ b/client/doc.go
@@ -17,9 +17,9 @@ Example:
 
 	func main() {
 		c, err := client.New(
-			client.From(...), // see concrete client implementations
+			client.From("..."), // see concrete client implementations
 			client.WithChainHash(chainHash),
-			)
+		)
 
 		// e.g. use the client to get the latest randomness round:
 		r := c.Get(context.Background(), 0)
@@ -27,13 +27,15 @@ Example:
 		fmt.Println(r.Round(), r.Randomness())
 	}
 
-
 The "From" option allows you to specify clients that work over particular
-transports. HTTP, gRPC and libp2p PubSub clients are provided. Note that you
-are not restricted to just one client. You can use multiple clients of the
-same type or of different types. The base client will periodically "speed
-test" it's clients, failover, cache results and aggregate calls to "Watch" to
-reduce requests.
+transports. HTTP, gRPC and libp2p PubSub clients are provided in drand's
+subpackages https://pkg.go.dev/github.com/drand/drand/client/http,
+https://pkg.go.dev/github.com/drand/drand/client/grpc and
+https://pkg.go.dev/github.com/drand/drand/lp2p/clientlp2p/client
+respectively. Note that you are not restricted to just one client. You can use
+multiple clients of the same type or of different types. The base client will
+periodically "speed test" it's clients, failover, cache results and aggregate
+calls to "Watch" to reduce requests.
 
 WARNING: When using the client you should use the "WithChainHash" or
 "WithChainInfo" option in order for your client to validate the randomness it
@@ -43,10 +45,21 @@ bypass this validation but it is not recommended.
 In an application that uses the drand client, the following options are likely
 to be needed/customized:
 
-	WithCacheSize() // should be set to something sensible for your application.
-	WithVerifiedResult() / WithFullChainVerification() // should be set for increased security if you have persistent state and expect to be following the chain.
-	WithAutoWatch() // will pre-load new results as they become available, adding them to the cache for speedy retreival when you need them.
-	WithPrometheus() // enables metrics reporting on speed and performance to a provided prometheus registry.
+	WithCacheSize()
+		should be set to something sensible for your application.
+
+	WithVerifiedResult()
+	WithFullChainVerification()
+		both should be set for increased security if you have
+		persistent state and expect to be following the chain.
+
+	WithAutoWatch()
+		will pre-load new results as they become available adding them
+		to the cache for speedy retreival when you need them.
+
+	WithPrometheus()
+		enables metrics reporting on speed and performance to a
+		provided prometheus registry.
 
 */
 package client

--- a/client/grpc/doc.go
+++ b/client/grpc/doc.go
@@ -1,0 +1,39 @@
+/*
+Package grpc provides a drand client implementation that uses drand's gRPC API.
+
+The client connects to a drand gRPC endpoint to fetch randomness. The gRPC
+client has some advantages over the HTTP client - it is more compact
+on-the-wire and supports streaming and authentication.
+
+Example:
+
+	package main
+
+	import (
+		"encoding/hex"
+
+		"github.com/drand/drand/client"
+		"github.com/drand/drand/client/grpc"
+	)
+
+	const (
+		grpcAddr = "example.drand.grpc.server:4444"
+		certPath = "/path/to/drand-grpc.cert"
+	)
+
+	var chainHash, _ = hex.DecodeString("8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce")
+
+	func main() {
+		gc, err := grpc.New(grpcAddr, certPath, false)
+
+		c, err := client.New(
+			client.From(gc),
+			client.WithChainHash(chainHash),
+		)
+	}
+
+A path to a file that holds TLS credentials for the drand server is required
+to validate server connections. Alternatively set the final parameter to
+`true` to enable _insecure_ connections (not recommended).
+*/
+package grpc

--- a/client/http/doc.go
+++ b/client/http/doc.go
@@ -35,7 +35,7 @@ The "ForURLs" helper creates multiple HTTP clients from a list of
 URLs. Alternatively you can use the "New" or "NewWithInfo" constructor to
 create clients.
 
-Tip: Provide multiple URLs to enable failover and speed optimised URL
+Tip: Provide multiple URLs to enable failover and speed optimized URL
 selection.
 */
 package http

--- a/client/http/doc.go
+++ b/client/http/doc.go
@@ -1,0 +1,41 @@
+/*
+Package http provides a drand client implementation that uses drand's HTTP API.
+
+The HTTP client uses drand's JSON HTTP API
+(https://drand.love/developer/http-api/) to fetch randomness. Watching is
+implemented by polling the endpoint at the expected round time.
+
+Example:
+
+
+	package main
+
+	import (
+		"encoding/hex"
+
+		"github.com/drand/drand/client"
+		"github.com/drand/drand/client/http"
+	)
+
+	var urls = []string{
+		"https://api.drand.sh",
+		"https://drand.cloudflare.com",
+	}
+
+	var chainHash, _ = hex.DecodeString("8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce")
+
+	func main() {
+		c, err := client.New(
+			client.From(http.ForURLs(urls, chainHash)...),
+			client.WithChainHash(chainHash),
+		)
+	}
+
+The "ForURLs" helper creates multiple HTTP clients from a list of
+URLs. Alternatively you can use the "New" or "NewWithInfo" constructor to
+create clients.
+
+Tip: Provide multiple URLs to enable failover and speed optimised URL
+selection.
+*/
+package http

--- a/lp2p/client/doc.go
+++ b/lp2p/client/doc.go
@@ -10,7 +10,7 @@ If you need to "Get" arbitrary rounds from the chain then you must combine this 
 
 The agnostic client builder must receive "WithChainInfo()" in order for it to
 validate randomness rounds it receives, or "WithChainHash()" and be combined
-with the http or grpc client implementations so that chain information can be
+with the HTTP or gRPC client implementations so that chain information can be
 fetched from them.
 
 It is particularly important that rounds are verified since they can be delivered by any peer in the network.

--- a/lp2p/client/doc.go
+++ b/lp2p/client/doc.go
@@ -3,16 +3,19 @@
 Package client provides a drand client implementation that retrieves
 randomness by subscribing to a libp2p pubsub topic.
 
-WARNING: this client can only be used to `Watch` for new randomness rounds and
-`Get` randomness rounds it has previously seen that are still in the cache.
+WARNING: this client can only be used to "Watch" for new randomness rounds and
+"Get" randomness rounds it has previously seen that are still in the cache.
 
-If you need to `Get` arbitrary rounds from the chain then you must combine this client with the http or grpc clients.
+If you need to "Get" arbitrary rounds from the chain then you must combine this client with the http or grpc clients.
 
-The agnostic client builder must receive `WithChainInfo()` in order for it to validate randomness rounds it receives, or `WithChainHash()` and be combined with the http or grpc client implementations so that chain information can be fetched from them.
+The agnostic client builder must receive "WithChainInfo()" in order for it to
+validate randomness rounds it receives, or "WithChainHash()" and be combined
+with the http or grpc client implementations so that chain information can be
+fetched from them.
 
 It is particularly important that rounds are verified since they can be delivered by any peer in the network.
 
-Example using WithChainInfo():
+Example using "WithChainInfo()":
 
 	package main
 
@@ -41,7 +44,7 @@ Example using WithChainInfo():
 		// ...
 	}
 
-Example using WithChainHash and combining it with a different client:
+Example using "WithChainHash()" and combining it with a different client:
 
 	package main
 

--- a/lp2p/client/doc.go
+++ b/lp2p/client/doc.go
@@ -1,0 +1,79 @@
+/*
+
+Package client provides a drand client implementation that retrieves
+randomness by subscribing to a libp2p pubsub topic.
+
+WARNING: this client can only be used to `Watch` for new randomness rounds and
+`Get` randomness rounds it has previously seen that are still in the cache.
+
+If you need to `Get` arbitrary rounds from the chain then you must combine this client with the http or grpc clients.
+
+The agnostic client builder must receive `WithChainInfo()` in order for it to validate randomness rounds it receives, or `WithChainHash()` and be combined with the http or grpc client implementations so that chain information can be fetched from them.
+
+It is particularly important that rounds are verified since they can be delivered by any peer in the network.
+
+Example using WithChainInfo():
+
+	package main
+
+	import (
+		"github.com/drand/drand/chain"
+		"github.com/drand/drand/client"
+		gclient "github.com/drand/drand/lp2p/client"
+		pubsub "github.com/libp2p/go-libp2p-pubsub"
+	)
+
+	func main() {
+		ps := newPubSub()
+		info := readChainInfo()
+
+		c, err := client.New(
+			gclient.WithPubsub(ps),
+			client.WithChainInfo(info),
+		)
+	}
+
+	func newPubSub() *pubsub.Pubsub {
+		// ...
+	}
+
+	func readChainInfo() *chain.Info {
+		// ...
+	}
+
+Example using WithChainHash and combining it with a different client:
+
+	package main
+
+	import (
+		"encoding/hex"
+
+		"github.com/drand/drand/client"
+		"github.com/drand/drand/client/http"
+		gclient "github.com/drand/drand/lp2p/client"
+		pubsub "github.com/libp2p/go-libp2p-pubsub"
+	)
+
+	var urls = []string{
+		"https://api.drand.sh",
+		"https://drand.cloudflare.com",
+		// ...
+	}
+
+	var chainHash, _ = hex.DecodeString("8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce")
+
+	func main() {
+		ps := newPubSub()
+
+		c, err := client.New(
+			gclient.WithPubsub(ps),
+			client.WithChainHash(chainHash),
+			client.From(http.ForURLs(urls, chainHash)...),
+		)
+	}
+
+	func newPubSub() *pubsub.Pubsub {
+		// ...
+	}
+*/
+package client


### PR DESCRIPTION
Client documentation and examples should live as part of the Go documentation
as it is normal and expected in Go programs.

Leaving essential information about client code usage away from the Go
reference documentation (where Go developers will look for docs) is no good.

Also, docs should be maintained with code by the developers.

The drand.love website should send people here.