### PR TITLE
Enabling Debug level logs in tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,6 +29,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Build
+        env:
+          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin
           make drand
@@ -54,8 +56,12 @@ jobs:
             ${{ runner.os }}-go-
       - run: go get -v -t -d ./...
       - name: Unit tests
+        env:
+          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
         run: make test-unit
       - name: Integration tests
+        env:
+          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
         run: make test-integration
 
   test_unchained:
@@ -77,8 +83,12 @@ jobs:
             ${{ runner.os }}-go-
       - run: go get -v -t -d ./...
       - name: Unit tests
+        env:
+          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
         run: SCHEME_ID=pedersen-bls-unchained make test-unit
       - name: Integration tests
+        env:
+          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
         run: SCHEME_ID=pedersen-bls-unchained make test-integration
 
   coverage:
@@ -99,4 +109,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: make coverage
+        env:
+          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
       - run: bash <(curl -s https://codecov.io/bash)

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -89,6 +89,7 @@ type DrandTestScenario struct {
 // to delete at the end of the test. As well, it returns a public grpc
 // client that can reach any drand node.
 // Deprecated: do not use
+//
 //nolint:funlen
 func BatchNewDrand(t *testing.T, n int, insecure bool, sch scheme.Scheme, beaconID string, opts ...ConfigOption) (
 	daemons []*DrandDaemon, drands []*BeaconProcess, group *key.Group, dir string, certPaths []string,


### PR DESCRIPTION
This is enabling Debug level logs in our tests, in order to help us debug our CI issues and flaky tests. (Most notably the stalled `make coverage` issues we seem to only have on the CI)

It is also adding some extra history to our race traces and stripping the specific GH prefixes from them, to allow for an easier usage when importing the logs locally.