### PR TITLE
Fix important issue on verifying client

### DIFF
--- a/chain/verify.go
+++ b/chain/verify.go
@@ -43,3 +43,7 @@ func (v Verifier) VerifyBeacon(b Beacon, pubkey kyber.Point) error {
 
 	return key.Scheme.VerifyRecovered(pubkey, msg, b.Signature)
 }
+
+func (v Verifier) IsPrevSigMeaningful() bool {
+	return !v.scheme.DecouplePrevSig
+}

--- a/client/verify.go
+++ b/client/verify.go
@@ -180,8 +180,10 @@ func (v *verifyingClient) getTrustedPreviousSignature(ctx context.Context, round
 }
 
 func (v *verifyingClient) verify(ctx context.Context, info *chain.Info, r *RandomData) (err error) {
+	checkPrevSignature := v.opts.strict || (v.verifier.IsPrevSigMeaningful() && r.PreviousSignature == nil)
 	ps := r.PreviousSignature
-	if v.opts.strict || r.PreviousSignature == nil {
+
+	if checkPrevSignature {
 		ps, err = v.getTrustedPreviousSignature(ctx, r.Round())
 		if err != nil {
 			return


### PR DESCRIPTION
On unchained randomness previous signature won't be present, so the verifying client should handle that scenario correctly. 