### PR TITLE
Test for broadcast based on callbacks instead of timeouts

### DIFF
--- a/core/broadcast_test.go
+++ b/core/broadcast_test.go
@@ -14,6 +14,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type packInfo struct {
+	id   string
+	self *echoBroadcast
+	p    *drand.DKGPacket
+}
+
+type callback func(*packInfo)
+
+type callbackBroadcast struct {
+	*echoBroadcast
+	id string
+	cb callback
+}
+
+func withCallback(id string, b *echoBroadcast, cb callback) Broadcast {
+	return &callbackBroadcast{
+		id:            id,
+		echoBroadcast: b,
+		cb:            cb,
+	}
+}
+
+func (cb *callbackBroadcast) BroadcastDKG(c context.Context, p *drand.DKGPacket) (*drand.Empty, error) {
+	r, err := cb.echoBroadcast.BroadcastDKG(c, p)
+	if err != nil {
+		return r, err
+	}
+	cb.cb(&packInfo{id: cb.id, self: cb.echoBroadcast, p: p})
+	return r, err
+}
+
 func TestBroadcastSet(t *testing.T) {
 	aset := new(arraySet)
 	h1 := []byte("Hello")
@@ -35,14 +66,24 @@ func TestBroadcast(t *testing.T) {
 	defer os.RemoveAll(dir)
 	defer CloseAllDrands(drands)
 
-	broads := make([]*broadcast, 0, n)
+	// channel that will receive all broadcasted packets
+	incPackets := make(chan *packInfo)
+	// callback that all nodes execute when they receive a "successful" packet
+	callback := func(p *packInfo) {
+		incPackets <- p
+	}
+	broads := make([]*echoBroadcast, 0, n)
+	ids := make([]string, 0, n)
 	for _, d := range drands {
-		b := newBroadcast(d.log, d.privGateway.ProtocolClient, d.priv.Public.Address(), group.Nodes, func(dkg.Packet) error { return nil })
+		id := d.priv.Public.Address()
+		b := newEchoBroadcast(d.log, d.privGateway.ProtocolClient, id, group.Nodes, func(dkg.Packet) error { return nil })
+
 		d.dkgInfo = &dkgInfo{
-			board:   b,
+			board:   withCallback(id, b, callback),
 			started: true,
 		}
 		broads = append(broads, b)
+		ids = append(ids, id)
 	}
 
 	deal := fakeDeal()
@@ -50,39 +91,40 @@ func TestBroadcast(t *testing.T) {
 	require.NoError(t, err)
 	_, err = broads[0].BroadcastDKG(context.Background(), &drand.DKGPacket{Dkg: dealProto})
 	require.NoError(t, err)
-	// leave some time so other get it
-	time.Sleep(100 * time.Millisecond)
+	received := make(map[string]bool)
+	exp := n * (n - 1)
+	for i := 0; i < exp; i++ {
+		select {
+		case info := <-incPackets:
+			info.self.Lock()
+			require.True(t, info.self.hashes.exists(deal.Hash()))
+			require.True(t, len(info.self.dealCh) == 1, "len of channel is %d", len(info.self.dealCh))
+			received[info.id] = true
+			info.self.Unlock()
+		case <-time.After(5 * time.Second):
+			require.True(t, false, "test failed to continue")
+		}
+	}
+	for _, id := range ids {
+		require.True(t, received[id])
+	}
 	for _, b := range broads {
-		b.Lock()
-		require.True(t, b.hashes.exists(deal.Hash()))
-		require.True(t, len(b.dealCh) == 1, "len of channel is %d", len(b.dealCh))
-		// drain the channel
-		<-b.dealCh
-		b.Unlock()
+		drain(t, b.dealCh)
 	}
 
-	// try again to broadcast but it shouldn't actually do it
-	broads[1].Lock()
-	broads[1].hashes = new(arraySet)
-	broads[1].Unlock()
+	// try again to broadcast but it shouldn't actually do it because the first
+	// node (the one we ask to send first) already has the hash registered.
 	_, err = broads[0].BroadcastDKG(context.Background(), &drand.DKGPacket{Dkg: dealProto})
 	require.NoError(t, err)
-	time.Sleep(500 * time.Millisecond)
-	broads[1].Lock()
 	select {
-	case <-broads[1].dealCh:
+	case <-incPackets:
 		require.False(t, true, "deal shouldn't be passed down to application")
 	case <-time.After(500 * time.Millisecond):
-		// all good - the message is not supposed to be passed down since it was
-		// already sent in the first round, so this broadcast instance should
-		// never have received it, because broads[0] should never have sent it
-		// in the first place
+		require.Len(t, broads[0].dealCh, 0)
 	}
-	// put it again
-	broads[1].hashes.put(deal.Hash())
-	broads[1].Unlock()
 
 	// let's make everyone broadcast a different packet
+	hashes := make([][]byte, 0, n-1)
 	for _, b := range broads[1:] {
 		deal := fakeDeal()
 		dealProto, err := dkgPacketToProto(deal)
@@ -91,11 +133,31 @@ func TestBroadcast(t *testing.T) {
 			Dkg: dealProto,
 		})
 		require.NoError(t, err)
+		hashes = append(hashes, deal.Hash())
 	}
 
-	time.Sleep(100 * time.Millisecond)
-	for i, b := range broads {
-		require.Equal(t, drain(t, b.dealCh), n-1, "node %d failed", i)
+	received = make(map[string]bool)
+	exp = exp * (n - 1)
+	for i := 0; i < exp; i++ {
+		select {
+		case info := <-incPackets:
+			info.self.Lock()
+			require.True(t, info.self.hashes.exists(deal.Hash()))
+			received[info.id] = true
+			info.self.Unlock()
+		case <-time.After(5 * time.Second):
+			require.True(t, false, "test failed to continue")
+		}
+	}
+	// check if everyone received
+	for _, id := range ids {
+		require.True(t, received[id])
+	}
+	// check if they all have all hashes
+	for _, broad := range broads {
+		for _, hash := range hashes {
+			require.True(t, broad.hashes.exists(hash))
+		}
 	}
 
 	// check that it dispatches to the correct channel

--- a/core/drand.go
+++ b/core/drand.go
@@ -210,7 +210,7 @@ func (d *Drand) WaitDKG() (*key.Group, error) {
 		return nil, err
 	}
 	d.opts.applyDkgCallback(d.share)
-	d.dkgInfo.board.stop()
+	d.dkgInfo.board.Stop()
 	d.dkgInfo = nil
 	return d.group, nil
 }
@@ -358,7 +358,7 @@ func checkGroup(l log.Logger, group *key.Group) {
 // necessary during the DKG protocol.
 type dkgInfo struct {
 	target  *key.Group
-	board   *broadcast
+	board   Broadcast
 	phaser  *dkg.TimePhaser
 	conf    *dkg.Config
 	proto   *dkg.Protocol

--- a/core/drand_control.go
+++ b/core/drand_control.go
@@ -134,7 +134,7 @@ func (d *Drand) runDKG(leader bool, group *key.Group, timeout uint32, randomness
 		Auth:           key.DKGAuthScheme,
 	}
 	phaser := d.getPhaser(timeout)
-	board := newBroadcast(d.log, d.privGateway.ProtocolClient, d.priv.Public.Address(), group.Nodes, func(p dkg.Packet) error {
+	board := newEchoBroadcast(d.log, d.privGateway.ProtocolClient, d.priv.Public.Address(), group.Nodes, func(p dkg.Packet) error {
 		return dkg.VerifyPacketSignature(config, p)
 	})
 	dkgProto, err := dkg.NewProtocol(config, board, phaser, true)
@@ -185,7 +185,7 @@ func (d *Drand) runDKG(leader bool, group *key.Group, timeout uint32, randomness
 
 func (d *Drand) cleanupDKG() {
 	if d.dkgInfo != nil {
-		d.dkgInfo.board.stop()
+		d.dkgInfo.board.Stop()
 	}
 	d.dkgInfo = nil
 }
@@ -238,7 +238,7 @@ func (d *Drand) runResharing(leader bool, oldGroup, newGroup *key.Group, timeout
 	}
 
 	allNodes := nodeUnion(oldGroup.Nodes, newGroup.Nodes)
-	board := newBroadcast(d.log, d.privGateway.ProtocolClient, d.priv.Public.Address(), allNodes, func(p dkg.Packet) error {
+	board := newEchoBroadcast(d.log, d.privGateway.ProtocolClient, d.priv.Public.Address(), allNodes, func(p dkg.Packet) error {
 		return dkg.VerifyPacketSignature(config, p)
 	})
 	phaser := d.getPhaser(timeout)


### PR DESCRIPTION
Tests were always passing locally on my machine but apparently not on Travis - I switched to having tests based on callbacks so travis weird timings doesn't influence test outcome.