### PR TITLE
Fix suboptimal lock release in `(*handler).getChainInfo`.

### DIFF
--- a/http/server.go
+++ b/http/server.go
@@ -74,8 +74,9 @@ func withCommonHeaders(version string, h func(http.ResponseWriter, *http.Request
 }
 
 type handler struct {
-	timeout     time.Duration
-	client      client.Client
+	timeout time.Duration
+	client  client.Client
+	// NOTE: should only be accessed via getChainInfo
 	chainInfo   *chain.Info
 	chainInfoLk sync.RWMutex
 	log         log.Logger
@@ -149,8 +150,9 @@ RESET:
 func (h *handler) getChainInfo(ctx context.Context) *chain.Info {
 	h.chainInfoLk.RLock()
 	if h.chainInfo != nil {
+		info := h.chainInfo
 		h.chainInfoLk.RUnlock()
-		return h.chainInfo
+		return info
 	}
 	h.chainInfoLk.RUnlock()
 
@@ -175,7 +177,7 @@ func (h *handler) getChainInfo(ctx context.Context) *chain.Info {
 	return info
 }
 
-func (h *handler) getRand(ctx context.Context, round uint64) ([]byte, error) {
+func (h *handler) getRand(ctx context.Context, info *chain.Info, round uint64) ([]byte, error) {
 	h.startOnce.Do(h.start)
 	// First see if we should get on the synchronized 'wait for next release' bandwagon.
 	block := false
@@ -212,7 +214,7 @@ func (h *handler) getRand(ctx context.Context, round uint64) ([]byte, error) {
 	}
 
 	// make sure we aren't going to ask for a round that doesn't exist yet.
-	if time.Unix(chain.TimeOfRound(h.chainInfo.Period, h.chainInfo.GenesisTime, round), 0).After(time.Now()) {
+	if time.Unix(chain.TimeOfRound(info.Period, info.GenesisTime, round), 0).After(time.Now()) {
 		return nil, nil
 	}
 
@@ -253,7 +255,7 @@ func (h *handler) PublicRand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := h.getRand(r.Context(), roundN)
+	data, err := h.getRand(r.Context(), info, roundN)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		h.log.Warn("http_server", "failed to get randomness", "client", r.RemoteAddr, "req", url.PathEscape(r.URL.Path), "err", err)


### PR DESCRIPTION
Possible source of bugs in the future but not currently a problem, as `h.chainInfo` is never set *to* `nil` but *from* `nil`.

`getChainInfo` could sometimes unnecessarily return `nil` if `h.chainInfo` were set to `nil` after releasing the `h.chainInfoLk` read lock.

Also remove direct, unsynchronized access to `h.chainInfo` in `h.getRand()`. Similarly not a bug in the current usage, but could be a source of crashes if `h.chainInfo` is set to `nil`, or `h.getRand()` isn't called after a previous call to `h.getChainInfo()`

