### PR TITLE
fix lint

### DIFF
--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -151,7 +151,6 @@ func TestDrandDKGReshareAbsent(t *testing.T) {
 	// the node that had stopped must not be in the group
 	missingPublic := dt.nodes[nodeToStop].drand.priv.Public
 	require.Nil(t, newGroup.Find(missingPublic), "missing public is found", missingPublic)
-
 }
 
 func TestDrandDKGReshareTimeout(t *testing.T) {

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -318,18 +318,59 @@ func (d *DrandTest2) SetupNewNodes(newNodes int) []*Node {
 	return d.newNodes
 }
 
+func (d *DrandTest2) runNodeReshare(n *Node, errCh chan error, force bool) {
+	var secret = "thisistheresharing"
+	leader := d.nodes[0]
+	// instruct to be ready for a reshare
+	client, err := net.NewControlClient(n.drand.opts.controlPort)
+	require.NoError(d.t, err)
+	_, err = client.InitReshare(leader.drand.priv.Public, secret, d.groupPath, force)
+	if err != nil {
+		fmt.Println("error in NON LEADER: ", err)
+		errCh <- err
+		return
+	}
+	fmt.Printf("\n\nRESHARING TEST: non-leader drand %s DONE RESHARING - %s\n", n.drand.priv.Public.Address(), n.drand.priv.Public.Key)
+}
+
+func (d *DrandTest2) runLeaderReshare(timeout time.Duration, errCh chan error, groupCh chan *key.Group) {
+	var secret = "thisistheresharing"
+	leader := d.nodes[0]
+	oldNode := d.group.Find(leader.drand.priv.Public)
+	if oldNode == nil {
+		panic("leader not found in old group")
+	}
+	// old root: oldNode.Index leater: leader.addr
+	client, err := net.NewControlClient(leader.drand.opts.controlPort)
+	require.NoError(d.t, err)
+	finalGroup, err := client.InitReshareLeader(d.newN, d.newThr, timeout, 0, secret, "", testBeaconOffset)
+	// Done resharing
+	if err != nil {
+		fmt.Println("error in LEADER: ", err)
+		errCh <- err
+	}
+	fg, err := key.GroupFromProto(finalGroup)
+	if err != nil {
+		errCh <- err
+	}
+	groupCh <- fg
+}
+
 // RunReshare runs the resharing procedure with only "oldRun" current nodes
 // running, and "newRun" new nodes running (the ones created via SetupNewNodes).
 // It sets the given threshold to the group.
 // It stops the nodes excluded first.
-func (d *DrandTest2) RunReshare(oldRun, newRun, newThr int, timeout time.Duration, force, onlyLeader bool, ignoreErrs ...bool) (*key.Group, error) {
+func (d *DrandTest2) RunReshare(
+	oldRun, newRun, newThr int,
+	timeout time.Duration,
+	force, onlyLeader bool,
+	ignoreErrs ...bool) (*key.Group, error) {
 	var ignoreErr bool
 	if len(ignoreErrs) > 0 {
 		ignoreErr = true
 	}
 	d.Lock()
 	fmt.Printf(" -- Running RESHARE with %d/%d old, %d/%d new nodes\n", oldRun, len(d.nodes), newRun, len(d.newNodes))
-	var secret = "thisistheresharing"
 	// stop the exluded nodes
 	for _, node := range d.nodes[oldRun:] {
 		d.StopDrand(node.addr, false)
@@ -345,44 +386,9 @@ func (d *DrandTest2) RunReshare(oldRun, newRun, newThr int, timeout time.Duratio
 	leader := d.nodes[0]
 	errCh := make(chan error, 1)
 	groupCh := make(chan *key.Group, 1)
-	// function that each non-leader runs to start the resharing
-	runreshare := func(n *Node) {
-		if onlyLeader {
-			return
-		}
-		// instruct to be ready for a reshare
-		client, err := net.NewControlClient(n.drand.opts.controlPort)
-		require.NoError(d.t, err)
-		_, err = client.InitReshare(leader.drand.priv.Public, secret, d.groupPath, force)
-		if err != nil {
-			fmt.Println("error in NON LEADER: ", err)
-			errCh <- err
-			return
-		}
-		fmt.Printf("\n\nRESHARING TEST: non-leader drand %s DONE RESHARING - %s\n", n.drand.priv.Public.Address(), n.drand.priv.Public.Key)
-	}
 	// first run the leader, then the other nodes will send their PK to the
 	// leader and then the leader will answer back with the new group
-	go func() {
-		oldNode := d.group.Find(leader.drand.priv.Public)
-		if oldNode == nil {
-			panic("leader not found in old group")
-		}
-		// old root: oldNode.Index leater: leader.addr
-		client, err := net.NewControlClient(leader.drand.opts.controlPort)
-		require.NoError(d.t, err)
-		finalGroup, err := client.InitReshareLeader(d.newN, d.newThr, timeout, 0, secret, "", testBeaconOffset)
-		// Done resharing
-		if err != nil {
-			fmt.Println("error in LEADER: ", err)
-			errCh <- err
-		}
-		fg, err := key.GroupFromProto(finalGroup)
-		if err != nil {
-			errCh <- err
-		}
-		groupCh <- fg
-	}()
+	go d.runLeaderReshare(timeout, errCh, groupCh)
 	d.resharedNodes = append(d.resharedNodes, leader)
 	// leave some time to make sure leader is listening
 	time.Sleep(1 * time.Second)
@@ -390,7 +396,9 @@ func (d *DrandTest2) RunReshare(oldRun, newRun, newThr int, timeout time.Duratio
 	// run the current nodes
 	for _, node := range d.nodes[1:oldRun] {
 		d.resharedNodes = append(d.resharedNodes, node)
-		go runreshare(node)
+		if !onlyLeader {
+			go d.runNodeReshare(node, errCh, force)
+		}
 	}
 
 	// run the new ones
@@ -398,7 +406,9 @@ func (d *DrandTest2) RunReshare(oldRun, newRun, newThr int, timeout time.Duratio
 		for _, node := range d.newNodes[:newRun] {
 			d.resharedNodes = append(d.resharedNodes, node)
 			fmt.Printf("\n ++ NEW NODE running RESHARE: %s\n", node.addr)
-			go runreshare(node)
+			if !onlyLeader {
+				go d.runNodeReshare(node, errCh, force)
+			}
 		}
 	}
 	d.Unlock()


### PR DESCRIPTION
keep `golangci-lint run ./...` happy locally