### PR TITLE
Using - instead of + for pre-releases for docker compat

### DIFF
--- a/.github/workflows/publish_tagged.yaml
+++ b/.github/workflows/publish_tagged.yaml
@@ -4,12 +4,12 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+(\\+**)?"
+      - 'v*'
   release:
     types:
       - created
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+(\\+**)?"
+      - 'v*'
 
 jobs:
   tagged-deploy:

--- a/common/version.go
+++ b/common/version.go
@@ -57,7 +57,7 @@ func (v Version) ToProto() *pbcommon.NodeVersion {
 func (v Version) String() string {
 	pre := ""
 	if v.Prerelease != "" {
-		pre = "+"
+		pre = "-"
 	}
 	return fmt.Sprintf("%d.%d.%d%s%s", v.Major, v.Minor, v.Patch, pre, v.Prerelease)
 }

--- a/common/version_test.go
+++ b/common/version_test.go
@@ -29,7 +29,7 @@ func TestVersionStringPre(t *testing.T) {
 	}
 
 	actual := version.String()
-	expected := "1.2.3+pre"
+	expected := "1.2.3-pre"
 
 	if actual != expected {
 		t.Fatalf("Incorrect version string. Actual: %s, expected: %s", actual, expected)
@@ -62,7 +62,7 @@ func TestVersionCompatible(t *testing.T) {
 		Major:      1,
 		Minor:      2,
 		Patch:      3,
-		Prerelease: "+pre",
+		Prerelease: "pre",
 	}
 
 	version130 := Version{


### PR DESCRIPTION
Since docker images cannot be tagged using a tag name containing a "+", we can use it for our versions as well.