### PR TITLE
harmonize go releaser config versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,21 +14,20 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+      - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: '^1.17'
       -
         name: Install Protoc
         uses: arduino/setup-protoc@v1.1.2
         with:
-          version: '3.12.3'
+          version: '3.14.0'
       -
         name: Install Protoc-gen-go
         run: |
-          GO111MODULE=off go get github.com/golang/protobuf/protoc-gen-go@v1.4.2
-          GO111MODULE=off go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@v0.0.0-20200617041141-9a465503579e
+          go install github.com/golang/protobuf/protoc-gen-go@v1.4.3
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0
           go mod tidy
       -
         name: Run GoReleaser


### PR DESCRIPTION
We bumped versions used in ci/tests, but not the ones goreleaser attempts to use when compiling at the end, so it's build will fail.