### PR TITLE
fail beaconID reads for unknown chain hashes

### DIFF
--- a/core/drand_daemon_helper.go
+++ b/core/drand_daemon_helper.go
@@ -28,6 +28,8 @@ func (dd *DrandDaemon) readBeaconID(metadata *protoCommon.Metadata) (string, err
 
 			// set beacon id found from chain hash on message to make it available for everyone
 			metadata.BeaconID = beaconIDByHash
+		} else {
+			return "", fmt.Errorf("unknown chain hash: %s", chainHashHex)
 		}
 	}
 


### PR DESCRIPTION
if the daemon got a grpc request specifying a chain hash, but didn't recognize it, it would go on with the default beacon. it should fail those requests.