### PR TITLE
[CI] Avoid running tests on both the branch and the PR

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,11 @@
 name: "Build/Tests"
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - main
+      - 'release/**'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
When devloping on a branch in the drand repo, we are running the CI on all pushes currently.

This changes the Github Action so that we are only running CI on PR and when pushing something on master or on a release branch.