### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/chain/beacon/callbacks_test.go
+++ b/chain/beacon/callbacks_test.go
@@ -1,7 +1,6 @@
 package beacon
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -12,9 +11,7 @@ import (
 )
 
 func TestStoreCallback(t *testing.T) {
-	dir, err := os.MkdirTemp("", "*")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	bbstore, err := boltdb.NewBoltStore(dir, nil)
 	require.NoError(t, err)
 	cb := NewCallbackStore(bbstore)

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -135,8 +135,7 @@ type BeaconTest struct {
 }
 
 func NewBeaconTest(t *testing.T, n, thr int, period time.Duration, genesisTime int64, sch scheme.Scheme, beaconID string) *BeaconTest {
-	prefix, err := os.MkdirTemp(os.TempDir(), beaconID)
-	checkErr(err)
+	prefix := t.TempDir()
 	paths := createBoltStores(prefix, n)
 	shares, commits := dkgShares(t, n, thr)
 	privs, group := test.BatchIdentities(n, sch, beaconID)

--- a/chain/beacon/store_test.go
+++ b/chain/beacon/store_test.go
@@ -2,7 +2,6 @@ package beacon
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,9 +14,7 @@ import (
 func TestSchemeStore(t *testing.T) {
 	sch, _ := scheme.ReadSchemeByEnv()
 
-	dir, err := os.MkdirTemp("", "*")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	bstore, err := boltdb.NewBoltStore(dir, nil)
 	require.NoError(t, err)

--- a/chain/boltdb/store_test.go
+++ b/chain/boltdb/store_test.go
@@ -1,7 +1,6 @@
 package boltdb
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,9 +9,7 @@ import (
 )
 
 func TestStoreBoltOrder(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "drandtest*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	store, err := NewBoltStore(tmp, nil)
 	require.NoError(t, err)
 
@@ -47,9 +44,7 @@ func TestStoreBoltOrder(t *testing.T) {
 }
 
 func TestStoreBolt(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "bolttest*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	var sig1 = []byte{0x01, 0x02, 0x03}
 	var sig2 = []byte{0x02, 0x03, 0x04}

--- a/cmd/client/lib/cli_test.go
+++ b/cmd/client/lib/cli_test.go
@@ -113,14 +113,9 @@ func TestClientLibGroupConfJSON(t *testing.T) {
 	var b bytes.Buffer
 	info.ToJSON(&b, nil)
 
-	tmpDir, err := os.MkdirTemp(os.TempDir(), "drand")
-	if err != nil {
-		t.Fatal(err)
-	}
+	infoPath := filepath.Join(t.TempDir(), "info.json")
 
-	infoPath := filepath.Join(tmpDir, "info.json")
-
-	err = os.WriteFile(infoPath, b.Bytes(), 0644)
+	err := os.WriteFile(infoPath, b.Bytes(), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -218,9 +218,8 @@ func TestKeyGen(t *testing.T) {
 
 // tests valid commands and then invalid commands
 func TestStartAndStop(t *testing.T) {
-	tmpPath := path.Join(os.TempDir(), "drand")
-	os.Mkdir(tmpPath, 0o740)
-	defer os.RemoveAll(tmpPath)
+	tmpPath := t.TempDir()
+	os.Chmod(tmpPath, 0o740)
 
 	n := 5
 	sch := scheme.GetSchemeFromEnv()
@@ -259,9 +258,7 @@ func TestStartAndStop(t *testing.T) {
 func TestUtilCheck(t *testing.T) {
 	beaconID := test.GetBeaconIDFromEnv()
 
-	tmp, err := os.MkdirTemp("", "drand-cli-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	// try to generate a keypair and make it listen on another address
 	keyPort := test.FreePort()
@@ -789,9 +786,7 @@ func TestDrandStatus(t *testing.T) {
 func TestEmptyPortSelectionUsesDefaultDuringKeygen(t *testing.T) {
 	beaconID := test.GetBeaconIDFromEnv()
 
-	tmp, err := os.MkdirTemp("", "drand-cli-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	app := CLI()
 
 	// args are missing a port for the node address
@@ -805,9 +800,7 @@ func TestEmptyPortSelectionUsesDefaultDuringKeygen(t *testing.T) {
 func TestValidPortSelectionSucceedsDuringKeygen(t *testing.T) {
 	beaconID := test.GetBeaconIDFromEnv()
 
-	tmp, err := os.MkdirTemp("", "drand-cli-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	app := CLI()
 
 	args := []string{"drand", "generate-keypair", "--folder", tmp, "--id", beaconID, "127.0.0.1"}
@@ -905,8 +898,8 @@ func (d *drandInstance) run(t *testing.T, beaconID string) {
 func launchDrandInstances(t *testing.T, n int) ([]*drandInstance, string) {
 	beaconID := test.GetBeaconIDFromEnv()
 
-	tmpPath := path.Join(os.TempDir(), "drand")
-	os.Mkdir(tmpPath, 0o740)
+	tmpPath := t.TempDir()
+	os.Chmod(tmpPath, 0o740)
 	certsDir, err := ioutil.TempDir(tmpPath, "certs")
 	require.NoError(t, err)
 
@@ -960,9 +953,6 @@ func launchDrandInstances(t *testing.T, n int) ([]*drandInstance, string) {
 
 func TestSharingWithInvalidFlagCombos(t *testing.T) {
 	beaconID := test.GetBeaconIDFromEnv()
-	tmp, err := os.MkdirTemp("", "drand-cli-*")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmp)
 
 	// leader and connect flags can't be used together
 	share1 := []string{

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -103,11 +103,8 @@ func BatchNewDrand(t *testing.T, n int, insecure bool, sch scheme.Scheme, beacon
 	ports := test.Ports(n)
 	daemons = make([]*DrandDaemon, n)
 	drands = make([]*BeaconProcess, n)
-	tmp := os.TempDir()
 
-	dir, err := os.MkdirTemp(tmp, "drand")
-	dir = path.Join(dir, common.MultiBeaconFolder)
-	assert.NoError(t, err)
+	dir = path.Join(t.TempDir(), common.MultiBeaconFolder)
 
 	certPaths = make([]string, n)
 	keyPaths := make([]string, n)

--- a/lp2p/client/client_test.go
+++ b/lp2p/client/client_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -36,14 +35,8 @@ func TestGRPCClientTestFunc(t *testing.T) {
 	go grpcLis.Start()
 	defer grpcLis.Stop(context.Background())
 
-	dataDir, err := os.MkdirTemp(os.TempDir(), "test-gossip-relay-node-datastore")
-	if err != nil {
-		t.Fatal(err)
-	}
-	identityDir, err := os.MkdirTemp(os.TempDir(), "test-gossip-relay-node-id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dataDir := t.TempDir()
+	identityDir := t.TempDir()
 
 	infoProto, err := svc.ChainInfo(context.Background(), nil)
 	if err != nil {
@@ -72,7 +65,7 @@ func TestGRPCClientTestFunc(t *testing.T) {
 	defer g.Shutdown()
 
 	// start client
-	c, err := newTestClient("test-gossip-relay-client", g.Multiaddrs(), info)
+	c, err := newTestClient(t, g.Multiaddrs(), info)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,14 +115,8 @@ func HTTPClientTestFunc(t *testing.T) {
 	addr, chainInfo, stop, emit := httpmock.NewMockHTTPPublicServer(t, false, sch)
 	defer stop()
 
-	dataDir, err := os.MkdirTemp(os.TempDir(), "test-gossip-relay-node-datastore")
-	if err != nil {
-		t.Fatal(err)
-	}
-	identityDir, err := os.MkdirTemp(os.TempDir(), "test-gossip-relay-node-id")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dataDir := t.TempDir()
+	identityDir := t.TempDir()
 
 	httpClient, err := dhttp.New("http://"+addr, chainInfo.Hash(), http.DefaultTransport)
 	if err != nil {
@@ -150,7 +137,7 @@ func HTTPClientTestFunc(t *testing.T) {
 	}
 	defer g.Shutdown()
 
-	c, err := newTestClient("test-http-gossip-relay-client", g.Multiaddrs(), chainInfo)
+	c, err := newTestClient(t, g.Multiaddrs(), chainInfo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,15 +165,9 @@ func HTTPClientTestFunc(t *testing.T) {
 	drain(t, ch, 10*time.Second)
 }
 
-func newTestClient(name string, relayMultiaddr []ma.Multiaddr, info *chain.Info) (*Client, error) {
-	dataDir, err := os.MkdirTemp(os.TempDir(), "client-"+name+"-datastore")
-	if err != nil {
-		return nil, err
-	}
-	identityDir, err := os.MkdirTemp(os.TempDir(), "client-"+name+"-id")
-	if err != nil {
-		return nil, err
-	}
+func newTestClient(t *testing.T, relayMultiaddr []ma.Multiaddr, info *chain.Info) (*Client, error) {
+	dataDir := t.TempDir()
+	identityDir := t.TempDir()
 	ds, err := bds.NewDatastore(dataDir, nil)
 	if err != nil {
 		return nil, err

--- a/lp2p/ctor_test.go
+++ b/lp2p/ctor_test.go
@@ -2,7 +2,6 @@ package lp2p
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"testing"
 
@@ -10,10 +9,7 @@ import (
 )
 
 func TestCreateThenLoadPrivKey(t *testing.T) {
-	dir, err := os.MkdirTemp(os.TempDir(), "test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	// should not exist yet...
 	identityPath := path.Join(dir, "identify.key")
@@ -35,10 +31,7 @@ func TestCreateThenLoadPrivKey(t *testing.T) {
 }
 
 func TestCreatePrivKeyMkdirp(t *testing.T) {
-	dir, err := os.MkdirTemp(os.TempDir(), "test")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	// should not exist yet and has an intermediate dir that does not exist
 	identityPath := path.Join(dir, "not-exists-dir", "identify.key")

--- a/lp2p/relaynode_test.go
+++ b/lp2p/relaynode_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"os"
 	"path"
 	"sync"
 	"testing"
@@ -59,15 +58,6 @@ func toRandomDataChain(results ...mock.Result) []client.RandomData {
 	return randomness
 }
 
-func tmpDir(t *testing.T) string {
-	t.Helper()
-	dir, err := os.MkdirTemp(os.TempDir(), "test-gossip-relay-node-datastore")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return dir
-}
-
 func TestWatchRetryOnClose(t *testing.T) {
 	chainInfo := &chain.Info{
 		Period:      time.Second,
@@ -99,10 +89,7 @@ func TestWatchRetryOnClose(t *testing.T) {
 
 	c := &mockClient{chainInfo, watchF}
 
-	td := tmpDir(t)
-	defer func() {
-		_ = os.RemoveAll(td)
-	}()
+	td := t.TempDir()
 	gr, err := NewGossipRelayNode(log.DefaultLogger(), &GossipRelayConfig{
 		ChainHash:    hex.EncodeToString(chainInfo.Hash()),
 		Addr:         "/ip4/0.0.0.0/tcp/0",

--- a/net/control_test.go
+++ b/net/control_test.go
@@ -1,7 +1,6 @@
 package net
 
 import (
-	"os"
 	"runtime"
 	"testing"
 
@@ -28,11 +27,7 @@ func TestControlUnix(t *testing.T) {
 		t.Skip("Platform does not support unix.")
 	}
 
-	name, err := os.MkdirTemp("", "unixtxt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(name)
+	name := t.TempDir()
 	s := testnet.EmptyServer{}
 	service, err := NewTCPGrpcControlListener(&s, "unix://"+name+"/sock")
 


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := os.MkdirTemp("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmp)

	// now
	tmpDir := t.TempDir()
}
```