### PR TITLE
remove SignatureV2 interface method

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -126,7 +126,7 @@ func TestClientWithoutCache(t *testing.T) {
 }
 
 func TestClientWithWatcher(t *testing.T) {
-	info, results := mock.VerifiableResults(2)
+	info, results := mock.VerifiableResults(2, 10)
 
 	ch := make(chan client.Result, len(results))
 	for i := range results {
@@ -239,7 +239,7 @@ func TestClientAutoWatch(t *testing.T) {
 }
 
 func TestClientAutoWatchRetry(t *testing.T) {
-	info, results := mock.VerifiableResults(5)
+	info, results := mock.VerifiableResults(5, 0)
 	resC := make(chan client.Result)
 	defer close(resC)
 

--- a/client/interface.go
+++ b/client/interface.go
@@ -38,7 +38,6 @@ type Result interface {
 	Round() uint64
 	Randomness() []byte
 	Signature() []byte
-	SignatureV2() []byte
 }
 
 // LoggingClient sets the logger for use by clients that suppport it

--- a/client/random.go
+++ b/client/random.go
@@ -8,6 +8,7 @@ type RandomData struct {
 	Sig               []byte `json:"signature,omitempty"`
 	PreviousSignature []byte `json:"previous_signature,omitempty"`
 	SigV2             []byte `json:"signaturev2,omitempty"`
+	version           byte
 }
 
 // Round provides access to the round associatted with this random data.
@@ -17,14 +18,13 @@ func (r *RandomData) Round() uint64 {
 
 // Signature provides the signature over this round's randomness
 func (r *RandomData) Signature() []byte {
+	if r.version == 2 {
+		return r.SigV2
+	}
 	return r.Sig
 }
 
 // Randomness exports the randomness
 func (r *RandomData) Randomness() []byte {
 	return r.Random
-}
-
-func (r *RandomData) SignatureV2() []byte {
-	return r.SigV2
 }

--- a/client/verify.go
+++ b/client/verify.go
@@ -187,7 +187,7 @@ func (v *verifyingClient) verify(ctx context.Context, info *chain.Info, r *Rando
 		b := chain.Beacon{
 			PreviousSig: ps,
 			Round:       r.Round(),
-			SignatureV2: r.Signature(),
+			SignatureV2: r.SigV2,
 		}
 
 		if err := chain.VerifyBeaconV2(ipk, &b); err != nil {

--- a/client/verify.go
+++ b/client/verify.go
@@ -53,7 +53,7 @@ func (v *verifyingClient) Get(ctx context.Context, round uint64) (Result, error)
 	if err != nil {
 		return nil, err
 	}
-	rd := asRandomData(r)
+	rd := v.asRandomData(r)
 	if err := v.verify(ctx, info, rd); err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (v *verifyingClient) Watch(ctx context.Context) <-chan Result {
 	go func() {
 		defer close(outCh)
 		for r := range inCh {
-			if err := v.verify(ctx, info, asRandomData(r)); err != nil {
+			if err := v.verify(ctx, info, v.asRandomData(r)); err != nil {
 				v.log.Warn("verifying_client", "skipping invalid watch round", "round", r.Round(), "err", err)
 				continue
 			}
@@ -89,16 +89,21 @@ type resultWithPreviousSignature interface {
 	PreviousSignature() []byte
 }
 
-func asRandomData(r Result) *RandomData {
+func (v *verifyingClient) asRandomData(r Result) *RandomData {
 	rd, ok := r.(*RandomData)
 	if ok {
 		return rd
 	}
+	s := r.Signature()
 	rd = &RandomData{
 		Rnd:    r.Round(),
 		Random: r.Randomness(),
-		Sig:    r.Signature(),
-		SigV2:  r.SignatureV2(),
+	}
+	if r.Round() >= v.v2from {
+		rd.SigV2 = s
+		rd.version = 2
+	} else {
+		rd.Sig = s
 	}
 	if rp, ok := r.(resultWithPreviousSignature); ok {
 		rd.PreviousSignature = rp.PreviousSignature()
@@ -148,7 +153,6 @@ func (v *verifyingClient) getTrustedPreviousSignature(ctx context.Context, round
 		b.PreviousSig = trustPrevSig
 		b.Round = trustRound
 		b.Signature = next.Signature()
-		b.SignatureV2 = next.SignatureV2()
 
 		ipk := info.PublicKey.Clone()
 		if err := chain.VerifyBeacon(ipk, &b); err != nil {
@@ -178,20 +182,24 @@ func (v *verifyingClient) verify(ctx context.Context, info *chain.Info, r *Rando
 		}
 	}
 
-	b := chain.Beacon{
-		PreviousSig: ps,
-		Round:       r.Round(),
-		Signature:   r.Signature(),
-		SignatureV2: r.SignatureV2(),
-	}
-
 	ipk := info.PublicKey.Clone()
 	if r.Round() >= v.v2from {
+		b := chain.Beacon{
+			PreviousSig: ps,
+			Round:       r.Round(),
+			SignatureV2: r.Signature(),
+		}
+
 		if err := chain.VerifyBeaconV2(ipk, &b); err != nil {
 			return fmt.Errorf("verification v2 of %s failed: %w", b.String(), err)
 		}
 		r.Random = chain.RandomnessFromSignature(r.SigV2)
 	} else {
+		b := chain.Beacon{
+			PreviousSig: ps,
+			Round:       r.Round(),
+			Signature:   r.Signature(),
+		}
 		if err = chain.VerifyBeacon(ipk, &b); err != nil {
 			return fmt.Errorf("verification v1 of %s failed: %w", b.String(), err)
 		}

--- a/client/verify_test.go
+++ b/client/verify_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func mockClientWithVerifiableResults(n int) (client.Client, []mock.Result, error) {
-	info, results := mock.VerifiableResults(n)
+	info, results := mock.VerifiableResults(n, 1000000000)
 	mc := client.MockClient{Results: results, StrictRounds: true}
 	c, err := client.Wrap(
 		[]client.Client{client.MockClientWithInfo(info), &mc},
@@ -28,7 +28,7 @@ func mockClientWithVerifiableResults(n int) (client.Client, []mock.Result, error
 
 func TestVerifyV1ToV2(t *testing.T) {
 	var fromV2 uint64 = 5
-	info, results := mock.VerifiableResults(10)
+	info, results := mock.VerifiableResults(10, fromV2)
 	mc := client.MockClient{Results: results, StrictRounds: true}
 	c, err := client.Wrap(
 		[]client.Client{client.MockClientWithInfo(info), &mc},

--- a/test/mock/grpcserver.go
+++ b/test/mock/grpcserver.go
@@ -65,6 +65,7 @@ func (s *Server) PublicRand(c context.Context, in *drand.PublicRandRequest) (*dr
 	signaturev2 := decodeHex(s.d.SignatureV2)
 	if s.d.BadSecondRound && in.GetRound() == uint64(s.d.Round) {
 		signature = []byte{0x01, 0x02, 0x03}
+		signaturev2 = []byte{0x01, 0x02, 0x03}
 	}
 	randomness := sha256Hash(signature)
 	resp := drand.PublicRandResponse{


### PR DESCRIPTION
Attempt at limiting the Result interface to a smarter `Signature`. Test compatibility not dealt with here.