### PR TITLE
bump protoc version in goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: 1.14
       -
         name: Install Protoc
-        uses: arduino/setup-protoc@v1.1.0
+        uses: arduino/setup-protoc@v1.1.2
         with:
           version: '3.12.3'
       -


### PR DESCRIPTION
previous run failed because this was using an insecure feature of github actions they've recently disabled.