### PR TITLE
Emit DKG/Reshare status when node starts up/shuts down

### DIFF
--- a/core/drand_daemon.go
+++ b/core/drand_daemon.go
@@ -209,6 +209,7 @@ func (dd *DrandDaemon) RemoveBeaconProcess(beaconID string, bp *BeaconProcess) {
 
 	metrics.DKGStateChange(metrics.DKGShutdown, beaconID, false)
 	metrics.ReshareStateChange(metrics.ReshareShutdown, beaconID, false)
+	metrics.IsDrandNode.Set(1)
 
 	dd.state.Unlock()
 }

--- a/core/drand_daemon.go
+++ b/core/drand_daemon.go
@@ -173,6 +173,7 @@ func (dd *DrandDaemon) InstantiateBeaconProcess(beaconID string, store key.Store
 
 	metrics.DKGStateChange(metrics.DKGNotStarted, beaconID, false)
 	metrics.ReshareStateChange(metrics.ReshareIdle, beaconID, false)
+	metrics.IsDrandNode.Set(1)
 
 	return bp, nil
 }

--- a/core/drand_daemon.go
+++ b/core/drand_daemon.go
@@ -171,6 +171,9 @@ func (dd *DrandDaemon) InstantiateBeaconProcess(beaconID string, store key.Store
 	dd.beaconProcesses[beaconID] = bp
 	dd.state.Unlock()
 
+	metrics.DKGStateChange(metrics.DKGNotStarted, beaconID, false)
+	metrics.ReshareStateChange(metrics.ReshareIdle, beaconID, false)
+
 	return bp, nil
 }
 
@@ -203,6 +206,9 @@ func (dd *DrandDaemon) RemoveBeaconProcess(beaconID string, bp *BeaconProcess) {
 	if common.IsDefaultBeaconID(beaconID) {
 		delete(dd.chainHashes, common.DefaultChainHash)
 	}
+
+	metrics.DKGStateChange(metrics.DKGShutdown, beaconID, false)
+	metrics.ReshareStateChange(metrics.ReshareShutdown, beaconID, false)
 
 	dd.state.Unlock()
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -198,7 +198,7 @@ var (
 	// IsDrandNode is 1 for drand nodes, 0 for relays
 	IsDrandNode = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "is_drand_node",
-		Help: "1 for drand nodes, 0 for relays",
+		Help: "1 for drand nodes, not emitted for relays",
 	})
 
 	metricsBound = false

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -27,6 +27,7 @@ const (
 	DKGWaiting       DKGStatus = "waiting"
 	DKGReady         DKGStatus = "ready"
 	DKGUnknownStatus DKGStatus = "unknown"
+	DKGShutdown      DKGStatus = "node_stopped"
 )
 
 const (
@@ -34,6 +35,7 @@ const (
 	ReshareWaiting       ReshareStatus = "waiting"
 	ReshareInProgess     ReshareStatus = "in_progress"
 	ReshareStatusUnknown ReshareStatus = "unknown"
+	ReshareShutdown      ReshareStatus = "node_stopped"
 )
 
 var (

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -195,6 +195,12 @@ var (
 		ConstLabels: map[string]string{"build": common.COMMIT, "version": common.GetAppVersion().String()},
 	}, func() float64 { return float64(getBuildTimestamp(common.BUILDDATE)) })
 
+	// IsDrandNode is 1 for drand nodes, 0 for relays
+	IsDrandNode = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "is_drand_node",
+		Help: "1 for drand nodes, 0 for relays",
+	})
+
 	metricsBound = false
 )
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -179,14 +179,14 @@ var (
 		Name:        "dkg_state_change_timestamp",
 		Help:        "DKG state change timestamp in seconds since the Epoch",
 		ConstLabels: map[string]string{},
-	}, []string{"state", "beacon_id", "is_leader"})
+	}, []string{"dkg_state", "beacon_id", "is_leader"})
 
 	// reshareStateChangeTimestamp tracks reshare status changes
 	reshareStateChangeTimestamp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:        "reshare_state_change_timestamp",
 		Help:        "Reshare state change timestamp in seconds since the Epoch",
 		ConstLabels: map[string]string{},
-	}, []string{"state", "beacon_id", "is_leader"})
+	}, []string{"reshare_state", "beacon_id", "is_leader"})
 
 	// drandBuildTime emits the timestamp when the binary was built in Unix time.
 	drandBuildTime = prometheus.NewUntypedFunc(prometheus.UntypedOpts{


### PR DESCRIPTION
I noticed that when the node starts up no status is emitted until the moment that a DKG or Reshare starts. This fixes it, and adds a status for when the node shuts down.

Part of https://github.com/drand/drand/issues/941