### PR TITLE
Fix bug on reshare process

### DIFF
--- a/cmd/drand-cli/control.go
+++ b/cmd/drand-cli/control.go
@@ -8,8 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/drand/drand/common"
-
 	"github.com/drand/drand/core/migration"
 
 	"github.com/drand/drand/common/scheme"
@@ -249,11 +247,11 @@ func reshareCmd(c *cli.Context) error {
 			return fmt.Errorf("could not load drand from path: %s", err)
 		}
 
-		if !common.CompareBeaconIDs(beaconID, oldGroup.ID) {
-			return fmt.Errorf("beacon ID [%s] is not equal to the present inside group file [%s]", beaconID, oldGroup.ID)
-		}
-
 		oldPath = c.String(oldGroupFlag.Name)
+
+		if beaconID != "" {
+			return fmt.Errorf("beacon id flag is not required when using --%s", oldGroupFlag.Name)
+		}
 	}
 
 	fmt.Fprintf(output, "Participating to the resharing. Beacon ID: [%s] \n", beaconID)

--- a/cmd/drand-cli/control.go
+++ b/cmd/drand-cli/control.go
@@ -214,10 +214,6 @@ func reloadCmd(c *cli.Context) error {
 }
 
 func reshareCmd(c *cli.Context) error {
-	if c.String(periodFlag.Name) != "" {
-		return fmt.Errorf("%s flag is not allowed on resharing", periodFlag.Name)
-	}
-
 	if c.Bool(leaderFlag.Name) {
 		return leadReshareCmd(c)
 	}
@@ -225,6 +221,10 @@ func reshareCmd(c *cli.Context) error {
 	args, err := getShareArgs(c)
 	if err != nil {
 		return err
+	}
+
+	if c.IsSet(periodFlag.Name) {
+		return fmt.Errorf("%s flag is not allowed on resharing", periodFlag.Name)
 	}
 
 	if !c.IsSet(connectFlag.Name) {
@@ -256,6 +256,8 @@ func reshareCmd(c *cli.Context) error {
 		if beaconID != "" {
 			return fmt.Errorf("beacon id flag is not required when using --%s", oldGroupFlag.Name)
 		}
+
+		beaconID = oldGroup.ID
 	}
 
 	fmt.Fprintf(output, "Participating to the resharing. Beacon ID: [%s] \n", beaconID)
@@ -277,6 +279,10 @@ func leadReshareCmd(c *cli.Context) error {
 		return err
 	}
 
+	if c.IsSet(periodFlag.Name) {
+		return fmt.Errorf("%s flag is not allowed on resharing", periodFlag.Name)
+	}
+
 	if !c.IsSet(thresholdFlag.Name) || !c.IsSet(shareNodeFlag.Name) {
 		return fmt.Errorf("leader needs to specify --nodes and --threshold for sharing")
 	}
@@ -287,6 +293,8 @@ func leadReshareCmd(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("could not create client: %v", err)
 	}
+
+	beaconID := c.String(beaconIDFlag.Name)
 
 	// resharing case needs the previous group
 	var oldPath string
@@ -299,6 +307,12 @@ func leadReshareCmd(c *cli.Context) error {
 			return fmt.Errorf("could not load drand from path: %s", err)
 		}
 		oldPath = c.String(oldGroupFlag.Name)
+
+		if beaconID != "" {
+			return fmt.Errorf("beacon id flag is not required when using --%s", oldGroupFlag.Name)
+		}
+
+		beaconID = oldGroup.ID
 	}
 
 	offset := int(core.DefaultResharingOffset.Seconds())
@@ -312,8 +326,6 @@ func leadReshareCmd(c *cli.Context) error {
 			return fmt.Errorf("catchup period given is invalid: %v", err)
 		}
 	}
-
-	beaconID := c.String(beaconIDFlag.Name)
 
 	fmt.Fprintf(output, "Initiating the resharing as a leader. Beacon ID: [%s] \n", beaconID)
 	groupP, shareErr := ctrlClient.InitReshareLeader(nodes, args.threshold, args.timeout,

--- a/cmd/drand-cli/control.go
+++ b/cmd/drand-cli/control.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/drand/drand/common"
+
 	"github.com/drand/drand/core/migration"
 
 	"github.com/drand/drand/common/scheme"
@@ -234,6 +236,8 @@ func reshareCmd(c *cli.Context) error {
 		return fmt.Errorf("could not create client: %v", err)
 	}
 
+	beaconID := c.String(beaconIDFlag.Name)
+
 	// resharing case needs the previous group
 	var oldPath string
 	if c.IsSet(transitionFlag.Name) {
@@ -244,10 +248,13 @@ func reshareCmd(c *cli.Context) error {
 		if err := key.Load(c.String(oldGroupFlag.Name), oldGroup); err != nil {
 			return fmt.Errorf("could not load drand from path: %s", err)
 		}
+
+		if !common.CompareBeaconIDs(beaconID, oldGroup.ID) {
+			return fmt.Errorf("beacon ID [%s] is not equal to the present inside group file [%s]", beaconID, oldGroup.ID)
+		}
+
 		oldPath = c.String(oldGroupFlag.Name)
 	}
-
-	beaconID := c.String(beaconIDFlag.Name)
 
 	fmt.Fprintf(output, "Participating to the resharing. Beacon ID: [%s] \n", beaconID)
 

--- a/cmd/drand-cli/control.go
+++ b/cmd/drand-cli/control.go
@@ -214,6 +214,10 @@ func reloadCmd(c *cli.Context) error {
 }
 
 func reshareCmd(c *cli.Context) error {
+	if c.String(periodFlag.Name) != "" {
+		return fmt.Errorf("%s flag is not allowed on resharing", periodFlag.Name)
+	}
+
 	if c.Bool(leaderFlag.Name) {
 		return leadReshareCmd(c)
 	}

--- a/common/beacon.go
+++ b/common/beacon.go
@@ -27,3 +27,17 @@ func GetBeaconIDFromEnv() string {
 func IsDefaultBeaconID(beaconID string) bool {
 	return beaconID == DefaultBeaconID || beaconID == ""
 }
+
+func CompareBeaconIDs(id1, id2 string) bool {
+	if IsDefaultBeaconID(id1) && !IsDefaultBeaconID(id2) {
+		return false
+	}
+	if IsDefaultBeaconID(id2) && !IsDefaultBeaconID(id1) {
+		return false
+	}
+	if id1 != id2 {
+		return false
+	}
+
+	return true
+}

--- a/common/beacon.go
+++ b/common/beacon.go
@@ -28,13 +28,13 @@ func IsDefaultBeaconID(beaconID string) bool {
 	return beaconID == DefaultBeaconID || beaconID == ""
 }
 
+// CompareBeaconIDs indicates if two different beacon ids are equivalent or not.
+// It handles default values too.
 func CompareBeaconIDs(id1, id2 string) bool {
-	if IsDefaultBeaconID(id1) && !IsDefaultBeaconID(id2) {
-		return false
+	if IsDefaultBeaconID(id1) && IsDefaultBeaconID(id2) {
+		return true
 	}
-	if IsDefaultBeaconID(id2) && !IsDefaultBeaconID(id1) {
-		return false
-	}
+
 	if id1 != id2 {
 		return false
 	}

--- a/common/beacon_test.go
+++ b/common/beacon_test.go
@@ -13,6 +13,6 @@ func TestCompareBeaconIDs(t *testing.T) {
 	require.True(t, CompareBeaconIDs(DefaultBeaconID, DefaultBeaconID))
 	require.False(t, CompareBeaconIDs("beacon_5s", DefaultBeaconID))
 	require.False(t, CompareBeaconIDs("beacon_5s", ""))
-	require.False(t, CompareBeaconIDs("", "beacon_5s"))
+	require.False(t, CompareBeaconIDs(DefaultBeaconID, "beacon_5s"))
 	require.False(t, CompareBeaconIDs("", "beacon_5s"))
 }

--- a/common/beacon_test.go
+++ b/common/beacon_test.go
@@ -1,0 +1,18 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareBeaconIDs(t *testing.T) {
+	require.True(t, CompareBeaconIDs("", ""))
+	require.True(t, CompareBeaconIDs("", DefaultBeaconID))
+	require.True(t, CompareBeaconIDs(DefaultBeaconID, ""))
+	require.True(t, CompareBeaconIDs(DefaultBeaconID, DefaultBeaconID))
+	require.False(t, CompareBeaconIDs("beacon_5s", DefaultBeaconID))
+	require.False(t, CompareBeaconIDs("beacon_5s", ""))
+	require.False(t, CompareBeaconIDs("", "beacon_5s"))
+	require.False(t, CompareBeaconIDs("", "beacon_5s"))
+}

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -104,7 +104,12 @@ func (bp *BeaconProcess) InitReshare(c context.Context, in *drand.InitResharePac
 		return nil, err
 	}
 
+	rcvBeaconID := in.GetMetadata().GetBeaconID()
 	beaconID := oldGroup.ID
+
+	if !commonutils.CompareBeaconIDs(rcvBeaconID, beaconID) {
+		return nil, fmt.Errorf("drand: invalid setup configuration: beacon id on flag is different to beacon id on group file")
+	}
 
 	if !in.GetInfo().GetLeader() {
 		bp.log.Infow("", "beacon_id", beaconID, "init_reshare", "begin", "leader", false)

--- a/core/drand_daemon_helper.go
+++ b/core/drand_daemon_helper.go
@@ -19,10 +19,15 @@ func (dd *DrandDaemon) readBeaconID(metadata *protoCommon.Metadata) (string, err
 		dd.state.Unlock()
 
 		if isChainHashFound {
+			// check if rcv beacon id on request points to a different id obtained from chain hash
 			if rcvBeaconID != "" && rcvBeaconID != beaconIDByHash {
 				return "", fmt.Errorf("invalid chain hash")
 			}
+
 			rcvBeaconID = beaconIDByHash
+
+			// set beacon id found from chain hash on message to make it available for everyone
+			metadata.BeaconID = beaconIDByHash
 		}
 	}
 

--- a/test/docker/utils/reshareBeacon.sh
+++ b/test/docker/utils/reshareBeacon.sh
@@ -8,7 +8,7 @@
 
 ## Default beacon
 # Start leader
-nohup docker exec -u drand drand_0 /bin/sh -c 'drand share --transition --leader --nodes 5 --threshold 4 --period "5s"' &
+nohup docker exec -u drand drand_0 /bin/sh -c 'drand share --transition --leader --nodes 5 --threshold 4' &
 
 sleep 3s
 
@@ -25,7 +25,7 @@ sleep 10s
 nohup docker exec -u drand drand_4 /bin/sh -c 'drand generate-keypair --tls-disable --id test_beacon "drand_4:8480"' &
 
 # Start leader
-nohup docker exec -u drand drand_0 /bin/sh -c 'drand share --transition --leader --nodes 5 --threshold 4 --period "60s" --id test_beacon' &
+nohup docker exec -u drand drand_0 /bin/sh -c 'drand share --transition --leader --nodes 5 --threshold 4 --id test_beacon' &
 
 sleep 3s
 

--- a/test/docker/utils/reshareBeacon.sh
+++ b/test/docker/utils/reshareBeacon.sh
@@ -33,4 +33,4 @@ sleep 3s
 nohup docker exec -u drand drand_2 /bin/sh -c 'drand share --transition  --connect drand_0:8080 --tls-disable --id test_beacon' &
 nohup docker exec -u drand drand_1 /bin/sh -c 'drand share --transition  --connect drand_0:8080 --tls-disable --id test_beacon' &
 nohup docker exec -u drand drand_3 /bin/sh -c 'drand share --transition  --connect drand_0:8080 --tls-disable --id test_beacon' &
-nohup docker exec -u drand drand_4 /bin/sh -c 'drand share --connect drand_0:8080 --from ./data/drand/.drand/multibeacon/test_beacon/groups/drand_group.toml --tls-disable --id test_beacon' &
+nohup docker exec -u drand drand_4 /bin/sh -c 'drand share --connect drand_0:8080 --from ./data/drand/.drand/multibeacon/test_beacon/groups/drand_group.toml --tls-disable' &


### PR DESCRIPTION
**Context**
This bug allows a user to init a reshape process with a difference between the beacon id he sets on CLI command and the ones present inside config file.

**Explanation**
Two networks are working inside the nodes: the default and a second one. We start a reshare on the second one to add a new node to this network. This new node uses the flag `--from` on CLI reshare cmd, but the user forgets to set the `--id` flag. The new node which is being added to the network uses the default one as the "resharing beacon process" instead of the second one. When it tries to send its share to the leader node, it uses the beacon id present on the old config file (it is the correct one). For that reason the leader is able to start the dkg process... as a result, the new node is not on the new group file. In some cases, this scenario triggered an existing kyber bug.