### PR TITLE
Expose own metrics in /metrics/peer/

### DIFF
--- a/core/drand_metrics.go
+++ b/core/drand_metrics.go
@@ -23,9 +23,6 @@ func (d *Drand) PeerMetrics(c context.Context) (map[string]http.Handler, error) 
 	handlers := make(map[string]http.Handler)
 	var err error
 	for _, n := range d.group.Nodes {
-		if n.Index == uint32(d.index) {
-			continue
-		}
 		p := net.CreatePeer(n.Address(), n.IsTLS())
 		if h, e := hc.HandleHTTP(p); e == nil {
 			handlers[n.Address()] = h


### PR DESCRIPTION
Rationaly here is that any metric scraper should support be configured in the
same way regardless of the peer. By skipping a handler for the current peer we
are creating an "exception" unique to every peer, which only makes things more
difficult to maintain on infra-side of things.

Also, chances are the index mapping is somehow borked, since in my tests it is
sometimes skipping the current node and sometimes a different node, so this might
fix that altogether.