### PR TITLE
Deprioritize passive clients in optimizingclient.get

### DIFF
--- a/client/empty.go
+++ b/client/empty.go
@@ -10,6 +10,8 @@ import (
 
 const emptyClientStringerValue = "EmptyClient"
 
+var errEmptyClientUnsupportedGet = errors.New("not supported")
+
 // EmptyClientWithInfo makes a client that returns the given info but no randomness
 func EmptyClientWithInfo(info *chain.Info) Client {
 	return &emptyClient{info}
@@ -32,7 +34,7 @@ func (m *emptyClient) RoundAt(t time.Time) uint64 {
 }
 
 func (m *emptyClient) Get(ctx context.Context, round uint64) (Result, error) {
-	return nil, errors.New("not supported")
+	return nil, errEmptyClientUnsupportedGet
 }
 
 func (m *emptyClient) Watch(ctx context.Context) <-chan Result {

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -240,7 +240,10 @@ LOOP:
 				break LOOP
 			}
 			stats = append(stats, rr.stat)
-			res, err = rr.result, rr.err
+			res = rr.result
+			if err != errEmptyClientUnsupportedGet {
+				err = fmt.Errorf("%v - %w", err, rr.err)
+			}
 		case <-ctx.Done():
 			oc.updateStats(stats)
 			return nil, ctx.Err()

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -104,6 +104,13 @@ func (oc *optimizingClient) Start() {
 // MarkPassive must tag clients as passive before `Start` is run.
 func (oc *optimizingClient) MarkPassive(c Client) {
 	oc.passiveClients = append(oc.passiveClients, c)
+	// push passive clients to the back of the list for `Get`s
+	for _, s := range oc.stats {
+		if s.client == c {
+			s.rtt = math.MaxInt64
+			s.startTime = time.Unix(1<<63-62135596801, 999999999)
+		}
+	}
 }
 
 type optimizingClient struct {


### PR DESCRIPTION
* when the libp2p client is marked 'passive' we should also not end up in cases where it is the first client to be queried when `Get` is called.
* Changes error bubbling in the optimizing client to not only return the final sub-client error.