### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/chain/beacon/callbacks_test.go
+++ b/chain/beacon/callbacks_test.go
@@ -1,7 +1,6 @@
 package beacon
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestStoreCallback(t *testing.T) {
-	dir, err := ioutil.TempDir("", "*")
+	dir, err := os.MkdirTemp("", "*")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	bbstore, err := boltdb.NewBoltStore(dir, nil)

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"sync"
@@ -136,7 +135,7 @@ type BeaconTest struct {
 }
 
 func NewBeaconTest(t *testing.T, n, thr int, period time.Duration, genesisTime int64, sch scheme.Scheme, beaconID string) *BeaconTest {
-	prefix, err := ioutil.TempDir(os.TempDir(), "beacon-test")
+	prefix, err := os.MkdirTemp(os.TempDir(), "beacon-test")
 	checkErr(err)
 	paths := createBoltStores(prefix, n)
 	shares, commits := dkgShares(t, n, thr)

--- a/chain/boltdb/store_test.go
+++ b/chain/boltdb/store_test.go
@@ -1,7 +1,6 @@
 package boltdb
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestStoreBoltOrder(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "drandtest*")
+	tmp, err := os.MkdirTemp("", "drandtest*")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmp)
 	store, err := NewBoltStore(tmp, nil)
@@ -49,7 +48,7 @@ func TestStoreBoltOrder(t *testing.T) {
 }
 
 func TestStoreBolt(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "bolttest*")
+	tmp, err := os.MkdirTemp("", "bolttest*")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmp)
 

--- a/cmd/client/lib/cli.go
+++ b/cmd/client/lib/cli.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"net"
 	nhttp "net/http"
 	"os"
@@ -309,7 +308,7 @@ func chainInfoFromGroupTOML(filePath string) (*chain.Info, error) {
 }
 
 func chainInfoFromChainInfoJSON(filePath string) (*chain.Info, error) {
-	b, err := ioutil.ReadFile(filePath)
+	b, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/client/lib/cli_test.go
+++ b/cmd/client/lib/cli_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -112,14 +111,14 @@ func TestClientLibGroupConfJSON(t *testing.T) {
 	var b bytes.Buffer
 	info.ToJSON(&b, nil)
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "drand")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "drand")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	infoPath := filepath.Join(tmpDir, "info.json")
 
-	err = ioutil.WriteFile(infoPath, b.Bytes(), 0644)
+	err = os.WriteFile(infoPath, b.Bytes(), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	gnet "net"
 	"os"
 	"path"
@@ -169,7 +168,7 @@ func TestStartAndStop(t *testing.T) {
 }
 
 func TestUtilCheck(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "drand-cli-*")
+	tmp, err := os.MkdirTemp("", "drand-cli-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmp)
 	// try to generate a keypair and make it listen on another address

--- a/cmd/drand-cli/control.go
+++ b/cmd/drand-cli/control.go
@@ -3,7 +3,6 @@ package drand
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -37,7 +36,7 @@ type shareArgs struct {
 func (s *shareArgs) loadSecret(c *cli.Context) error {
 	secret := os.Getenv("DRAND_SHARE_SECRET")
 	if c.IsSet(secretFlag.Name) {
-		bytes, err := ioutil.ReadFile(c.String(secretFlag.Name))
+		bytes, err := os.ReadFile(c.String(secretFlag.Name))
 		if err != nil {
 			return err
 		}

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	gnet "net"
 	"os"
 	"path"
@@ -101,7 +100,7 @@ func BatchNewDrand(t *testing.T, n int, insecure bool, sch scheme.Scheme, beacon
 	drands = make([]*Drand, n)
 	tmp := os.TempDir()
 
-	dir, err := ioutil.TempDir(tmp, "drand")
+	dir, err := os.MkdirTemp(tmp, "drand")
 	assert.NoError(t, err)
 
 	certPaths = make([]string, n)

--- a/demo/lib/orchestrator.go
+++ b/demo/lib/orchestrator.go
@@ -3,7 +3,6 @@ package lib
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -300,7 +299,7 @@ func (e *Orchestrator) checkBeaconNodes(nodes []node.Node, group string, tryCurl
 		args := []string{"-k", "-s"}
 		http := "http"
 		if e.tls {
-			tmp, _ := ioutil.TempFile("", "cert")
+			tmp, _ := os.CreateTemp("", "cert")
 			defer os.Remove(tmp.Name())
 			tmp.Close()
 			n.WriteCertificate(tmp.Name())

--- a/demo/node/node_inprocess.go
+++ b/demo/node/node_inprocess.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -282,7 +281,7 @@ func (l *LocalNode) Stop() {
 
 func (l *LocalNode) PrintLog() {
 	fmt.Printf("[-] Printing logs of node %s:\n", l.PrivateAddr())
-	buff, err := ioutil.ReadFile(l.logPath)
+	buff, err := os.ReadFile(l.logPath)
 	if err != nil {
 		fmt.Printf("[-] Can't read logs !\n\n")
 		return

--- a/demo/node/node_subprocess.go
+++ b/demo/node/node_subprocess.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -126,7 +125,7 @@ func (n *NodeProc) setup() {
 
 func (n *NodeProc) Start(certFolder string) error {
 	// create log file
-	//logFile, err := os.Create(n.logPath)
+	// logFile, err := os.Create(n.logPath)
 	flags := os.O_RDWR | os.O_APPEND | os.O_CREATE
 	logFile, err := os.OpenFile(n.logPath, flags, 0777)
 	logFile.Write([]byte("\n\nNEW LOG\n\n"))
@@ -276,7 +275,7 @@ func (n *NodeProc) Ping() bool {
 	out, err := cmd.CombinedOutput()
 	fmt.Printf(" -- ping output : %s - err %s\n", out, err)
 	if err != nil {
-		//fmt.Printf("\t- node %s: ping: %v - \n\tout: %s\n", n.privAddr, err, string(out))
+		// fmt.Printf("\t- node %s: ping: %v - \n\tout: %s\n", n.privAddr, err, string(out))
 		return false
 	}
 	return true
@@ -333,7 +332,7 @@ func (n *NodeProc) Stop() {
 
 func (n *NodeProc) PrintLog() {
 	fmt.Printf("[-] Printing logs of node %s:\n", n.privAddr)
-	buff, err := ioutil.ReadFile(n.logPath)
+	buff, err := os.ReadFile(n.logPath)
 	if err != nil {
 		fmt.Printf("[-] Can't read logs !\n\n")
 		return

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -3,7 +3,6 @@ package fs
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
 	"path"
@@ -74,7 +73,7 @@ func CreateSecureFile(file string) (*os.File, error) {
 // Files returns the list of file names included in the given path or error if
 // any.
 func Files(folderPath string) ([]string, error) {
-	fi, err := ioutil.ReadDir(folderPath)
+	fi, err := os.ReadDir(folderPath)
 	if err != nil {
 		return nil, err
 	}

--- a/key/group_test.go
+++ b/key/group_test.go
@@ -1,7 +1,6 @@
 package key
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -10,7 +9,7 @@ import (
 
 	"github.com/drand/drand/common/scheme"
 	"github.com/drand/drand/protobuf/drand"
-	kyber "github.com/drand/kyber"
+	"github.com/drand/kyber"
 	"github.com/drand/kyber/util/random"
 	"github.com/stretchr/testify/require"
 )
@@ -134,7 +133,7 @@ func TestGroupSaveLoad(t *testing.T) {
 	require.NotNil(t, gtoml.PublicKey)
 
 	// faking distributed public key coefficients
-	groupFile, err := ioutil.TempFile("", "group.toml")
+	groupFile, err := os.CreateTemp("", "group.toml")
 	require.NoError(t, err)
 	groupPath := groupFile.Name()
 	groupFile.Close()

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"testing"
 
 	"go.uber.org/zap/zapcore"
@@ -79,7 +78,7 @@ func TestLoggerKit(t *testing.T) {
 }
 
 func requireContains(t *testing.T, r io.Reader, outs []string, present bool) {
-	out, err := ioutil.ReadAll(r)
+	out, err := io.ReadAll(r)
 	require.NoError(t, err)
 	if !present {
 		require.Equal(t, string(out), "")

--- a/lp2p/client/client_test.go
+++ b/lp2p/client/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -37,11 +36,11 @@ func TestGRPCClientTestFunc(t *testing.T) {
 	go grpcLis.Start()
 	defer grpcLis.Stop(context.Background())
 
-	dataDir, err := ioutil.TempDir(os.TempDir(), "test-gossip-relay-node-datastore")
+	dataDir, err := os.MkdirTemp(os.TempDir(), "test-gossip-relay-node-datastore")
 	if err != nil {
 		t.Fatal(err)
 	}
-	identityDir, err := ioutil.TempDir(os.TempDir(), "test-gossip-relay-node-id")
+	identityDir, err := os.MkdirTemp(os.TempDir(), "test-gossip-relay-node-id")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,11 +122,11 @@ func HTTPClientTestFunc(t *testing.T) {
 	addr, chainInfo, stop, emit := httpmock.NewMockHTTPPublicServer(t, false, sch)
 	defer stop()
 
-	dataDir, err := ioutil.TempDir(os.TempDir(), "test-gossip-relay-node-datastore")
+	dataDir, err := os.MkdirTemp(os.TempDir(), "test-gossip-relay-node-datastore")
 	if err != nil {
 		t.Fatal(err)
 	}
-	identityDir, err := ioutil.TempDir(os.TempDir(), "test-gossip-relay-node-id")
+	identityDir, err := os.MkdirTemp(os.TempDir(), "test-gossip-relay-node-id")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,11 +179,11 @@ func HTTPClientTestFunc(t *testing.T) {
 }
 
 func newTestClient(name string, relayMultiaddr []ma.Multiaddr, info *chain.Info) (*Client, error) {
-	dataDir, err := ioutil.TempDir(os.TempDir(), "client-"+name+"-datastore")
+	dataDir, err := os.MkdirTemp(os.TempDir(), "client-"+name+"-datastore")
 	if err != nil {
 		return nil, err
 	}
-	identityDir, err := ioutil.TempDir(os.TempDir(), "client-"+name+"-id")
+	identityDir, err := os.MkdirTemp(os.TempDir(), "client-"+name+"-id")
 	if err != nil {
 		return nil, err
 	}

--- a/lp2p/ctor.go
+++ b/lp2p/ctor.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	mrand "math/rand"
 	"os"
 	"path"
@@ -27,7 +26,7 @@ import (
 	libp2ptls "github.com/libp2p/go-libp2p-tls"
 	ma "github.com/multiformats/go-multiaddr"
 	"golang.org/x/crypto/blake2b"
-	xerrors "golang.org/x/xerrors"
+	"golang.org/x/xerrors"
 )
 
 const (
@@ -128,7 +127,7 @@ func ConstructHost(ds datastore.Datastore, priv crypto.PrivKey, listenAddr strin
 
 // LoadOrCreatePrivKey loads a base64 encoded libp2p private key from a file or creates one if it does not exist.
 func LoadOrCreatePrivKey(identityPath string, log dlog.Logger) (crypto.PrivKey, error) {
-	privB64, err := ioutil.ReadFile(identityPath)
+	privB64, err := os.ReadFile(identityPath)
 
 	var priv crypto.PrivKey
 	switch {
@@ -156,7 +155,7 @@ func LoadOrCreatePrivKey(identityPath string, log dlog.Logger) (crypto.PrivKey, 
 		if err != nil {
 			return nil, xerrors.Errorf("creating identity directory and parents: %w", err)
 		}
-		err = ioutil.WriteFile(identityPath, []byte(base64.RawStdEncoding.EncodeToString(b)), identityFilePerm)
+		err = os.WriteFile(identityPath, []byte(base64.RawStdEncoding.EncodeToString(b)), identityFilePerm)
 		if err != nil {
 			return nil, xerrors.Errorf("writing identity file: %w", err)
 		}

--- a/lp2p/ctor_test.go
+++ b/lp2p/ctor_test.go
@@ -2,7 +2,6 @@ package lp2p
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -11,7 +10,7 @@ import (
 )
 
 func TestCreateThenLoadPrivKey(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "test")
+	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +35,7 @@ func TestCreateThenLoadPrivKey(t *testing.T) {
 }
 
 func TestCreatePrivKeyMkdirp(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "test")
+	dir, err := os.MkdirTemp(os.TempDir(), "test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lp2p/relaynode_test.go
+++ b/lp2p/relaynode_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path"
 	"sync"
@@ -62,7 +61,7 @@ func toRandomDataChain(results ...mock.Result) []client.RandomData {
 
 func tmpDir(t *testing.T) string {
 	t.Helper()
-	dir, err := ioutil.TempDir(os.TempDir(), "test-gossip-relay-node-datastore")
+	dir, err := os.MkdirTemp(os.TempDir(), "test-gossip-relay-node-datastore")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/net/certs.go
+++ b/net/certs.go
@@ -3,7 +3,7 @@ package net
 import (
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/drand/drand/log"
 )
@@ -33,7 +33,7 @@ func (p *CertManager) Pool() *x509.CertPool {
 // Add tries to add the certificate at the given path to the pool and returns an
 // error otherwise
 func (p *CertManager) Add(certPath string) error {
-	b, err := ioutil.ReadFile(certPath)
+	b, err := os.ReadFile(certPath)
 	if err != nil {
 		return err
 	}

--- a/net/control_test.go
+++ b/net/control_test.go
@@ -1,7 +1,6 @@
 package net
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -29,7 +28,7 @@ func TestControlUnix(t *testing.T) {
 		t.Skip("Platform does not support unix.")
 	}
 
-	name, err := ioutil.TempDir("", "unixtxt")
+	name, err := os.MkdirTemp("", "unixtxt")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). Since drand has been upgraded to Go 1.17 in #813, this PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.