### PR TITLE
Collapse `util/` and `common/` packages together.

### DIFF
--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -10,10 +10,10 @@ import (
 	"time"
 
 	"github.com/drand/drand/chain"
+	commonutils "github.com/drand/drand/common"
 	"github.com/drand/drand/log"
 	"github.com/drand/drand/protobuf/common"
 	proto "github.com/drand/drand/protobuf/drand"
-	"github.com/drand/drand/utils"
 	clock "github.com/jonboulle/clockwork"
 
 	"github.com/drand/drand/key"
@@ -54,12 +54,12 @@ type Handler struct {
 	serving bool
 	stopped bool
 	l       log.Logger
-	version utils.Version
+	version commonutils.Version
 }
 
 // NewHandler returns a fresh handler ready to serve and create randomness
 // beacon
-func NewHandler(c net.ProtocolClient, s chain.Store, conf *Config, l log.Logger, version utils.Version) (*Handler, error) {
+func NewHandler(c net.ProtocolClient, s chain.Store, conf *Config, l log.Logger, version commonutils.Version) (*Handler, error) {
 	if conf.Share == nil || conf.Group == nil {
 		return nil, errors.New("beacon: invalid configuration")
 	}

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/drand/drand/protobuf/drand"
 	"github.com/drand/drand/test"
 	testnet "github.com/drand/drand/test/net"
-	"github.com/drand/drand/utils"
 	"github.com/drand/kyber"
 	"github.com/drand/kyber/share"
 	"github.com/drand/kyber/util/random"
@@ -204,7 +203,7 @@ func (b *BeaconTest) CreateNode(t *testing.T, i int) {
 	}
 
 	logger := log.NewLogger(nil, log.LogDebug)
-	version := utils.Version{Major: 0, Minor: 0, Patch: 0}
+	version := common.Version{Major: 0, Minor: 0, Patch: 0}
 	node.handler, err = NewHandler(net.NewGrpcClient(), store, conf, logger, version)
 	checkErr(err)
 	if node.callback != nil {

--- a/chain/beacon/sync.go
+++ b/chain/beacon/sync.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/drand/drand/utils"
+	commonutils "github.com/drand/drand/common"
 
 	"github.com/drand/drand/protobuf/common"
 
@@ -100,7 +100,7 @@ func (s *syncer) tryNode(global context.Context, upTo uint64, n net.Peer) bool {
 	}
 
 	beaconID := s.info.ID
-	metadata := common.NewMetadata(utils.Version{Major: 0, Minor: 0, Patch: 0}.ToProto()) // FIXME We should set node version here
+	metadata := common.NewMetadata(commonutils.Version{Major: 0, Minor: 0, Patch: 0}.ToProto()) // FIXME We should set node version here
 	metadata.BeaconID = beaconID
 
 	beaconCh, err := s.client.SyncChain(cnode, n, &proto.SyncRequest{

--- a/common/constants.go
+++ b/common/constants.go
@@ -3,8 +3,6 @@ package common
 import (
 	"strconv"
 	"sync"
-
-	"github.com/drand/drand/utils"
 )
 
 const (
@@ -13,14 +11,14 @@ const (
 )
 
 var LoadProcess sync.Once
-var version utils.Version
+var version Version
 var (
 	MAJOR = "0"
 	MINOR = "0"
 	PATCH = "0"
 )
 
-func GetAppVersion() utils.Version {
+func GetAppVersion() Version {
 	LoadProcess.Do(parseAppVersion)
 	return version
 }
@@ -28,18 +26,18 @@ func GetAppVersion() utils.Version {
 func parseAppVersion() {
 	major, err := strconv.ParseInt(MAJOR, VersionBase, VersionSize)
 	if err != nil {
-		version = utils.Version{Major: 0, Minor: 0, Patch: 0}
+		version = Version{Major: 0, Minor: 0, Patch: 0}
 	}
 
 	minor, err := strconv.ParseInt(MINOR, VersionBase, VersionSize)
 	if err != nil {
-		version = utils.Version{Major: 0, Minor: 0, Patch: 0}
+		version = Version{Major: 0, Minor: 0, Patch: 0}
 	}
 
 	patch, err := strconv.ParseInt(PATCH, VersionBase, VersionSize)
 	if err != nil {
-		version = utils.Version{Major: 0, Minor: 0, Patch: 0}
+		version = Version{Major: 0, Minor: 0, Patch: 0}
 	}
 
-	version = utils.Version{Major: uint32(major), Minor: uint32(minor), Patch: uint32(patch)}
+	version = Version{Major: uint32(major), Minor: uint32(minor), Patch: uint32(patch)}
 }

--- a/common/version.go
+++ b/common/version.go
@@ -1,9 +1,9 @@
-package utils
+package common
 
 import (
 	"fmt"
 
-	"github.com/drand/drand/protobuf/common"
+	pbcommon "github.com/drand/drand/protobuf/common"
 )
 
 const (
@@ -29,8 +29,8 @@ func (v Version) IsCompatible(verRcv Version) bool {
 	return false
 }
 
-func (v Version) ToProto() *common.NodeVersion {
-	return &common.NodeVersion{Minor: v.Minor, Major: v.Major, Patch: v.Patch}
+func (v Version) ToProto() *pbcommon.NodeVersion {
+	return &pbcommon.NodeVersion{Minor: v.Minor, Major: v.Major, Patch: v.Patch}
 }
 
 func (v Version) String() string {

--- a/core/broadcast.go
+++ b/core/broadcast.go
@@ -8,12 +8,12 @@ import (
 	"math/rand"
 	"sync"
 
+	commonutils "github.com/drand/drand/common"
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/log"
 	"github.com/drand/drand/net"
 	"github.com/drand/drand/protobuf/common"
 	"github.com/drand/drand/protobuf/drand"
-	"github.com/drand/drand/utils"
 	"github.com/drand/kyber/share/dkg"
 )
 
@@ -49,7 +49,7 @@ type Broadcast interface {
 type echoBroadcast struct {
 	sync.Mutex
 	l        log.Logger
-	version  utils.Version
+	version  commonutils.Version
 	beaconID string
 	// responsible for sending out the messages
 	dispatcher *dispatcher
@@ -69,7 +69,7 @@ var _ Broadcast = (*echoBroadcast)(nil)
 // Packet, namely that the signature is correct.
 type verifier func(packet) error
 
-func newEchoBroadcast(l log.Logger, version utils.Version, beaconID string,
+func newEchoBroadcast(l log.Logger, version commonutils.Version, beaconID string,
 	c net.ProtocolClient, own string, to []*key.Node, v verifier) *echoBroadcast {
 	return &echoBroadcast{
 		l:          l,

--- a/core/broadcast_test.go
+++ b/core/broadcast_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/drand/drand/common/scheme"
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/protobuf/drand"
-	"github.com/drand/drand/utils"
 	"github.com/drand/kyber"
 	"github.com/drand/kyber/share/dkg"
 	"github.com/drand/kyber/util/random"
@@ -82,7 +81,7 @@ func TestBroadcast(t *testing.T) {
 	ids := make([]string, 0, n)
 	for _, d := range drands {
 		id := d.priv.Public.Address()
-		version := utils.Version{Major: 0, Minor: 0, Patch: 0}
+		version := common.Version{Major: 0, Minor: 0, Patch: 0}
 		b := newEchoBroadcast(d.log, version, beaconID, d.privGateway.ProtocolClient,
 			id, group.Nodes, func(dkg.Packet) error { return nil })
 

--- a/core/drand.go
+++ b/core/drand.go
@@ -17,7 +17,6 @@ import (
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/log"
 	"github.com/drand/drand/net"
-	"github.com/drand/drand/utils"
 	"github.com/drand/kyber/share/dkg"
 )
 
@@ -66,7 +65,7 @@ type Drand struct {
 	setupCB func(*key.Group)
 
 	// version indicates the base code variant
-	version utils.Version
+	version common.Version
 }
 
 // NewDrand returns a drand struct. It assumes the private key pair

--- a/core/drand_control.go
+++ b/core/drand_control.go
@@ -13,12 +13,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/drand/drand/utils"
-
-	"github.com/drand/drand/common/scheme"
-
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/chain/beacon"
+	commonutils "github.com/drand/drand/common"
+	"github.com/drand/drand/common/scheme"
 	"github.com/drand/drand/entropy"
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/log"
@@ -1026,7 +1024,7 @@ func (d *Drand) StartFollowChain(req *drand.StartFollowRequest, stream drand.Con
 
 // chainInfoFromPeers attempts to fetch chain info from one of the passed peers.
 func chainInfoFromPeers(ctx context.Context, privGateway *net.PrivateGateway,
-	peers []net.Peer, l log.Logger, version utils.Version, beaconID string) (*chain.Info, error) {
+	peers []net.Peer, l log.Logger, version commonutils.Version, beaconID string) (*chain.Info, error) {
 	request := new(drand.ChainInfoRequest)
 	request.Metadata = &common.Metadata{BeaconID: beaconID, NodeVersion: version.ToProto()}
 

--- a/core/drand_interceptors.go
+++ b/core/drand_interceptors.go
@@ -3,8 +3,8 @@ package core
 import (
 	"context"
 
+	commonutils "github.com/drand/drand/common"
 	"github.com/drand/drand/protobuf/common"
-	"github.com/drand/drand/utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -32,7 +32,7 @@ func (d *Drand) NodeVersionValidator(ctx context.Context, req interface{},
 		return handler(ctx, req)
 	}
 
-	rcvVer := utils.Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch}
+	rcvVer := commonutils.Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch}
 	if !d.version.IsCompatible(rcvVer) {
 		d.log.Warnw("", "node_version_interceptor", "node version rcv is no compatible --> rejecting message", "version", rcvVer)
 		return nil, status.Error(codes.PermissionDenied, "Node Version not valid")
@@ -59,7 +59,7 @@ func (d *Drand) NodeVersionStreamValidator(srv interface{}, ss grpc.ServerStream
 		return handler(srv, ss)
 	}
 
-	rcvVer := utils.Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch}
+	rcvVer := commonutils.Version{Major: v.Major, Minor: v.Minor, Patch: v.Patch}
 	if !d.version.IsCompatible(rcvVer) {
 		d.log.Warnw("", "node_version_interceptor", "node version rcv is no compatible --> rejecting message", "version", rcvVer)
 		return status.Error(codes.PermissionDenied, "Node Version not valid")

--- a/core/group_setup.go
+++ b/core/group_setup.go
@@ -13,12 +13,12 @@ import (
 	common2 "github.com/drand/drand/common/scheme"
 
 	"github.com/drand/drand/chain"
+	commonutils "github.com/drand/drand/common"
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/log"
 	"github.com/drand/drand/net"
 	"github.com/drand/drand/protobuf/common"
 	"github.com/drand/drand/protobuf/drand"
-	"github.com/drand/drand/utils"
 	clock "github.com/jonboulle/clockwork"
 )
 
@@ -299,10 +299,10 @@ type setupReceiver struct {
 	leaderID *key.Identity
 	secret   []byte
 	done     bool
-	version  utils.Version
+	version  commonutils.Version
 }
 
-func newSetupReceiver(version utils.Version, l log.Logger, c clock.Clock,
+func newSetupReceiver(version commonutils.Version, l log.Logger, c clock.Clock,
 	client net.ProtocolClient, in *drand.SetupInfoPacket) (*setupReceiver, error) {
 	setup := &setupReceiver{
 		ch:      make(chan *dkgGroup, 1),

--- a/key/group.go
+++ b/key/group.go
@@ -12,18 +12,15 @@ import (
 	"sort"
 	"time"
 
-	"github.com/drand/drand/utils"
-
-	"github.com/drand/drand/protobuf/common"
-
+	commonutils "github.com/drand/drand/common"
 	"github.com/drand/drand/common/scheme"
+	"github.com/drand/drand/protobuf/common"
+	proto "github.com/drand/drand/protobuf/drand"
 
 	"github.com/BurntSushi/toml"
 	kyber "github.com/drand/kyber"
 	dkg "github.com/drand/kyber/share/dkg"
 	"golang.org/x/crypto/blake2b"
-
-	proto "github.com/drand/drand/protobuf/drand"
 )
 
 // XXX new256 returns an error so we make a wrapper around
@@ -430,7 +427,7 @@ func GroupFromProto(g *proto.GroupPacket) (*Group, error) {
 }
 
 // ToProto encodes a local group object into its wire format
-func (g *Group) ToProto(version utils.Version) *proto.GroupPacket {
+func (g *Group) ToProto(version commonutils.Version) *proto.GroupPacket {
 	var out = new(proto.GroupPacket)
 	var ids = make([]*proto.Node, len(g.Nodes))
 

--- a/key/group_test.go
+++ b/key/group_test.go
@@ -5,8 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/drand/drand/utils"
-
+	"github.com/drand/drand/common"
 	"github.com/drand/drand/common/scheme"
 	"github.com/drand/drand/protobuf/drand"
 	"github.com/drand/kyber"
@@ -76,7 +75,7 @@ func TestGroupProtobuf(t *testing.T) {
 		isErr:  false,
 	})
 
-	version := utils.Version{Major: 0, Minor: 0, Patch: 0}
+	version := common.Version{Major: 0, Minor: 0, Patch: 0}
 	for i, tv := range vectors {
 		protoGroup := tv.group.ToProto(version)
 		if tv.change != nil {
@@ -174,7 +173,7 @@ func TestConvertGroup(t *testing.T) {
 	group.Period = 5 * time.Second
 	group.TransitionTime = time.Now().Unix()
 	group.GenesisTime = time.Now().Unix()
-	version := utils.Version{Major: 0, Minor: 0, Patch: 0}
+	version := common.Version{Major: 0, Minor: 0, Patch: 0}
 
 	proto := group.ToProto(version)
 	received, err := GroupFromProto(proto)

--- a/net/control.go
+++ b/net/control.go
@@ -11,7 +11,6 @@ import (
 	"github.com/drand/drand/log"
 	protoCommon "github.com/drand/drand/protobuf/common"
 	control "github.com/drand/drand/protobuf/drand"
-	"github.com/drand/drand/utils"
 
 	"google.golang.org/grpc"
 )
@@ -53,7 +52,7 @@ func (g *ControlListener) Stop() {
 type ControlClient struct {
 	conn    *grpc.ClientConn
 	client  control.ControlClient
-	version utils.Version
+	version common.Version
 }
 
 // NewControlClient creates a client capable of issuing control commands to a


### PR DESCRIPTION
The functions for the new `Version` struct were split between two packages, though were logically used together. Neither package had a clear focus and having both will make it unclear where to put future code.