### PR TITLE
Heartbeat logic to switch to catchup mode

### DIFF
--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -333,7 +333,8 @@ func (h *Handler) run(startTime int64) {
 				// now we look if WE are late or the NETWORK is late
 				if highestSeenRound > lastBeacon.Round {
 					catchupMode = false
-					// WE are latethen run sync
+					// WE are latethen run sync. Once we are caught up with
+					// others, then we'll switch to catchup mode eventually.
 					go h.chain.RunSync(context.Background(), current.round, nil)
 				} else {
 					// the network is late, then we run catchup mode

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -87,7 +87,8 @@ func NewHandler(c net.PrivateGateway, s chain.Store, conf *Config, l log.Logger,
 		Clock:  conf.Clock,
 		Client: c,
 		// TODO
-		Frequency: time.Duration(1 * time.Second),
+		Frequency:  time.Duration(1 * time.Second),
+		Aggregator: syncChain.NewMaxAggregator(),
 	})
 
 	handler := &Handler{
@@ -311,10 +312,8 @@ func (h *Handler) run(startTime int64) {
 	var catchupMode bool
 	for {
 		select {
-		case beat := <-h.beats.Beats():
-			if beat.LastRound > highestSeenRound {
-				highestSeenRound = beat.LastRound
-			}
+		case r := <-h.beats.Beats():
+			highestSeenRound = r.(uint64)
 		case current = <-chanTick:
 			setRunning.Do(func() {
 				h.Lock()

--- a/chain/sync/heartbeat.go
+++ b/chain/sync/heartbeat.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -23,19 +24,32 @@ type HeartbeatConfig struct {
 	Client net.PublicClient
 	// Frequency at which the heartbeat should contact other nodes
 	Frequency time.Duration
+	// Aggregator to collect and aggregate beats -
+	Aggregator BeatAggregator
+}
+
+// Aggregator is used to collect all individual beats during each period and
+// will output the aggregated one at each tick.
+// All methods are called synchronously.
+type BeatAggregator interface {
+	// PushBeat is called when a new beat is received from the heartbeat logic.
+	PushBeat(BeatInfo)
+	// AggregatedBeats returns a struct that contains an certain aggregation of
+	// all beats received - all the previous beats should probably be erased.
+	AggregatedBeats() interface{}
 }
 
 // BeatInfo contains information relayed by the heartbeat logic. The peer who
 // replied and the last beacon that he has.
 type BeatInfo struct {
-	Peer      *key.Identity
-	LastRound uint64
+	Peer  *key.Identity
+	Round uint64
 }
 
 // Heartbeat contacts other nodes in the network and relay their latest beacon
 type Heartbeat interface {
 	UpdateGroup([]*key.Identity)
-	Beats() chan BeatInfo
+	Beats() chan interface{}
 	Stop()
 }
 
@@ -44,7 +58,17 @@ type heartbeat struct {
 	stop     chan bool
 	newGroup chan []*key.Identity
 	beats    chan BeatInfo
+	aggBeats chan interface{}
+	newFetch chan fetchInfo
 }
+
+// TODO: ?
+const workers = 4
+const maxQueueLength = 100
+
+// MaxHeartbeatTime sets how long we'll wait after a new connection to receive
+// new beacons from one peer
+var MaxSyncWaitTime = 2 * time.Second
 
 func NewHeartbeat(c *HeartbeatConfig) Heartbeat {
 	h := &heartbeat{
@@ -52,9 +76,14 @@ func NewHeartbeat(c *HeartbeatConfig) Heartbeat {
 		stop:     make(chan bool, 1),
 		newGroup: make(chan []*key.Identity, 1),
 		// TODO: It might work for now but wont for bigger size
-		beats: make(chan BeatInfo, 100),
+		beats:    make(chan BeatInfo, 1),
+		aggBeats: make(chan interface{}, 1),
+		newFetch: make(chan fetchInfo, maxQueueLength),
 	}
 	go h.run()
+	for i := 0; i < workers; i++ {
+		go h.worker()
+	}
 	return h
 }
 
@@ -62,8 +91,8 @@ func (h *heartbeat) Stop() {
 	close(h.stop)
 }
 
-func (h *heartbeat) Beats() chan BeatInfo {
-	return h.beats
+func (h *heartbeat) Beats() chan interface{} {
+	return h.aggBeats
 }
 
 func (h *heartbeat) UpdateGroup(g []*key.Identity) {
@@ -72,6 +101,7 @@ func (h *heartbeat) UpdateGroup(g []*key.Identity) {
 
 func (h *heartbeat) run() {
 	var currentGroup []*key.Identity
+	var agg = h.c.Aggregator
 	ctx, cancel := context.WithCancel(context.Background())
 	for {
 		select {
@@ -83,11 +113,23 @@ func (h *heartbeat) run() {
 			currentGroup = ng
 			cancel() // we cancel current sync operations
 			ctx, cancel = context.WithCancel(context.Background())
-			go h.fetch(ctx, currentGroup)
+		case beat := <-h.beats:
+			agg.PushBeat(beat)
 		case <-h.c.Clock.After(h.c.Frequency):
 			if currentGroup == nil {
 				h.c.Log.Debugw("heartbeat", "empty group - skipping beat()")
 				continue
+			}
+			aggBeat := agg.AggregatedBeats()
+			select {
+			case h.aggBeats <- aggBeat:
+				h.c.Log.Debugw("heartbeat", fmt.Sprintf("tick aggregated beat %v", aggBeat))
+			default:
+				h.c.Log.Debugw("heartbeat", "aggregated heartbeat full")
+			}
+			// launh a new fetch
+			for i := range rand.Perm(len(currentGroup)) {
+				h.newFetch <- fetchInfo{ctx: ctx, id: currentGroup[i]}
 			}
 		case <-h.stop:
 			h.c.Log.Debugw("heartbeat", "stops")
@@ -95,27 +137,56 @@ func (h *heartbeat) run() {
 	}
 }
 
-func (h *heartbeat) fetch(ctx context.Context, group []*key.Identity) {
-	for i := range rand.Perm(len(group)) {
-		// TODO what happens when stream breaks - does it try again?
-		stream, err := h.c.Client.PublicRandStream(ctx, group[i], &drand.PublicRandRequest{})
-		if err != nil {
-			h.c.Log.Error("heartbeat", "can not contact node", err)
-			continue
-		}
-		go func(id *key.Identity, ch chan *drand.PublicRandResponse) {
-			for rand := range ch {
-				beat := BeatInfo{
-					Peer:      id,
-					LastRound: rand.GetRound(),
-				}
-				select {
-				case h.beats <- beat:
-					continue
-				default:
-					h.c.Log.Debugw("heartbeat", "beat channel full")
-				}
-			}
-		}(group[i], stream)
+type fetchInfo struct {
+	ctx context.Context
+	id  *key.Identity
+}
+
+func (h *heartbeat) worker() {
+	select {
+	case fi := <-h.newFetch:
+		h.fetch(fi)
+	case <-h.stop:
+		return
 	}
+}
+
+func (h *heartbeat) fetch(fi fetchInfo) {
+	// TODO what happens when stream breaks - does it try again?
+	r, err := h.c.Client.PublicRand(fi.ctx, fi.id, &drand.PublicRandRequest{})
+	if err != nil {
+		h.c.Log.Error("heartbeat", "can not contact node", err)
+		return
+	}
+	beat := BeatInfo{
+		Peer:  fi.id,
+		Round: r.GetRound(),
+	}
+	select {
+	case h.beats <- beat:
+	default:
+		h.c.Log.Debugw("heartbeat", "beat channel full")
+	}
+}
+
+type maxRoundAgg struct {
+	max uint64
+}
+
+// NewMaxAggregator returns an aggregator that stores the highest round seen on
+// the network per beat. It returns an uint64.
+func NewMaxAggregator() BeatAggregator {
+	return &maxRoundAgg{}
+}
+
+func (m *maxRoundAgg) PushBeat(b BeatInfo) {
+	if m.max < b.Round {
+		m.max = b.Round
+	}
+}
+
+func (m *maxRoundAgg) AggregatedBeats() interface{} {
+	max := m.max
+	m.max = 0
+	return max
 }

--- a/chain/sync/heartbeat.go
+++ b/chain/sync/heartbeat.go
@@ -1,0 +1,121 @@
+package sync
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/drand/drand/key"
+	"github.com/drand/drand/log"
+	"github.com/drand/drand/net"
+	"github.com/drand/drand/protobuf/drand"
+	clock "github.com/jonboulle/clockwork"
+)
+
+// HeartbeatConfig holds all the required information for the heartbeat to
+// proceed.
+type HeartbeatConfig struct {
+	// Logger where heartbeat will log important event such as network down
+	Log log.Logger
+	// Clock to regulate the heartbeats
+	Clock clock.Clock
+	// Client used by the heartbeat logic to contact other nodes
+	Client net.PublicClient
+	// Frequency at which the heartbeat should contact other nodes
+	Frequency time.Duration
+}
+
+// BeatInfo contains information relayed by the heartbeat logic. The peer who
+// replied and the last beacon that he has.
+type BeatInfo struct {
+	Peer      *key.Identity
+	LastRound uint64
+}
+
+// Heartbeat contacts other nodes in the network and relay their latest beacon
+type Heartbeat interface {
+	UpdateGroup([]*key.Identity)
+	Beats() chan BeatInfo
+	Stop()
+}
+
+type heartbeat struct {
+	c        *HeartbeatConfig
+	stop     chan bool
+	newGroup chan []*key.Identity
+	beats    chan BeatInfo
+}
+
+func NewHeartbeat(c *HeartbeatConfig) Heartbeat {
+	h := &heartbeat{
+		c:        c,
+		stop:     make(chan bool, 1),
+		newGroup: make(chan []*key.Identity, 1),
+		// TODO: It might work for now but wont for bigger size
+		beats: make(chan BeatInfo, 100),
+	}
+	go h.run()
+	return h
+}
+
+func (h *heartbeat) Stop() {
+	close(h.stop)
+}
+
+func (h *heartbeat) Beats() chan BeatInfo {
+	return h.beats
+}
+
+func (h *heartbeat) UpdateGroup(g []*key.Identity) {
+	h.newGroup <- g
+}
+
+func (h *heartbeat) run() {
+	var currentGroup []*key.Identity
+	ctx, cancel := context.WithCancel(context.Background())
+	for {
+		select {
+		case ng := <-h.newGroup:
+			if ng == nil {
+				h.c.Log.Error("heartbeat", "received nil group")
+				continue
+			}
+			currentGroup = ng
+			cancel() // we cancel current sync operations
+			ctx, cancel = context.WithCancel(context.Background())
+			go h.fetch(ctx, currentGroup)
+		case <-h.c.Clock.After(h.c.Frequency):
+			if currentGroup == nil {
+				h.c.Log.Debugw("heartbeat", "empty group - skipping beat()")
+				continue
+			}
+		case <-h.stop:
+			h.c.Log.Debugw("heartbeat", "stops")
+		}
+	}
+}
+
+func (h *heartbeat) fetch(ctx context.Context, group []*key.Identity) {
+	for i := range rand.Perm(len(group)) {
+		// TODO what happens when stream breaks - does it try again?
+		stream, err := h.c.Client.PublicRandStream(ctx, group[i], &drand.PublicRandRequest{})
+		if err != nil {
+			h.c.Log.Error("heartbeat", "can not contact node", err)
+			continue
+		}
+		go func(id *key.Identity, ch chan *drand.PublicRandResponse) {
+			for rand := range ch {
+				beat := BeatInfo{
+					Peer:      id,
+					LastRound: rand.GetRound(),
+				}
+				select {
+				case h.beats <- beat:
+					continue
+				default:
+					h.c.Log.Debugw("heartbeat", "beat channel full")
+				}
+			}
+		}(group[i], stream)
+	}
+}


### PR DESCRIPTION
The idea is to monitor all (or whatever subset of nodes we want) continuously for their last round they have. 
When we detect we are out of touch with the time, we can now decide whether we should sync because other are more advanced than me, i.e. I had a network problem or stg, OR the rest of the network is as good or worse than me that means we need to catchup.

The current (on master) logic is to first run sync, and if we had synced some new beacons, then we look if we need to catchup. Unfortunately, if sync is stuck, nothing happens. We could make such that it doesn't get stuck ("sync already in progress" error in the logs we're seeing), and that's a work I'm trying to do in https://github.com/drand/drand/pull/798, but that won't necessarily solve the problem because we can't know why the sync is failing. Maybe we are all at the same stage again so we haven't gotten a new beacon.

There may be other solutions to this problem to be honest. I'm proposing one here that increase a bit the runtime (we should probably sample a threshold of them etc) but has a simpler mechanic than before, which is in my opinion more valuable than some go routines at this point. 

**-->** This is a DRAFT just to see if that makes sense for me to go forward with this approach (tests, details etc). Comments more than welcomed :pray: 