### PR TITLE
revert relay to using a single command to make sure grpc endpoint is parsed correctly.

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/hex"
-	"flag"
 	"fmt"
 	"net"
 	"net/http"
@@ -81,28 +80,21 @@ func Relay(c *cli.Context) error {
 	}
 
 	for hash := range hashesMap {
-		fs := flag.NewFlagSet(fmt.Sprintf("sub-client %s", hash), flag.ContinueOnError)
-		for _, f := range c.App.Flags {
-			if err := f.Apply(fs); err != nil {
-				return fmt.Errorf("failed to transfer flag: %w", err)
-			}
-		}
-		subC := cli.NewContext(c.App, fs, c)
-
+		// todo: don't reuse 'c'
 		if hash != common.DefaultChainHash {
 			if _, err := hex.DecodeString(hash); err != nil {
 				return fmt.Errorf("failed to decode chain hash value: %w", err)
 			}
-			if err := subC.Set(lib.HashFlag.Name, hash); err != nil {
+			if err := c.Set(lib.HashFlag.Name, hash); err != nil {
 				return fmt.Errorf("failed to initiate chain hash handler: %w", err)
 			}
 		} else {
-			if err := subC.Set(lib.HashFlag.Name, ""); err != nil {
+			if err := c.Set(lib.HashFlag.Name, ""); err != nil {
 				return fmt.Errorf("failed to initiate default chain hash handler: %w", err)
 			}
 		}
 
-		subCli, err := lib.Create(subC, c.IsSet(metricsFlag.Name))
+		subCli, err := lib.Create(c, c.IsSet(metricsFlag.Name))
 		if err != nil {
 			return err
 		}

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -45,7 +45,7 @@ var metricsFlag = &cli.StringFlag{
 }
 
 // Relay a GRPC connection to an HTTP server.
-// nolint:gocyclo,funlen
+// nolint:gocyclo
 func Relay(c *cli.Context) error {
 	version := common.GetAppVersion()
 

--- a/core/drand_daemon_helper.go
+++ b/core/drand_daemon_helper.go
@@ -29,7 +29,7 @@ func (dd *DrandDaemon) readBeaconID(metadata *protoCommon.Metadata) (string, err
 			// set beacon id found from chain hash on message to make it available for everyone
 			metadata.BeaconID = beaconIDByHash
 		} else {
-			return "", fmt.Errorf("unknown chain hash: %s", chainHashHex)
+			return "", fmt.Errorf("unknown chain hash: %s", chainHash)
 		}
 	}
 


### PR DESCRIPTION
* print out hex of passed in hash
* use the same cli.Context to make sure args are passed through