### PR TITLE
Logging improvements

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -7,7 +7,7 @@
   description: "Good for newcomers"
 - name: "hacktoberfest"
   color: ff8c00
-  description: "Help wanted" 
+  description: "Help wanted"
 
 ###
 ### Areas

--- a/chain/beacon/chain.go
+++ b/chain/beacon/chain.go
@@ -39,10 +39,10 @@ type chainStore struct {
 }
 
 func newChainStore(l log.Logger, cf *Config, cl net.ProtocolClient, c *cryptoStore, store chain.Store, t *ticker) *chainStore {
-	// we make sure the chain is increasing monotically
+	// we make sure the chain is increasing monotonically
 	as := newAppendStore(store)
 
-	// we add an store to run some checks depending on scheme-related config
+	// we add a store to run some checks depending on scheme-related config
 	ss := NewSchemeStore(as, cf.Group.Scheme)
 
 	// we write some stats about the timing when new beacon is saved
@@ -104,7 +104,7 @@ func (c *chainStore) runAggregator() {
 	beaconID := c.conf.Group.ID
 	lastBeacon, err := c.Last()
 	if err != nil {
-		c.l.Fatalw("", "beacon_id", beaconID, "chain_aggregator", "loading", "last_beacon", err)
+		c.l.Fatalw("", "chain_aggregator", "loading", "last_beacon", err)
 	}
 
 	var cache = newPartialCache(c.l, beaconID)
@@ -124,7 +124,7 @@ func (c *chainStore) runAggregator() {
 			shouldStore := isNotInPast && isNotTooFar
 			// check if we can reconstruct
 			if !shouldStore {
-				c.l.Debugw("", "beacon_id", beaconID, "ignoring_partial", partial.p.GetRound(), "last_beacon_stored", lastBeacon.Round)
+				c.l.Debugw("", "ignoring_partial", partial.p.GetRound(), "last_beacon_stored", lastBeacon.Round)
 				break
 			}
 			// NOTE: This line means we can only verify partial signatures of
@@ -137,11 +137,11 @@ func (c *chainStore) runAggregator() {
 			cache.Append(partial.p)
 			roundCache := cache.GetRoundCache(partial.p.GetRound(), partial.p.GetPreviousSig())
 			if roundCache == nil {
-				c.l.Errorw("", "beacon_id", beaconID, "store_partial", partial.addr, "no_round_cache", partial.p.GetRound())
+				c.l.Errorw("", "store_partial", partial.addr, "no_round_cache", partial.p.GetRound())
 				break
 			}
 
-			c.l.Debugw("", "beacon_id", beaconID, "store_partial", partial.addr,
+			c.l.Debugw("", "store_partial", partial.addr,
 				"round", roundCache.round, "len_partials", fmt.Sprintf("%d/%d", roundCache.Len(), thr))
 			if roundCache.Len() < thr {
 				break
@@ -151,11 +151,11 @@ func (c *chainStore) runAggregator() {
 
 			finalSig, err := key.Scheme.Recover(c.crypto.GetPub(), msg, roundCache.Partials(), thr, n)
 			if err != nil {
-				c.l.Debugw("", "beacon_id", beaconID, "invalid_recovery", err, "round", pRound, "got", fmt.Sprintf("%d/%d", roundCache.Len(), n))
+				c.l.Debugw("", "invalid_recovery", err, "round", pRound, "got", fmt.Sprintf("%d/%d", roundCache.Len(), n))
 				break
 			}
 			if err := key.Scheme.VerifyRecovered(c.crypto.GetPub().Commit(), msg, finalSig); err != nil {
-				c.l.Errorw("", "beacon_id", beaconID, "invalid_sig", err, "round", pRound)
+				c.l.Errorw("", "invalid_sig", err, "round", pRound)
 				break
 			}
 			cache.FlushRounds(partial.p.GetRound())
@@ -166,21 +166,21 @@ func (c *chainStore) runAggregator() {
 				Signature:   finalSig,
 			}
 
-			c.l.Infow("", "beacon_id", beaconID, "aggregated_beacon", newBeacon.Round)
+			c.l.Infow("", "aggregated_beacon", newBeacon.Round)
 			if c.tryAppend(lastBeacon, newBeacon) {
 				lastBeacon = newBeacon
 				break
 			}
 			// XXX store them for lfutur usage if it's a later round than what
 			// we have
-			c.l.Debugw("", "beacon_id", beaconID, "new_aggregated", "not_appendable", "last", lastBeacon.String(), "new", newBeacon.String())
+			c.l.Debugw("", "new_aggregated", "not_appendable", "last", lastBeacon.String(), "new", newBeacon.String())
 			if c.shouldSync(lastBeacon, newBeacon) {
 				peers := toPeers(c.crypto.GetGroup().Nodes)
 				go func() {
 					// XXX Could do something smarter with context and cancellation
 					// if we got to the right round
 					if err := c.sync.Follow(context.Background(), newBeacon.Round, peers); err != nil {
-						c.l.Debugw("", "beacon_id", beaconID, "chain_store", "unable to follow", "err", err)
+						c.l.Debugw("", "chain_store", "unable to follow", "err", err)
 					}
 				}()
 			}
@@ -195,10 +195,9 @@ func (c *chainStore) tryAppend(last, newB *chain.Beacon) bool {
 		return false
 	}
 
-	beaconID := c.conf.Group.ID
 	if err := c.CallbackStore.Put(newB); err != nil {
 		// if round is ok but bytes are different, error will be raised
-		c.l.Errorw("", "beacon_id", beaconID, "chain_store", "error storing beacon", "err", err)
+		c.l.Errorw("", "chain_store", "error storing beacon", "err", err)
 		return false
 	}
 	select {
@@ -222,14 +221,12 @@ func (c *chainStore) shouldSync(last *chain.Beacon, newB likeBeacon) bool {
 // 0, then it will follow the chain indefinitely. If peers is nil, it uses the
 // peers of the current group.
 func (c *chainStore) RunSync(ctx context.Context, upTo uint64, peers []net.Peer) {
-	beaconID := c.conf.Group.ID
-
 	if peers == nil {
 		peers = toPeers(c.crypto.GetGroup().Nodes)
 	}
 
 	if err := c.sync.Follow(ctx, upTo, peers); err != nil {
-		c.l.Debugw("", "beacon_id", beaconID, "chain_store", "follow_finished", "err", err)
+		c.l.Debugw("", "chain_store", "follow_finished", "err", err)
 	}
 }
 

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -202,7 +202,7 @@ func (b *BeaconTest) CreateNode(t *testing.T, i int) {
 		Clock:  node.clock,
 	}
 
-	logger := log.NewLogger(nil, log.LogDebug)
+	logger := log.NewLogger(nil, log.LogDebug).Named("BeaconTest").Named(knode.Addr).Named(fmt.Sprint(idx))
 	version := common.Version{Major: 0, Minor: 0, Patch: 0}
 	node.handler, err = NewHandler(net.NewGrpcClient(), store, conf, logger, version)
 	checkErr(err)

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -114,14 +114,13 @@ func (d *discrepancyStore) Put(b *chain.Beacon) error {
 		return err
 	}
 	actual := d.clock.Now().UnixNano()
-	beaconID := d.group.ID
 	expected := chain.TimeOfRound(d.group.Period, d.group.GenesisTime, b.Round) * 1e9
 	discrepancy := float64(actual-expected) / float64(time.Millisecond)
 	metrics.BeaconDiscrepancyLatency.Set(float64(actual-expected) / float64(time.Millisecond))
 	metrics.LastBeaconRound.Set(float64(b.GetRound()))
 	metrics.GroupSize.Set(float64(d.group.Len()))
 	metrics.GroupThreshold.Set(float64(d.group.Threshold))
-	d.l.Infow("", "beacon_id", beaconID, "NEW_BEACON_STORED", b.String(), "time_discrepancy_ms", discrepancy)
+	d.l.Infow("", "NEW_BEACON_STORED", b.String(), "time_discrepancy_ms", discrepancy)
 	return nil
 }
 

--- a/chain/beacon/sync.go
+++ b/chain/beacon/sync.go
@@ -64,7 +64,6 @@ func (s *syncer) Syncing() bool {
 
 func (s *syncer) Follow(c context.Context, upTo uint64, nodes []net.Peer) error {
 	s.Lock()
-	beaconID := s.info.ID
 
 	if s.following {
 		s.Unlock()
@@ -78,7 +77,7 @@ func (s *syncer) Follow(c context.Context, upTo uint64, nodes []net.Peer) error 
 		s.Unlock()
 	}()
 
-	s.l.Debugw("", "beacon_id", beaconID, "syncer", "starting", "up_to", upTo, "nodes", peersToString(nodes))
+	s.l.Debugw("", "syncer", "starting", "up_to", upTo, "nodes", peersToString(nodes))
 
 	// shuffle through the nodes
 	for _, n := range rand.Perm(len(nodes)) {
@@ -109,14 +108,14 @@ func (s *syncer) tryNode(global context.Context, upTo uint64, n net.Peer) bool {
 	})
 
 	if err != nil {
-		s.l.Debugw("", "beacon_id", beaconID, "syncer", "unable_to_sync", "with_peer", n.Address(), "err", err)
+		s.l.Debugw("", "syncer", "unable_to_sync", "with_peer", n.Address(), "err", err)
 		return false
 	}
 
-	s.l.Debugw("", "beacon_id", beaconID, "syncer", "start_follow", "with_peer", n.Address(), "from_round", last.Round+1)
+	s.l.Debugw("", "syncer", "start_follow", "with_peer", n.Address(), "from_round", last.Round+1)
 
 	for beaconPacket := range beaconCh {
-		s.l.Debugw("", "beacon_id", beaconID, "syncer", "new_beacon_fetched",
+		s.l.Debugw("", "syncer", "new_beacon_fetched",
 			"with_peer", n.Address(), "from_round", last.Round+1, "got_round", beaconPacket.GetRound())
 		beacon := protoToBeacon(beaconPacket)
 
@@ -124,25 +123,25 @@ func (s *syncer) tryNode(global context.Context, upTo uint64, n net.Peer) bool {
 		err := s.verifier.VerifyBeacon(*beacon, s.info.PublicKey)
 
 		if err != nil {
-			s.l.Debugw("", "beacon_id", beaconID, "syncer", "invalid_beacon",
+			s.l.Debugw("", "syncer", "invalid_beacon",
 				"with_peer", n.Address(), "round", beacon.Round, "err", err, fmt.Sprintf("%+v", beacon))
 			return false
 		}
 
 		if err := s.store.Put(beacon); err != nil {
-			s.l.Debugw("", "beacon_id", beaconID, "syncer", "unable to save", "with_peer", n.Address(), "err", err)
+			s.l.Debugw("", "syncer", "unable to save", "with_peer", n.Address(), "err", err)
 			return false
 		}
 		last = beacon
 		if last.Round == upTo {
-			s.l.Debugw("", "beacon_id", beaconID, "syncer", "syncing finished to", "round", upTo)
+			s.l.Debugw("", "syncer", "syncing finished to", "round", upTo)
 			return true
 		}
 	}
 	// see if this was a cancellation from the call itself
 	select {
 	case <-global.Done():
-		s.l.Debugw("", "beacon_id", beaconID, "syncer", "follow canceled", "err?", global.Err())
+		s.l.Debugw("", "syncer", "follow canceled", "err?", global.Err())
 		if global.Err() == nil {
 			return true
 		}
@@ -153,10 +152,9 @@ func (s *syncer) tryNode(global context.Context, upTo uint64, n net.Peer) bool {
 }
 
 func (s *syncer) SyncChain(req *proto.SyncRequest, stream proto.Protocol_SyncChainServer) error {
-	beaconID := s.info.ID
 	fromRound := req.GetFromRound()
 	addr := net.RemoteAddress(stream.Context())
-	s.l.Debugw("", "beacon_id", beaconID, "syncer", "sync_request", "from", addr, "from_round", fromRound)
+	s.l.Debugw("", "syncer", "sync_request", "from", addr, "from_round", fromRound)
 
 	last, err := s.store.Last()
 	if err != nil {
@@ -172,7 +170,7 @@ func (s *syncer) SyncChain(req *proto.SyncRequest, stream proto.Protocol_SyncCha
 		s.store.Cursor(func(c chain.Cursor) {
 			for bb := c.Seek(fromRound); bb != nil; bb = c.Next() {
 				if err = stream.Send(beaconToProto(bb)); err != nil {
-					s.l.Debugw("", "beacon_id", beaconID, "syncer", "streaming_send", "err", err)
+					s.l.Debugw("", "syncer", "streaming_send", "err", err)
 					return
 				}
 			}
@@ -186,7 +184,7 @@ func (s *syncer) SyncChain(req *proto.SyncRequest, stream proto.Protocol_SyncCha
 	s.store.AddCallback(addr, func(b *chain.Beacon) {
 		err := stream.Send(beaconToProto(b))
 		if err != nil {
-			s.l.Debugw("", "beacon_id", beaconID, "syncer", "streaming_send", "err", err)
+			s.l.Debugw("", "syncer", "streaming_send", "err", err)
 			done <- nil
 		}
 	})

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -27,7 +27,7 @@ func (bp *BeaconProcess) BroadcastDKG(c context.Context, in *drand.DKGPacket) (*
 	addr := net.RemoteAddress(c)
 
 	if !bp.dkgInfo.started {
-		bp.log.Infow("", "beacon_id", bp.dkgInfo.target.ID, "init_dkg", "START DKG",
+		bp.log.Infow("", "init_dkg", "START DKG",
 			"signal from leader", addr, "group", hex.EncodeToString(bp.dkgInfo.target.Hash()))
 		bp.dkgInfo.started = true
 		go bp.dkgInfo.phaser.Start()
@@ -214,12 +214,10 @@ func (bp *BeaconProcess) PushDKGInfo(ctx context.Context, in *drand.DKGInfoPacke
 	bp.state.Lock()
 	defer bp.state.Unlock()
 
-	beaconID := in.GetMetadata().GetBeaconID()
-
 	if bp.receiver == nil {
 		return nil, errors.New("no receiver setup")
 	}
-	bp.log.Infow("", "beacon_id", beaconID, "push_group", "received_new")
+	bp.log.Infow("", "push_group", "received_new")
 
 	// the control routine will receive this info and start the dkg at the right
 	// time - if that is the right secret.

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -108,10 +108,11 @@ func (bp *BeaconProcess) PublicRandStream(req *drand.PublicRandRequest, stream d
 	if req.GetRound() != 0 && req.GetRound() <= lastb.Round {
 		// we need to stream from store first
 		var err error
+		logger := bp.log.Named("StoreCursor")
 		b.Store().Cursor(func(c chain.Cursor) {
 			for bb := c.Seek(req.GetRound()); bb != nil; bb = c.Next() {
 				if err = stream.Send(beaconToProto(bb)); err != nil {
-					bp.log.Debugw("", "stream", err)
+					logger.Debugw("", "stream", err)
 					return
 				}
 			}

--- a/core/drand_daemon_control.go
+++ b/core/drand_daemon_control.go
@@ -25,13 +25,13 @@ func (dd *DrandDaemon) InitDKG(c context.Context, in *drand.InitDKGPacket) (*dra
 	if err != nil {
 		store, isStoreLoaded := dd.initialStores[beaconID]
 		if !isStoreLoaded {
-			dd.log.Infow("", "beacon_id", beaconID, "init_dkg", "loading store from disk")
+			dd.log.Infow("", "init_dkg", "loading store from disk")
 
 			newStore := key.NewFileStore(dd.opts.ConfigFolderMB(), beaconID)
 			store = &newStore
 		}
 
-		dd.log.Infow("", "beacon_id", beaconID, "init_dkg", "instantiating a new beacon process")
+		dd.log.Infow("", "init_dkg", "instantiating a new beacon process")
 		bp, err = dd.InstantiateBeaconProcess(beaconID, *store)
 		if err != nil {
 			return nil, fmt.Errorf("something went wrong try to initiate DKG. err: %w", err)
@@ -53,13 +53,13 @@ func (dd *DrandDaemon) InitReshare(ctx context.Context, in *drand.InitResharePac
 	if err != nil {
 		store, isStoreLoaded := dd.initialStores[beaconID]
 		if !isStoreLoaded {
-			dd.log.Infow("", "beacon_id", beaconID, "init_reshare", "loading store from disk")
+			dd.log.Infow("", "init_reshare", "loading store from disk")
 
 			newStore := key.NewFileStore(dd.opts.ConfigFolderMB(), beaconID)
 			store = &newStore
 		}
 
-		dd.log.Infow("", "beacon_id", beaconID, "init_reshare", "instantiating a new beacon process")
+		dd.log.Infow("", "init_reshare", "instantiating a new beacon process")
 		bp, err = dd.InstantiateBeaconProcess(beaconID, *store)
 		if err != nil {
 			return nil, fmt.Errorf("something went wrong try to initiate DKG")

--- a/core/group_setup.go
+++ b/core/group_setup.go
@@ -175,16 +175,16 @@ func (s *setupManager) ReceivedKey(addr string, p *drand.SignalDKGPacket) error 
 
 	newID, err := key.IdentityFromProto(p.GetNode())
 	if err != nil {
-		s.l.Infow("", "beacon_id", s.beaconID, "setup", "error_decoding", "id", addr, "err", err)
+		s.l.Infow("", "setup", "error_decoding", "id", addr, "err", err)
 		return fmt.Errorf("invalid id: %w", err)
 	}
 
 	if err := newID.ValidSignature(); err != nil {
-		s.l.Infow("", "beacon_id", s.beaconID, "setup", "invalid_sig", "id", addr, "err", err)
+		s.l.Infow("", "setup", "invalid_sig", "id", addr, "err", err)
 		return fmt.Errorf("invalid sig: %w", err)
 	}
 
-	s.l.Debugw("", "beacon_id", s.beaconID, "setup", "received_new_key", "id", newID.String())
+	s.l.Debugw("", "setup", "received_new_key", "id", newID.String())
 
 	s.pushKeyCh <- pushKey{
 		addr: addr,
@@ -205,11 +205,11 @@ func (s *setupManager) run() {
 			for _, id := range inKeys {
 				if id.Address() == pk.id.Address() {
 					found = true
-					s.l.Debugw("", "beacon_id", s.beaconID, "setup", "duplicate", "ip", pk.addr, "addr", pk.id.String())
+					s.l.Debugw("", "setup", "duplicate", "ip", pk.addr, "addr", pk.id.String())
 					break
 				} else if id.Key.Equal(pk.id.Key) {
 					found = true
-					s.l.Debugw("", "beacon_id", s.beaconID, "setup", "duplicate", "ip", pk.addr, "addr", pk.id.String())
+					s.l.Debugw("", "setup", "duplicate", "ip", pk.addr, "addr", pk.id.String())
 					break
 				}
 			}
@@ -218,7 +218,7 @@ func (s *setupManager) run() {
 				break
 			}
 			inKeys = append(inKeys, pk.id)
-			s.l.Debugw("", "beacon_id", s.beaconID, "setup", "added", "key", pk.id.String(), "have", fmt.Sprintf("%d/%d", len(inKeys), s.expected))
+			s.l.Debugw("", "setup", "added", "key", pk.id.String(), "have", fmt.Sprintf("%d/%d", len(inKeys), s.expected))
 
 			// create group if we have enough keys
 			if len(inKeys) == s.expected {
@@ -233,7 +233,7 @@ func (s *setupManager) run() {
 				}
 			}
 		case <-s.doneCh:
-			s.l.Debugw("", "beacon_id", s.beaconID, "setup", "preempted", "collected_keys", len(inKeys))
+			s.l.Debugw("", "setup", "preempted", "collected_keys", len(inKeys))
 			return
 		}
 	}
@@ -259,7 +259,7 @@ func (s *setupManager) createAndSend(keys []*key.Identity) {
 		group.TransitionTime = transition
 		group.GenesisSeed = s.oldGroup.GetGenesisSeed()
 	}
-	s.l.Debugw("", "beacon_id", s.beaconID, "setup", "created_group")
+	s.l.Debugw("", "setup", "created_group")
 	fmt.Printf("Generated group:\n%s\n", group.String()) // nolint
 	// signal the leader it's ready to run the DKG
 	s.startDKG <- group
@@ -354,10 +354,8 @@ type dkgGroup struct {
 // leader. It runs some routines verification of the group before passing it on
 // to the routine that waits for the group to start the DKG.
 func (r *setupReceiver) PushDKGInfo(pg *drand.DKGInfoPacket) error {
-	beaconID := pg.GetMetadata().GetBeaconID()
-
 	if !correctSecret(r.secret, pg.GetSecretProof()) {
-		r.l.Debugw("", "beacon_id", beaconID, "received", "invalid_secret_proof")
+		r.l.Debugw("", "received", "invalid_secret_proof")
 		return errors.New("invalid secret")
 	}
 	// verify things are all in order
@@ -366,7 +364,7 @@ func (r *setupReceiver) PushDKGInfo(pg *drand.DKGInfoPacket) error {
 		return fmt.Errorf("group from leader invalid: %w", err)
 	}
 	if err := key.DKGAuthScheme.Verify(r.leaderID.Key, group.Hash(), pg.Signature); err != nil {
-		r.l.Errorw("", "beacon_id", beaconID, "received", "group", "invalid_sig", err)
+		r.l.Errorw("", "received", "group", "invalid_sig", err)
 		return fmt.Errorf("invalid group sig: %w", err)
 	}
 	checkGroup(r.l, group)
@@ -383,7 +381,7 @@ func (r *setupReceiver) WaitDKGInfo(ctx context.Context) (*key.Group, uint32, er
 		if dkgGroup == nil {
 			return nil, 0, errors.New("unable to fetch group")
 		}
-		r.l.Debugw("", "beacon_id", dkgGroup.group.ID, "init_dkg", "received_group")
+		r.l.Debugw("", "init_dkg", "received_group")
 		return dkgGroup.group, dkgGroup.timeout, nil
 	case <-r.clock.After(MaxWaitPrepareDKG):
 		r.l.Errorw("", "init_dkg", "wait_group", "err", "timeout")

--- a/demo/node/node_inprocess.go
+++ b/demo/node/node_inprocess.go
@@ -68,7 +68,7 @@ func NewLocalNode(i int, period string, base string, tls bool, bindAddr string, 
 		period:   period,
 		tls:      tls,
 		logPath:  logPath,
-		log:      log.DefaultLogger(),
+		log:      log.NewLogger(nil, log.LogDebug),
 		pubAddr:  test.FreeBind(bindAddr),
 		privAddr: test.FreeBind(bindAddr),
 		ctrlAddr: test.FreeBind("localhost"),
@@ -141,7 +141,6 @@ func (l *LocalNode) Start(certFolder string) error {
 			fmt.Printf("beacon id [%s]: will run as fresh install -> expect to run DKG.\n", beaconID)
 		} else {
 			fmt.Printf("beacon id [%s]: will already start running randomness beacon.\n", beaconID)
-
 			// Add beacon handler from chain hash for http server
 			drandDaemon.AddBeaconHandler(beaconID, bp)
 

--- a/log/log.go
+++ b/log/log.go
@@ -8,6 +8,10 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+type logger struct {
+	*zap.SugaredLogger
+}
+
 // Logger is a interface that can log to different levels.
 type Logger interface {
 	Info(keyvals ...interface{})
@@ -22,8 +26,16 @@ type Logger interface {
 	Errorw(msg string, keyvals ...interface{})
 	Fatalw(msg string, keyvals ...interface{})
 	Panicw(msg string, keyvals ...interface{})
-	With(args ...interface{}) *zap.SugaredLogger
-	Named(s string) *zap.SugaredLogger
+	With(args ...interface{}) Logger
+	Named(s string) Logger
+}
+
+func (l *logger) With(args ...interface{}) Logger {
+	return &logger{l.SugaredLogger.With(args...)}
+}
+
+func (l *logger) Named(s string) Logger {
+	return &logger{l.SugaredLogger.Named(s)}
 }
 
 const (
@@ -57,19 +69,19 @@ func DefaultLogger() Logger {
 		zap.ReplaceGlobals(NewZapLogger(nil, getConsoleEncoder(), DefaultLevel))
 	})
 
-	return zap.S()
+	return &logger{zap.S()}
 }
 
 // NewLogger returns a logger that prints statements at the given level.
 func NewLogger(output zapcore.WriteSyncer, level int) Logger {
-	logger := NewZapLogger(output, getConsoleEncoder(), level)
-	return logger.Sugar()
+	l := NewZapLogger(output, getConsoleEncoder(), level)
+	return &logger{l.Sugar()}
 }
 
 // NewJSONLogger returns a logger that prints statements at the given level as JSON output.
 func NewJSONLogger(output zapcore.WriteSyncer, level int) Logger {
-	logger := NewZapLogger(output, getJSONEncoder(), level)
-	return logger.Sugar()
+	l := NewZapLogger(output, getJSONEncoder(), level)
+	return &logger{l.Sugar()}
 }
 
 func NewZapLogger(output zapcore.WriteSyncer, encoder zapcore.Encoder, level int) *zap.Logger {

--- a/log/log.go
+++ b/log/log.go
@@ -23,6 +23,7 @@ type Logger interface {
 	Fatalw(msg string, keyvals ...interface{})
 	Panicw(msg string, keyvals ...interface{})
 	With(args ...interface{}) *zap.SugaredLogger
+	Named(s string) *zap.SugaredLogger
 }
 
 const (
@@ -59,13 +60,13 @@ func DefaultLogger() Logger {
 	return zap.S()
 }
 
-// NewLogger returns a kit logger that prints statements at the given level.
+// NewLogger returns a logger that prints statements at the given level.
 func NewLogger(output zapcore.WriteSyncer, level int) Logger {
 	logger := NewZapLogger(output, getConsoleEncoder(), level)
 	return logger.Sugar()
 }
 
-// NewJSONLogger returns a kit logger that prints statements at the given level as JSON output.
+// NewJSONLogger returns a logger that prints statements at the given level as JSON output.
 func NewJSONLogger(output zapcore.WriteSyncer, level int) Logger {
 	logger := NewZapLogger(output, getJSONEncoder(), level)
 	return logger.Sugar()


### PR DESCRIPTION
- Using With for prefixes
- Logs cleanups
- Trying to add more useful information in logs, including node address and index

Before:
```
2022-03-07T18:13:08.781+0100	DEBUG	beacon/chain.go:144		{"beacon_id": "", "store_partial": "127.0.0.1:37900", "round": 1, "len_partials": "2/2"}
2022-03-07T18:13:08.781+0100	DEBUG	beacon/node.go:106		{"beacon_id": "", "received": "request", "from": "127.0.0.1:38166", "round": 1}
2022-03-07T18:13:08.784+0100	DEBUG	beacon/node.go:136		{"beacon_id": "", "process_partial": "127.0.0.1:38166", "prev_sig": "bffcfc", "curr_round": 1, "msg_sign": "e38cc7", "from_node": "127.0.0.1:34863", "status": "OK"}
2022-03-07T18:13:08.785+0100	DEBUG	beacon/node.go:136		{"beacon_id": "", "process_partial": "127.0.0.1:40218", "prev_sig": "bffcfc", "curr_round": 1, "msg_sign": "e38cc7", "from_node": "127.0.0.1:34863", "status": "OK"}
2022-03-07T18:13:08.791+0100	INFO	beacon/chain.go:169		{"beacon_id": "", "aggregated_beacon": 1}
2022-03-07T18:13:08.805+0100	INFO	beacon/store.go:120		{"beacon_id": "", "NEW_BEACON_STORED": "{ round: 1, sig: 9430a5, prevSig: bffcfc }", "time_discrepancy_ms": 805.320942}
2022-03-07T18:13:08.805+0100	DEBUG	beacon/chain.go:127		{"beacon_id": "", "ignoring_partial": 1, "last_beacon_stored": 1}
2022-03-07T18:13:08.806+0100	INFO	beacon/store.go:120		{"beacon_id": "", "NEW_BEACON_STORED": "{ round: 1, sig: 9430a5, prevSig: bffcfc }", "time_discrepancy_ms": 806.974191}
2022-03-07T18:13:08.807+0100	DEBUG	beacon/chain.go:127		{"beacon_id": "", "ignoring_partial": 1, "last_beacon_stored": 
```

After:
```
2022-03-07T19:50:32.663+0100	DEBUG	beacon/chain.go:144		{"idx": 0, "addr": "127.0.0.1:43151", "beacon_id": "", "store_partial": "127.0.0.1:43151", "round": 1, "len_partials": "1/2"}
2022-03-07T19:50:32.663+0100	DEBUG	beacon/node.go:105		{"idx": 1, "addr": "127.0.0.1:37497", "beacon_id": "", "received": "request", "from": "127.0.0.1:39508", "round": 1}
2022-03-07T19:50:32.671+0100	DEBUG	beacon/node.go:135		{"idx": 0, "addr": "127.0.0.1:43151", "beacon_id": "", "process_partial": "127.0.0.1:60694", "prev_sig": "b70359", "curr_round": 1, "msg_sign": "d4a4c2", "from_node": "127.0.0.1:37497", "status": "OK"}
2022-03-07T19:50:32.671+0100	DEBUG	beacon/node.go:135		{"idx": 2, "addr": "127.0.0.1:35643", "beacon_id": "", "process_partial": "127.0.0.1:50120", "prev_sig": "b70359", "curr_round": 1, "msg_sign": "d4a4c2", "from_node": "127.0.0.1:37497", "status": "OK"}
2022-03-07T19:50:32.671+0100	DEBUG	beacon/chain.go:144		{"idx": 0, "addr": "127.0.0.1:43151", "beacon_id": "", "store_partial": "127.0.0.1:60694", "round": 1, "len_partials": "2/2"}
2022-03-07T19:50:32.671+0100	DEBUG	beacon/node.go:135		{"idx": 1, "addr": "127.0.0.1:37497", "beacon_id": "", "process_partial": "127.0.0.1:39510", "prev_sig": "b70359", "curr_round": 1, "msg_sign": "d4a4c2", "from_node": "127.0.0.1:35643", "status": "OK"}
2022-03-07T19:50:32.678+0100	INFO	beacon/chain.go:169		{"idx": 1, "addr": "127.0.0.1:37497", "beacon_id": "", "aggregated_beacon": 1}
2022-03-07T19:50:32.693+0100	INFO	beacon/store.go:119		{"idx": 1, "addr": "127.0.0.1:37497", "beacon_id": "", "NEW_BEACON_STORED": "{ round: 1, sig: ade005, prevSig: b70359 }", "time_discrepancy_ms": 693.710468}
2022-03-07T19:50:32.693+0100	DEBUG	beacon/chain.go:127		{"idx": 1, "addr": "127.0.0.1:37497", "beacon_id": "", "ignoring_partial": 1, "last_beacon_stored": 1}
```