### PR TITLE
[Cleanup] Avoid leaking deferred calls

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 issues:
+  # Let us display all issues of one type at once
+  max-same-issues: 0
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
     - path: _test\.go

--- a/chain/beacon/chain.go
+++ b/chain/beacon/chain.go
@@ -46,7 +46,7 @@ func newChainStore(l log.Logger, cf *Config, cl net.ProtocolClient, c *cryptoSto
 	ss := NewSchemeStore(as, cf.Group.Scheme)
 
 	// we write some stats about the timing when new beacon is saved
-	ds := newDiscrepancyStore(ss, l, c.GetGroup())
+	ds := newDiscrepancyStore(ss, l, c.GetGroup(), cf.Clock)
 
 	// we can register callbacks on it
 	cbs := NewCallbackStore(ds)

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -162,7 +162,7 @@ func NewBeaconTest(t *testing.T, n, thr int, period time.Duration, genesisTime i
 
 	for i := 0; i < n; i++ {
 		bt.CreateNode(t, i)
-		t.Logf("Creating node %d/%d", i, n)
+		t.Logf("Creating node %d/%d", i+1, n)
 	}
 	return bt
 }

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -3,10 +3,11 @@ package beacon
 import (
 	"bytes"
 	"fmt"
-	clock "github.com/jonboulle/clockwork"
 	"runtime"
 	"sync"
 	"time"
+
+	clock "github.com/jonboulle/clockwork"
 
 	"github.com/drand/drand/common/scheme"
 

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -3,6 +3,7 @@ package beacon
 import (
 	"bytes"
 	"fmt"
+	clock "github.com/jonboulle/clockwork"
 	"runtime"
 	"sync"
 	"time"
@@ -95,13 +96,15 @@ type discrepancyStore struct {
 	chain.Store
 	l     log.Logger
 	group *key.Group
+	clock clock.Clock
 }
 
-func newDiscrepancyStore(s chain.Store, l log.Logger, group *key.Group) chain.Store {
+func newDiscrepancyStore(s chain.Store, l log.Logger, group *key.Group, cl clock.Clock) chain.Store {
 	return &discrepancyStore{
 		Store: s,
 		l:     l,
 		group: group,
+		clock: cl,
 	}
 }
 
@@ -109,7 +112,7 @@ func (d *discrepancyStore) Put(b *chain.Beacon) error {
 	if err := d.Store.Put(b); err != nil {
 		return err
 	}
-	actual := time.Now().UnixNano()
+	actual := d.clock.Now().UnixNano()
 	beaconID := d.group.ID
 	expected := chain.TimeOfRound(d.group.Period, d.group.GenesisTime, b.Round) * 1e9
 	discrepancy := float64(actual-expected) / float64(time.Millisecond)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -212,7 +212,7 @@ func TestClientWithWatcherCtorError(t *testing.T) {
 		client.WithChainInfo(fakeChainInfo()),
 		client.WithWatcher(watcherCtor),
 	)
-	if err != watcherErr {
+	if !errors.Is(err, watcherErr) {
 		t.Fatal(err)
 	}
 }

--- a/client/http/http.go
+++ b/client/http/http.go
@@ -119,10 +119,10 @@ func ForURLs(urls []string, chainHash []byte) []client.Client {
 	return clients
 }
 
-func Ping(root string) error {
+func Ping(ctx context.Context, root string) error {
 	url := fmt.Sprintf("%s/health", root)
 
-	ctx, cancel := context.WithTimeout(context.Background(), maxTimeoutHTTPRequest)
+	ctx, cancel := context.WithTimeout(ctx, maxTimeoutHTTPRequest)
 	defer cancel()
 
 	req, err := nhttp.NewRequestWithContext(ctx, "GET", url, nhttp.NoBody)
@@ -177,7 +177,8 @@ func instrumentClient(url string, transport nhttp.RoundTripper) *nhttp.Client {
 func IsServerReady(addr string) (er error) {
 	counter := 0
 	for {
-		err := Ping("http://" + addr)
+		// Ping is wrapping its context with a Timeout on maxTimeoutHTTPRequest anyway.
+		err := Ping(context.Background(), "http://"+addr)
 		if err == nil {
 			return nil
 		}

--- a/client/http/http_test.go
+++ b/client/http/http_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sync"
 	"testing"
@@ -172,7 +173,7 @@ func TestHTTPClientClose(t *testing.T) {
 	}
 
 	_, err = httpClient.Get(context.Background(), 0)
-	if err != errClientClosed {
+	if !errors.Is(err, errClientClosed) {
 		t.Fatal("unexpected error from closed client", err)
 	}
 

--- a/client/optimizing.go
+++ b/client/optimizing.go
@@ -244,7 +244,7 @@ LOOP:
 			}
 			stats = append(stats, rr.stat)
 			res = rr.result
-			if rr.err != errEmptyClientUnsupportedGet && rr.err != nil {
+			if rr.err != nil && !errors.Is(rr.err, errEmptyClientUnsupportedGet) {
 				err = fmt.Errorf("%v - %w", err, rr.err)
 			} else if rr.err == nil {
 				err = nil
@@ -270,7 +270,7 @@ func get(ctx context.Context, client Client, round uint64) *requestResult {
 	var stat requestStat
 
 	// client failure, set a large RTT so it is sent to the back of the list
-	if err != nil && err != ctx.Err() {
+	if err != nil && !errors.Is(err, ctx.Err()) {
 		stat = requestStat{client, math.MaxInt64, start}
 		return &requestResult{client, res, err, &stat}
 	}
@@ -606,7 +606,7 @@ CLIENT_LOOP:
 func (oc *optimizingClient) Info(ctx context.Context) (chainInfo *chain.Info, err error) {
 	clients := oc.fastestClients()
 	for _, c := range clients {
-		ctx, cancel := context.WithTimeout(context.Background(), oc.requestTimeout)
+		ctx, cancel := context.WithTimeout(ctx, oc.requestTimeout)
 		chainInfo, err = c.Info(ctx)
 		cancel()
 		if err == nil {

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -20,16 +20,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setFDLimit() {
+func setFDLimit(t *testing.T) {
 	fdOpen := uint64(3000)
 	curr, max, err := unixGetLimit()
 	if err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 	if fdOpen <= curr {
+		t.Logf("Current limit is larger (%d) than ours (%d); not changing it.\n", curr, fdOpen)
 		return
 	} else if err := unixSetLimit(fdOpen, max); err != nil {
-		panic(err)
+		t.Fatal(err)
 	}
 }
 
@@ -63,7 +64,7 @@ func TestRunDKGLarge(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 
-	setFDLimit()
+	setFDLimit(t)
 
 	n := 22
 	expectedBeaconPeriod := 5 * time.Second

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -875,7 +875,11 @@ func TestDrandPublicStreamProxy(t *testing.T) {
 
 	root := dt.nodes[0]
 	dt.SetMockClock(t, group.GenesisTime)
-	dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	err := dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	if err != nil {
+		t.Log("Error waiting until chain is serving:", err)
+		t.Fail()
+	}
 
 	// do a few periods
 	for i := 0; i < 3; i++ {

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -21,12 +21,14 @@ import (
 )
 
 func setFDLimit() {
-	fdOpen := 2000
-	_, max, err := unixGetLimit()
+	fdOpen := uint64(3000)
+	curr, max, err := unixGetLimit()
 	if err != nil {
 		panic(err)
 	}
-	if err := unixSetLimit(uint64(fdOpen), max); err != nil {
+	if fdOpen <= curr {
+		return
+	} else if err := unixSetLimit(fdOpen, max); err != nil {
 		panic(err)
 	}
 }

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -441,6 +441,8 @@ func (d *DrandTestScenario) AdvanceMockClock(t *testing.T, p time.Duration) {
 		node.clock.Advance(p)
 	}
 	d.clock.Advance(p)
+	// we sleep to make sure everyone has the time to get the new time before continuing
+	time.Sleep(10 * time.Millisecond)
 }
 
 // CheckBeaconLength looks if the beacon chain on the given addresses is of the

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -433,6 +433,7 @@ func (d *DrandTestScenario) SetMockClock(t *testing.T, targetUnixTime int64) {
 
 // AdvanceMockClock advances the clock of all drand by the given duration
 func (d *DrandTestScenario) AdvanceMockClock(t *testing.T, p time.Duration) {
+	t.Log("Advancing time by", p, "from", d.clock.Now().Unix())
 	for _, node := range d.nodes {
 		node.clock.Advance(p)
 	}
@@ -515,7 +516,7 @@ func (d *DrandTestScenario) WaitUntilRound(t *testing.T, node *MockNode, round u
 		}
 
 		t.Logf("node %s is on %d round (vs expected %d), waiting some time to ask again...", node.addr, status.ChainStore.LastRound, round)
-		time.Sleep(1000 * time.Millisecond)
+		time.Sleep(d.period)
 	}
 }
 
@@ -530,7 +531,7 @@ func (d *DrandTestScenario) WaitUntilChainIsServing(t *testing.T, node *MockNode
 		require.NoError(t, err)
 
 		if status.Beacon.IsServing {
-			t.Logf("node %s has its beacon chain running", node.addr)
+			t.Logf("node %s has its beacon chain running on round %d", node.addr, status.ChainStore.LastRound)
 			return nil
 		}
 

--- a/lp2p/client/client.go
+++ b/lp2p/client/client.go
@@ -129,7 +129,7 @@ func NewWithPubsub(ps *pubsub.PubSub, info *chain.Info, cache client.Cache) (*Cl
 type UnsubFunc func()
 
 // Sub subscribes to notfications about new randomness.
-// Client instnace owns the channel after it is passed to Sub function,
+// Client instance owns the channel after it is passed to Sub function,
 // thus the channel should not be closed by library user
 //
 // It is recommended to use a buffered channel. If the channel is full,

--- a/net/client_grpc.go
+++ b/net/client_grpc.go
@@ -3,6 +3,7 @@ package net
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -122,7 +123,7 @@ func (g *grpcClient) PublicRandStream(
 	go func() {
 		for {
 			resp, err := stream.Recv()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				close(outCh)
 				return
 			}

--- a/net/control.go
+++ b/net/control.go
@@ -50,6 +50,7 @@ func (g *ControlListener) Start() {
 // Stop the listener and connections
 func (g *ControlListener) Stop() {
 	g.conns.Stop()
+	g.lis.Close()
 }
 
 // ControlClient is a struct that implement control.ControlClient and is used to


### PR DESCRIPTION
We had deferred calls that were issued in a for loop, and as such were "leaking".

This PR wraps the deferred calls and code into anonymous function, which means that the deferred calls are run at the end of each iteration instead of leaking until the end of the function execution.