### PR TITLE
Letting more time for the demo to timeout

### DIFF
--- a/demo/demo_test.go
+++ b/demo/demo_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -15,30 +13,49 @@ import (
 
 func TestLocalOrchestration(t *testing.T) {
 
-	// Let us have a 4 minutes deadline since the CI is slow
+	// Let us have a 3 minutes deadline since the CI is slow
 	time.AfterFunc(
-		4*time.Minute,
+		3*time.Minute,
 		func() {
-			fmt.Println("Deadline reached")
-			os.Exit(1)
+			t.Fatal("[DEBUG]", "Deadline reached")
 		})
 
 	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
 
 	o := lib.NewOrchestrator(3, 2, "4s", true, "", false, sch, beaconID, true)
 	defer o.Shutdown()
+	t.Log("[DEBUG]", "[+] StartCurrentNodes")
 	o.StartCurrentNodes()
+
 	o.RunDKG("3")
 	o.WaitGenesis()
+
+	t.Log("[DEBUG]", "[+] WaitPeriod", 1)
 	o.WaitPeriod()
+
+	t.Log("[DEBUG]", "[+] CheckCurrentBeacon", 1)
 	o.CheckCurrentBeacon()
 	o.StopNodes(1)
+
+	t.Log("[DEBUG]", "[+] WaitPeriod", 2)
 	o.WaitPeriod()
+
+	t.Log("[DEBUG]", "[+] CheckCurrentBeacon", 2)
 	o.CheckCurrentBeacon(1)
 	o.StopNodes(2)
+
+	t.Log("[DEBUG]", "[+] WaitPeriod", 3)
 	o.WaitPeriod()
+
+	t.Log("[DEBUG]", "[+] WaitPeriod", 4)
 	o.WaitPeriod()
 	o.StartNode(1, 2)
+
+	t.Log("[DEBUG]", "[+] WaitPeriod", 5)
 	o.WaitPeriod()
+
+	t.Log("[DEBUG]", "[+] CheckCurrentBeacon", 3)
 	o.CheckCurrentBeacon()
+
+	t.Log("[DEBUG]", "[+] LocalOrchestration test finished, initiating shutdown")
 }

--- a/demo/demo_test.go
+++ b/demo/demo_test.go
@@ -15,9 +15,9 @@ import (
 
 func TestLocalOrchestration(t *testing.T) {
 
-	// Let us have a 2 minutes deadline
+	// Let us have a 4 minutes deadline since the CI is slow
 	time.AfterFunc(
-		2*time.Minute,
+		4*time.Minute,
 		func() {
 			fmt.Println("Deadline reached")
 			os.Exit(1)


### PR DESCRIPTION
It seems the CI is slower these days and this makes our tests fail without the demo being actually stuck.