### PR TITLE
Revert "Remove scheme id from client CLI and take it from chain info"

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -30,11 +30,7 @@ func TestClientConstraints(t *testing.T) {
 		t.Fatal("Client needs root of trust unless insecure specified explicitly")
 	}
 
-	c := client.MockClientWithResults(0, 5)
-	// As we will run is insecurely, we will set chain info so client can fetch it
-	c.OptionalInfo = fakeChainInfo()
-
-	if _, e := client.New(client.From(c), client.Insecurely()); e != nil {
+	if _, e := client.New(client.From(client.MockClientWithResults(0, 5)), client.Insecurely()); e != nil {
 		t.Fatal(e)
 	}
 }
@@ -52,6 +48,7 @@ func TestClientMultiple(t *testing.T) {
 	var e error
 	c, e = client.New(
 		client.From(http.ForURLs([]string{"http://" + addr1, "http://" + addr2}, chainInfo.Hash())...),
+		client.WithSchemeID(sch.ID),
 		client.WithChainHash(chainInfo.Hash()))
 
 	if e != nil {
@@ -96,6 +93,7 @@ func TestClientCache(t *testing.T) {
 	var c client.Client
 	var e error
 	c, e = client.New(client.From(http.ForURLs([]string{"http://" + addr1}, chainInfo.Hash())...),
+		client.WithSchemeID(sch.ID),
 		client.WithChainHash(chainInfo.Hash()), client.WithCacheSize(1))
 
 	if e != nil {
@@ -127,6 +125,7 @@ func TestClientWithoutCache(t *testing.T) {
 	var e error
 	c, e = client.New(
 		client.From(http.ForURLs([]string{"http://" + addr1}, chainInfo.Hash())...),
+		client.WithSchemeID(sch.ID),
 		client.WithChainHash(chainInfo.Hash()),
 		client.WithCacheSize(0))
 
@@ -163,6 +162,7 @@ func TestClientWithWatcher(t *testing.T) {
 	var err error
 	c, err = client.New(
 		client.WithChainInfo(info),
+		client.WithSchemeID(sch.ID),
 		client.WithWatcher(watcherCtor),
 	)
 
@@ -250,6 +250,7 @@ func TestClientAutoWatch(t *testing.T) {
 		client.From(client.MockClientWithInfo(chainInfo)),
 		client.WithChainHash(chainInfo.Hash()),
 		client.WithWatcher(watcherCtor),
+		client.WithSchemeID(sch.ID),
 		client.WithAutoWatch(),
 	)
 
@@ -313,6 +314,7 @@ func TestClientAutoWatchRetry(t *testing.T) {
 		client.WithAutoWatch(),
 		client.WithAutoWatchRetry(time.Second),
 		client.WithCacheSize(len(results)),
+		client.WithSchemeID(sch.ID),
 	)
 
 	if err != nil {

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -13,10 +13,9 @@ import (
 // MockClient provide a mocked client interface
 type MockClient struct {
 	sync.Mutex
-	OptionalInfo *chain.Info
-	WatchCh      chan Result
-	WatchF       func(context.Context) <-chan Result
-	Results      []mock.Result
+	WatchCh chan Result
+	WatchF  func(context.Context) <-chan Result
+	Results []mock.Result
 	// Delay causes results to be delivered after this period of time has
 	// passed. Note that if the context is canceled a result is still consumed
 	// from Results.
@@ -84,9 +83,6 @@ func (m *MockClient) Watch(ctx context.Context) <-chan Result {
 }
 
 func (m *MockClient) Info(ctx context.Context) (*chain.Info, error) {
-	if m.OptionalInfo != nil {
-		return m.OptionalInfo, nil
-	}
 	return nil, errors.New("not supported (mock client info)")
 }
 

--- a/client/utils_test.go
+++ b/client/utils_test.go
@@ -6,17 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/drand/drand/common/scheme"
-
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/test"
 )
 
 // fakeChainInfo creates a chain info object for use in tests.
 func fakeChainInfo() *chain.Info {
-	sch := scheme.GetSchemeFromEnv()
 	return &chain.Info{
-		Scheme:      sch,
 		Period:      time.Second,
 		GenesisTime: time.Now().Unix(),
 		PublicKey:   test.GenerateIDs(1)[0].Public.Key,

--- a/client/verify_test.go
+++ b/client/verify_test.go
@@ -14,7 +14,7 @@ func mockClientWithVerifiableResults(n int) (client.Client, []mock.Result, error
 	sch := scheme.GetSchemeFromEnv()
 
 	info, results := mock.VerifiableResults(n, sch)
-	mc := client.MockClient{Results: results, StrictRounds: true, OptionalInfo: info}
+	mc := client.MockClient{Results: results, StrictRounds: true}
 
 	var c client.Client
 	var err error
@@ -24,6 +24,7 @@ func mockClientWithVerifiableResults(n int) (client.Client, []mock.Result, error
 		client.WithChainInfo(info),
 		client.WithVerifiedResult(&results[0]),
 		client.WithFullChainVerification(),
+		client.WithSchemeID(sch.ID),
 	)
 
 	if err != nil {

--- a/cmd/client/lib/cli.go
+++ b/cmd/client/lib/cli.go
@@ -12,6 +12,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/drand/drand/common/scheme"
+
 	"github.com/BurntSushi/toml"
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/client"
@@ -79,6 +81,13 @@ var (
 		Usage: "Local (host:)port for constructed libp2p host to listen on",
 	}
 
+	// TypeFlag indicates a set of values drand will use to configure the randomness generation process
+	SchemeFlag = &cli.StringFlag{
+		Name:  "scheme",
+		Usage: "Indicates a set of values drand will use to configure the randomness generation process",
+		Value: scheme.DefaultSchemeID,
+	}
+
 	// JsonFlag is the CLI flag for enabling JSON output for logger
 	JSONFlag = &cli.BoolFlag{
 		Name:  "json",
@@ -97,6 +106,7 @@ var ClientFlags = []cli.Flag{
 	RelayFlag,
 	PortFlag,
 	JSONFlag,
+	SchemeFlag,
 }
 
 // Create builds a client, and can be invoked from a cli action supplied
@@ -142,6 +152,13 @@ func Create(c *cli.Context, withInstrumentation bool, opts ...client.Option) (cl
 	if c.Bool(InsecureFlag.Name) {
 		opts = append(opts, client.Insecurely())
 	}
+
+	schemeFound, err := scheme.GetSchemeByIDWithDefault(c.String(SchemeFlag.Name))
+	if err != nil {
+		return nil, fmt.Errorf("scheme %s given is invalid", c.String(SchemeFlag.Name))
+	}
+
+	opts = append(opts, client.WithSchemeID(schemeFound.ID))
 
 	clients = append(clients, buildHTTPClients(c, &info, hash, withInstrumentation)...)
 

--- a/cmd/client/lib/cli_test.go
+++ b/cmd/client/lib/cli_test.go
@@ -59,7 +59,7 @@ func TestClientLib(t *testing.T) {
 	go grpcLis.Start()
 	defer grpcLis.Stop(context.Background())
 
-	args := []string{"mock-client", "--url", "http://" + addr, "--grpc-connect", grpcLis.Addr(), "--insecure"}
+	args := []string{"mock-client", "--url", "http://" + addr, "--grpc-connect", grpcLis.Addr(), "--insecure", "--scheme", sch.ID}
 
 	fmt.Printf("%+v", args)
 	err = run(args)
@@ -67,28 +67,28 @@ func TestClientLib(t *testing.T) {
 		t.Fatal("GRPC should work", err)
 	}
 
-	args = []string{"mock-client", "--url", "https://" + addr}
+	args = []string{"mock-client", "--url", "https://" + addr, "--scheme", sch.ID}
 
 	err = run(args)
 	if err == nil {
 		t.Fatal("http needs insecure or hash", err)
 	}
 
-	args = []string{"mock-client", "--url", "http://" + addr, "--hash", hex.EncodeToString(info.Hash())}
+	args = []string{"mock-client", "--url", "http://" + addr, "--hash", hex.EncodeToString(info.Hash()), "--scheme", sch.ID}
 
 	err = run(args)
 	if err != nil {
 		t.Fatal("http should construct", err)
 	}
 
-	args = []string{"mock-client", "--relay", fakeGossipRelayAddr}
+	args = []string{"mock-client", "--relay", fakeGossipRelayAddr, "--scheme", sch.ID}
 
 	err = run(args)
 	if err == nil {
 		t.Fatal("relays need URL or hash", err)
 	}
 
-	args = []string{"mock-client", "--relay", fakeGossipRelayAddr, "--hash", hex.EncodeToString(info.Hash())}
+	args = []string{"mock-client", "--relay", fakeGossipRelayAddr, "--hash", hex.EncodeToString(info.Hash()), "--scheme", sch.ID}
 
 	err = run(args)
 	if err != nil {


### PR DESCRIPTION
Attempt to revert Previous commit to see if it is responsible for autodeploy errors in gossip client.

Reverts drand/drand#836