### PR TITLE
Streamline BeaconID and metadata in beaconProcess

### DIFF
--- a/chain/beacon/cache.go
+++ b/chain/beacon/cache.go
@@ -18,15 +18,13 @@ type partialCache struct {
 	rounds map[string]*roundCache
 	rcvd   map[int][]string
 	l      log.Logger
-	id     string
 }
 
-func newPartialCache(l log.Logger, id string) *partialCache {
+func newPartialCache(l log.Logger) *partialCache {
 	return &partialCache{
 		rounds: make(map[string]*roundCache),
 		rcvd:   make(map[int][]string),
 		l:      l,
-		id:     id,
 	}
 }
 

--- a/chain/beacon/cache_test.go
+++ b/chain/beacon/cache_test.go
@@ -60,7 +60,7 @@ func TestCacheRound(t *testing.T) {
 
 func TestCachePartial(t *testing.T) {
 	l := log.DefaultLogger()
-	cache := newPartialCache(l, "test_id")
+	cache := newPartialCache(l)
 	var round uint64 = 64
 	prev := []byte("yesterday was another day")
 

--- a/chain/beacon/chain.go
+++ b/chain/beacon/chain.go
@@ -58,7 +58,6 @@ func newChainStore(l log.Logger, cf *Config, cl net.ProtocolClient, c *cryptoSto
 		Client:   cl,
 		Clock:    cf.Clock,
 		NodeAddr: cf.Public.Address(),
-		BeaconID: cf.Group.ID,
 	})
 	go syncm.Run()
 

--- a/chain/beacon/chain.go
+++ b/chain/beacon/chain.go
@@ -108,13 +108,12 @@ var partialCacheStoreLimit = 3
 // runAggregator runs a continuous loop that tries to aggregate partial
 // signatures when it can
 func (c *chainStore) runAggregator() {
-	beaconID := c.conf.Group.ID
 	lastBeacon, err := c.Last()
 	if err != nil {
 		c.l.Fatalw("", "chain_aggregator", "loading", "last_beacon", err)
 	}
 
-	var cache = newPartialCache(c.l, beaconID)
+	var cache = newPartialCache(c.l)
 	for {
 		select {
 		case <-c.done:

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -358,7 +358,7 @@ func (h *Handler) broadcastNextPartial(current roundInfo, upon *chain.Beacon) {
 	ctx := context.Background()
 	previousSig := upon.Signature
 	round := upon.Round + 1
-	beaconID := h.conf.Group.ID
+	beaconID := commonutils.GetCorrectBeaconID(h.conf.Group.ID)
 	if current.round == upon.Round {
 		// we already have the beacon of the current round for some reasons - on
 		// CI it happens due to time shifts -

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -120,7 +120,7 @@ func (h *Handler) ProcessPartialBeacon(c context.Context, p *proto.PartialBeacon
 	if idx < 0 {
 		return nil, fmt.Errorf("invalid index %d in partial with msg %v", idx, msg)
 	}
-	nodeName := h.crypto.GetGroup().Node(uint32(idx)).Identity.Address()
+	nodeName := h.crypto.GetGroup().Node(uint32(idx)).Address()
 	// verify if request is valid
 	if err := key.Scheme.VerifyPartial(h.crypto.GetPub(), msg, p.GetPartialSig()); err != nil {
 		h.l.Errorw("",
@@ -358,7 +358,7 @@ func (h *Handler) broadcastNextPartial(current roundInfo, upon *chain.Beacon) {
 	ctx := context.Background()
 	previousSig := upon.Signature
 	round := upon.Round + 1
-	beaconID := commonutils.GetCorrectBeaconID(h.conf.Group.ID)
+	beaconID := commonutils.GetCanonicalBeaconID(h.conf.Group.ID)
 	if current.round == upon.Round {
 		// we already have the beacon of the current round for some reasons - on
 		// CI it happens due to time shifts -

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -421,7 +421,7 @@ func (h *Handler) Stop() {
 
 	h.stopped = true
 	h.running = false
-	h.l.Infow("", "beacon", "stop")
+	h.l.Infow("beacon handler stopped", "time", h.conf.Clock.Now())
 }
 
 // StopAt will stop the handler at the given time. It is useful when

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -399,7 +399,7 @@ func TestBeaconSync(t *testing.T) {
 
 	genesisOffset := 2 * time.Second
 	genesisTime := clock.NewFakeClock().Now().Add(genesisOffset).Unix()
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	bt := NewBeaconTest(t, n, thr, period, genesisTime, sch, beaconID)
 	defer bt.CleanUp()
@@ -478,7 +478,7 @@ func TestBeaconSimple(t *testing.T) {
 	period := 2 * time.Second
 
 	genesisTime := clock.NewFakeClock().Now().Unix() + 2
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	bt := NewBeaconTest(t, n, thr, period, genesisTime, sch, beaconID)
 	defer bt.CleanUp()
@@ -539,7 +539,7 @@ func TestBeaconThreshold(t *testing.T) {
 
 	offsetGenesis := 2 * time.Second
 	genesisTime := clock.NewFakeClock().Now().Add(offsetGenesis).Unix()
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	bt := NewBeaconTest(t, n, thr, period, genesisTime, sch, beaconID)
 	defer func() { go bt.CleanUp() }()

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -115,7 +115,7 @@ func (d *discrepancyStore) Put(b *chain.Beacon) error {
 		return err
 	}
 
-	beaconID := common.GetCorrectBeaconID(d.group.ID)
+	beaconID := common.GetCanonicalBeaconID(d.group.ID)
 
 	actual := d.clock.Now().UnixNano()
 	expected := chain.TimeOfRound(d.group.Period, d.group.GenesisTime, b.Round) * 1e9

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -115,10 +115,7 @@ func (d *discrepancyStore) Put(b *chain.Beacon) error {
 		return err
 	}
 
-	beaconID := d.group.ID
-	if beaconID == "" {
-		beaconID = common.DefaultBeaconID
-	}
+	beaconID := common.GetCorrectBeaconID(d.group.ID)
 
 	actual := d.clock.Now().UnixNano()
 	expected := chain.TimeOfRound(d.group.Period, d.group.GenesisTime, b.Round) * 1e9

--- a/chain/beacon/sync_manager.go
+++ b/chain/beacon/sync_manager.go
@@ -59,7 +59,6 @@ type SyncConfig struct {
 	Store    chain.Store
 	Info     *chain.Info
 	NodeAddr string
-	BeaconID string
 }
 
 // NewSyncManager returns a sync manager that will use the given store to store

--- a/chain/beacon/sync_manager.go
+++ b/chain/beacon/sync_manager.go
@@ -106,6 +106,11 @@ func (s *SyncManager) RequestSync(nodes []net.Peer, upTo uint64) {
 }
 
 func (s *SyncManager) Run() {
+	// no need to sync until genesis time
+	for time.Now().Unix() < s.info.GenesisTime {
+		s.log.Info("waiting for genesis")
+		time.Sleep(s.period)
+	}
 	// tracks the time of the last round we successfully synced
 	lastRoundTime := 0
 	// the context being used by the current sync process

--- a/chain/beacon/sync_manager.go
+++ b/chain/beacon/sync_manager.go
@@ -211,7 +211,7 @@ func (s *SyncManager) tryNode(global context.Context, upTo uint64, peer net.Peer
 			// Check if we got the right packet
 			metadata := beaconPacket.GetMetadata()
 			if metadata != nil && metadata.BeaconID != s.info.ID {
-				logger.Debugw("wrong beaconID", "expected", s.info.ID, "got", metadata.BeaconID)
+				logger.Errorw("wrong beaconID", "expected", s.info.ID, "got", metadata.BeaconID)
 				return false
 			}
 
@@ -277,7 +277,7 @@ func SyncChain(l log.Logger, store CallbackStore, req SyncRequest, stream SyncSt
 		return fmt.Errorf("no metadata in sync request")
 	}
 
-	// NB: this can never be undefined with our current implementation
+	// this can never be "" at this point, since we set it at the daemon level
 	beaconID := req.GetMetadata().GetBeaconID()
 
 	l.Debugw("Starting SyncChain", "syncer", "sync_request", "from", addr, "from_round", fromRound, "beaconID", beaconID)

--- a/chain/beacon/sync_manager.go
+++ b/chain/beacon/sync_manager.go
@@ -107,9 +107,8 @@ func (s *SyncManager) RequestSync(nodes []net.Peer, upTo uint64) {
 
 func (s *SyncManager) Run() {
 	// no need to sync until genesis time
-	for time.Now().Unix() < s.info.GenesisTime {
-		s.log.Info("waiting for genesis")
-		time.Sleep(s.period)
+	for s.clock.Now().Unix() < s.info.GenesisTime {
+		time.Sleep(time.Second)
 	}
 	// tracks the time of the last round we successfully synced
 	lastRoundTime := 0

--- a/chain/info.go
+++ b/chain/info.go
@@ -74,7 +74,7 @@ func (c *Info) Equal(c2 *Info) bool {
 		c.Period == c2.Period &&
 		c.PublicKey.Equal(c2.PublicKey) &&
 		bytes.Equal(c.GenesisSeed, c2.GenesisSeed) &&
-		c.ID == c2.ID
+		common.CompareBeaconIDs(c.ID, c2.ID)
 }
 
 // Verifier returns the verifier used to verify the beacon produced by this

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -760,7 +760,7 @@ func checkConnection(c *cli.Context) error {
 		for _, id := range group.Nodes {
 			names = append(names, id.Address())
 		}
-		beaconID = group.ID
+		beaconID = common.GetCorrectBeaconID(group.ID)
 	} else if c.Args().Present() {
 		for _, serverAddr := range c.Args().Slice() {
 			_, _, err := gonet.SplitHostPort(serverAddr)
@@ -769,7 +769,7 @@ func checkConnection(c *cli.Context) error {
 			}
 			names = append(names, serverAddr)
 		}
-		beaconID = c.String(beaconIDFlag.Name)
+		beaconID = common.GetCorrectBeaconID(c.String(beaconIDFlag.Name))
 	} else {
 		return fmt.Errorf("drand: check-group expects a list of identities or %s flag", groupFlag.Name)
 	}
@@ -1013,9 +1013,7 @@ func testEmptyGroup(filePath string) error {
 }
 
 func getBeaconID(c *cli.Context) string {
-	beaconID := c.String(beaconIDFlag.Name)
-
-	return common.GetCorrectBeaconID(beaconID)
+	return common.GetCorrectBeaconID(c.String(beaconIDFlag.Name))
 }
 
 func getDBStoresPaths(c *cli.Context) (map[string]string, error) {

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -760,7 +760,7 @@ func checkConnection(c *cli.Context) error {
 		for _, id := range group.Nodes {
 			names = append(names, id.Address())
 		}
-		beaconID = common.GetCorrectBeaconID(group.ID)
+		beaconID = common.GetCanonicalBeaconID(group.ID)
 	} else if c.Args().Present() {
 		for _, serverAddr := range c.Args().Slice() {
 			_, _, err := gonet.SplitHostPort(serverAddr)
@@ -769,7 +769,7 @@ func checkConnection(c *cli.Context) error {
 			}
 			names = append(names, serverAddr)
 		}
-		beaconID = common.GetCorrectBeaconID(c.String(beaconIDFlag.Name))
+		beaconID = common.GetCanonicalBeaconID(c.String(beaconIDFlag.Name))
 	} else {
 		return fmt.Errorf("drand: check-group expects a list of identities or %s flag", groupFlag.Name)
 	}
@@ -1013,7 +1013,7 @@ func testEmptyGroup(filePath string) error {
 }
 
 func getBeaconID(c *cli.Context) string {
-	return common.GetCorrectBeaconID(c.String(beaconIDFlag.Name))
+	return common.GetCanonicalBeaconID(c.String(beaconIDFlag.Name))
 }
 
 func getDBStoresPaths(c *cli.Context) (map[string]string, error) {

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -1014,11 +1014,8 @@ func testEmptyGroup(filePath string) error {
 
 func getBeaconID(c *cli.Context) string {
 	beaconID := c.String(beaconIDFlag.Name)
-	if beaconID == "" {
-		beaconID = common.DefaultBeaconID
-	}
 
-	return beaconID
+	return common.GetCorrectBeaconID(beaconID)
 }
 
 func getDBStoresPaths(c *cli.Context) (map[string]string, error) {

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -64,7 +64,7 @@ func TestMigrate(t *testing.T) {
 }
 
 func TestResetError(t *testing.T) {
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	tmp := getSBFolderStructure()
 	defer os.RemoveAll(tmp)
@@ -75,7 +75,7 @@ func TestResetError(t *testing.T) {
 }
 
 func TestDeleteBeaconError(t *testing.T) {
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	tmp := getSBFolderStructure()
 	defer os.RemoveAll(tmp)
@@ -87,7 +87,7 @@ func TestDeleteBeaconError(t *testing.T) {
 }
 
 func TestDeleteBeacon(t *testing.T) {
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	tmp := path.Join(os.TempDir(), "drand")
 	defer os.RemoveAll(tmp)
@@ -141,7 +141,7 @@ func TestDeleteBeacon(t *testing.T) {
 }
 
 func TestKeySelfSignError(t *testing.T) {
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	tmp := getSBFolderStructure()
 	defer os.RemoveAll(tmp)
@@ -152,7 +152,7 @@ func TestKeySelfSignError(t *testing.T) {
 }
 
 func TestKeySelfSign(t *testing.T) {
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	tmp := path.Join(os.TempDir(), "drand")
 	defer os.RemoveAll(tmp)
@@ -179,7 +179,7 @@ func TestKeySelfSign(t *testing.T) {
 }
 
 func TestKeyGenError(t *testing.T) {
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	tmp := getSBFolderStructure()
 	defer os.RemoveAll(tmp)
@@ -190,7 +190,7 @@ func TestKeyGenError(t *testing.T) {
 }
 
 func TestKeyGen(t *testing.T) {
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	tmp := path.Join(os.TempDir(), "drand")
 	defer os.RemoveAll(tmp)
@@ -225,7 +225,7 @@ func TestStartAndStop(t *testing.T) {
 
 	n := 5
 	sch := scheme.GetSchemeFromEnv()
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	_, group := test.BatchIdentities(n, sch, beaconID)
 	groupPath := path.Join(tmpPath, "group.toml")
@@ -258,7 +258,7 @@ func TestStartAndStop(t *testing.T) {
 }
 
 func TestUtilCheck(t *testing.T) {
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	tmp, err := os.MkdirTemp("", "drand-cli-*")
 	require.NoError(t, err)
@@ -307,7 +307,7 @@ func TestUtilCheck(t *testing.T) {
 //nolint:funlen
 func TestStartWithoutGroup(t *testing.T) {
 	sch := scheme.GetSchemeFromEnv()
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	tmpPath := path.Join(os.TempDir(), "drand")
 	os.Mkdir(tmpPath, 0740)
@@ -521,7 +521,7 @@ func testListSchemes(t *testing.T, ctrlPort string) {
 
 func TestClientTLS(t *testing.T) {
 	sch := scheme.GetSchemeFromEnv()
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	tmpPath := path.Join(os.TempDir(), "drand")
 	os.Mkdir(tmpPath, 0740)
@@ -679,13 +679,7 @@ func TestDrandListSchemes(t *testing.T) {
 
 func TestDrandReloadBeacon(t *testing.T) {
 	sch := scheme.GetSchemeFromEnv()
-	beaconID := common.GetBeaconIDFromEnv()
-
-	// beacon id need to have a value in order to stop one beacon process
-	// if beacon id is empty, the id will be "default" internally
-	if beaconID == "" {
-		beaconID = common.DefaultBeaconID
-	}
+	beaconID := test.GetBeaconIDFromEnv()
 
 	n := 4
 	instances, tempPath := launchDrandInstances(t, n)
@@ -878,7 +872,7 @@ func (d *drandInstance) run(t *testing.T, beaconID string) {
 
 //nolint: gocritic
 func launchDrandInstances(t *testing.T, n int) ([]*drandInstance, string) {
-	beaconID := common.GetBeaconIDFromEnv()
+	beaconID := test.GetBeaconIDFromEnv()
 
 	tmpPath := path.Join(os.TempDir(), "drand")
 	os.Mkdir(tmpPath, 0740)

--- a/cmd/drand-cli/control.go
+++ b/cmd/drand-cli/control.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/drand/drand/common"
+
 	"github.com/drand/drand/core/migration"
 
 	"github.com/drand/drand/common/scheme"
@@ -124,7 +126,7 @@ func shareCmd(c *cli.Context) error {
 		return fmt.Errorf("could not create client: %w", err)
 	}
 
-	beaconID := c.String(beaconIDFlag.Name)
+	beaconID := getBeaconID(c)
 
 	fmt.Fprintf(output, "Participating to the setup of the DKG. Beacon ID: [%s] \n", beaconID)
 	groupP, shareErr := ctrlClient.InitDKG(connectPeer, args.entropy, args.secret, beaconID)
@@ -185,7 +187,7 @@ func leadShareCmd(c *cli.Context) error {
 		offset = c.Int(beaconOffset.Name)
 	}
 
-	beaconID := c.String(beaconIDFlag.Name)
+	beaconID := getBeaconID(c)
 
 	str1 := fmt.Sprintf("Initiating the DKG as a leader. Beacon ID: [%s]", beaconID)
 
@@ -250,7 +252,7 @@ func reshareCmd(c *cli.Context) error {
 		return fmt.Errorf("could not create client: %w", err)
 	}
 
-	beaconID := c.String(beaconIDFlag.Name)
+	beaconID := getBeaconID(c)
 
 	// resharing case needs the previous group
 	var oldPath string
@@ -269,7 +271,7 @@ func reshareCmd(c *cli.Context) error {
 			return fmt.Errorf("beacon id flag is not required when using --%s", oldGroupFlag.Name)
 		}
 
-		beaconID = oldGroup.ID
+		beaconID = common.GetCorrectBeaconID(oldGroup.ID)
 	}
 
 	fmt.Fprintf(output, "Participating to the resharing. Beacon ID: [%s] \n", beaconID)
@@ -306,7 +308,7 @@ func leadReshareCmd(c *cli.Context) error {
 		return fmt.Errorf("could not create client: %w", err)
 	}
 
-	beaconID := c.String(beaconIDFlag.Name)
+	beaconID := getBeaconID(c)
 
 	// resharing case needs the previous group
 	var oldPath string
@@ -324,7 +326,7 @@ func leadReshareCmd(c *cli.Context) error {
 			return fmt.Errorf("beacon id flag is not required when using --%s", oldGroupFlag.Name)
 		}
 
-		beaconID = oldGroup.ID
+		beaconID = common.GetCorrectBeaconID(oldGroup.ID)
 	}
 
 	offset := int(core.DefaultResharingOffset.Seconds())
@@ -723,7 +725,7 @@ func followCmd(c *cli.Context) error {
 		addrs,
 		!c.Bool(insecureFlag.Name),
 		uint64(c.Int(upToFlag.Name)),
-		c.String(beaconIDFlag.Name))
+		getBeaconID(c))
 
 	if err != nil {
 		return fmt.Errorf("error asking to follow chain: %w", err)

--- a/cmd/drand-cli/control.go
+++ b/cmd/drand-cli/control.go
@@ -271,7 +271,7 @@ func reshareCmd(c *cli.Context) error {
 			return fmt.Errorf("beacon id flag is not required when using --%s", oldGroupFlag.Name)
 		}
 
-		beaconID = common.GetCorrectBeaconID(oldGroup.ID)
+		beaconID = common.GetCanonicalBeaconID(oldGroup.ID)
 	}
 
 	fmt.Fprintf(output, "Participating to the resharing. Beacon ID: [%s] \n", beaconID)
@@ -326,7 +326,7 @@ func leadReshareCmd(c *cli.Context) error {
 			return fmt.Errorf("beacon id flag is not required when using --%s", oldGroupFlag.Name)
 		}
 
-		beaconID = common.GetCorrectBeaconID(oldGroup.ID)
+		beaconID = common.GetCanonicalBeaconID(oldGroup.ID)
 	}
 
 	offset := int(core.DefaultResharingOffset.Seconds())

--- a/cmd/drand-cli/public.go
+++ b/cmd/drand-cli/public.go
@@ -135,7 +135,7 @@ func getChainInfo(c *cli.Context) error {
 			addr, err)
 	}
 	if ci == nil {
-		return errors.New("drand: can't retrieve dist. key from all nodes")
+		return errors.New("drand: can't retrieve dist. key from any nodes")
 	}
 	return printChainInfo(c, ci)
 }

--- a/common/beacon.go
+++ b/common/beacon.go
@@ -9,7 +9,7 @@ const DefaultBeaconID = "default"
 // backward-compatibility reasons
 const DefaultChainHash = "default"
 
-// MultiBeaconFolder
+// MultiBeaconFolder is the name of the folder where the multi-beacon data is stored
 const MultiBeaconFolder = "multibeacon"
 
 // IsDefaultBeaconID indicates if the beacon id received is the default one or not.

--- a/common/beacon.go
+++ b/common/beacon.go
@@ -1,7 +1,5 @@
 package common
 
-import "os"
-
 // DefaultBeaconID is the value used when beacon id has an empty value. This
 // value should not be changed for backward-compatibility reasons
 const DefaultBeaconID = "default"
@@ -13,12 +11,6 @@ const DefaultChainHash = "default"
 
 // MultiBeaconFolder
 const MultiBeaconFolder = "multibeacon"
-
-// GetBeaconIDFromEnv read beacon id from an environmental variable.
-// It is used for testing purpose.
-func GetBeaconIDFromEnv() string {
-	return os.Getenv("BEACON_ID")
-}
 
 // IsDefaultBeaconID indicates if the beacon id received is the default one or not.
 // There is a direct relationship between an empty string and the reserved id "default".
@@ -40,4 +32,12 @@ func CompareBeaconIDs(id1, id2 string) bool {
 	}
 
 	return true
+}
+
+// GetCorrectBeaconID returns the correct beacon id.
+func GetCorrectBeaconID(id string) string {
+	if IsDefaultBeaconID(id) {
+		return DefaultBeaconID
+	}
+	return id
 }

--- a/common/beacon.go
+++ b/common/beacon.go
@@ -34,8 +34,8 @@ func CompareBeaconIDs(id1, id2 string) bool {
 	return true
 }
 
-// GetCorrectBeaconID returns the correct beacon id.
-func GetCorrectBeaconID(id string) string {
+// GetCanonicalBeaconID returns the correct beacon id.
+func GetCanonicalBeaconID(id string) string {
 	if IsDefaultBeaconID(id) {
 		return DefaultBeaconID
 	}

--- a/core/broadcast_test.go
+++ b/core/broadcast_test.go
@@ -67,7 +67,6 @@ func TestBroadcastSet(t *testing.T) {
 func TestBroadcast(t *testing.T) {
 	n := 5
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
-
 	_, drands, group, dir, _ := BatchNewDrand(t, n, true, sch, beaconID)
 	defer os.RemoveAll(dir)
 	defer CloseAllDrands(drands)
@@ -100,7 +99,7 @@ func TestBroadcast(t *testing.T) {
 		for i := 0; i < exp; i++ {
 			select {
 			case info := <-incPackets:
-				t.Logf("received packet from %s", info.id)
+				t.Logf("received packet from %s, %d out of %d", info.id, i, exp)
 				received[info.id] = true
 			case <-time.After(5 * time.Second):
 				require.True(t, false, "test failed to continue")

--- a/core/broadcast_test.go
+++ b/core/broadcast_test.go
@@ -6,15 +6,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/drand/drand/common"
-
-	"github.com/drand/drand/common/scheme"
-	"github.com/drand/drand/key"
-	"github.com/drand/drand/protobuf/drand"
 	"github.com/drand/kyber"
 	"github.com/drand/kyber/share/dkg"
 	"github.com/drand/kyber/util/random"
 	"github.com/stretchr/testify/require"
+
+	"github.com/drand/drand/common"
+	"github.com/drand/drand/common/scheme"
+	"github.com/drand/drand/key"
+	"github.com/drand/drand/protobuf/drand"
+	"github.com/drand/drand/test"
 )
 
 type packInfo struct {
@@ -65,7 +66,7 @@ func TestBroadcastSet(t *testing.T) {
 
 func TestBroadcast(t *testing.T) {
 	n := 5
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	_, drands, group, dir, _ := BatchNewDrand(t, n, true, sch, beaconID)
 	defer os.RemoveAll(dir)
@@ -99,6 +100,7 @@ func TestBroadcast(t *testing.T) {
 		for i := 0; i < exp; i++ {
 			select {
 			case info := <-incPackets:
+				t.Logf("received packet from %s", info.id)
 				received[info.id] = true
 			case <-time.After(5 * time.Second):
 				require.True(t, false, "test failed to continue")

--- a/core/client_public.go
+++ b/core/client_public.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/drand/drand/protobuf/common"
 
@@ -57,15 +58,16 @@ func (c *Client) Private(id *key.Identity) ([]byte, error) {
 	ephPoint := key.KeyGroup.Point().Mul(ephScalar, nil)
 	ephBuff, err := ephPoint.MarshalBinary()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to marshal ephemeral point: %w", err)
 	}
 	obj, err := ecies.Encrypt(key.KeyGroup, id.Key, ephBuff, EciesHash)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to encrypt ephemeral key: %w", err)
 	}
-	resp, err := c.client.PrivateRand(context.TODO(), id, &drand.PrivateRandRequest{Request: obj})
+	resp, err := c.client.PrivateRand(context.TODO(), id,
+		&drand.PrivateRandRequest{Request: obj, Metadata: &common.Metadata{ChainHash: c.chainHash}})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get private rand: %w", err)
 	}
 	return ecies.Decrypt(key.KeyGroup, ephScalar, resp.GetResponse(), EciesHash)
 }

--- a/core/client_public.go
+++ b/core/client_public.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/drand/drand/protobuf/common"
+	"github.com/drand/kyber/encrypt/ecies"
+	"google.golang.org/grpc"
 
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/net"
+	"github.com/drand/drand/protobuf/common"
 	"github.com/drand/drand/protobuf/drand"
-	"github.com/drand/kyber/encrypt/ecies"
-	"google.golang.org/grpc"
 )
 
 // Client is the endpoint logic, communicating with drand servers

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -4,17 +4,15 @@ import (
 	"os"
 	"testing"
 
-	"github.com/drand/drand/common"
+	"github.com/stretchr/testify/require"
 
 	"github.com/drand/drand/common/scheme"
-	"github.com/stretchr/testify/require"
+	"github.com/drand/drand/test"
 )
 
 func TestClientPrivate(t *testing.T) {
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
-	if beaconID == "" {
-		beaconID = common.DefaultBeaconID
-	}
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
+
 	//nolint:dogsled
 	_, drands, _, dir, _ := BatchNewDrand(t, 1, false, sch, beaconID, WithPrivateRandomness())
 	defer CloseAllDrands(drands)

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -12,7 +12,9 @@ import (
 
 func TestClientPrivate(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
-
+	if beaconID == "" {
+		beaconID = common.DefaultBeaconID
+	}
 	//nolint:dogsled
 	_, drands, _, dir, _ := BatchNewDrand(t, 1, false, sch, beaconID, WithPrivateRandomness())
 	defer CloseAllDrands(drands)

--- a/core/config.go
+++ b/core/config.go
@@ -72,7 +72,7 @@ func (d *Config) ConfigFolderMB() string {
 // DBFolder returns the folder under which drand stores db file specifically.
 // If beacon id is empty, it will use the default value
 func (d *Config) DBFolder(beaconID string) string {
-	return path.Join(d.ConfigFolderMB(), common.GetCorrectBeaconID(beaconID), DefaultDBFolder)
+	return path.Join(d.ConfigFolderMB(), common.GetCanonicalBeaconID(beaconID), DefaultDBFolder)
 }
 
 // Certs returns all custom certs currently being trusted by drand.

--- a/core/config.go
+++ b/core/config.go
@@ -72,11 +72,7 @@ func (d *Config) ConfigFolderMB() string {
 // DBFolder returns the folder under which drand stores db file specifically.
 // If beacon id is empty, it will use the default value
 func (d *Config) DBFolder(beaconID string) string {
-	if beaconID == "" {
-		beaconID = common.DefaultBeaconID
-	}
-
-	return path.Join(d.ConfigFolderMB(), beaconID, DefaultDBFolder)
+	return path.Join(d.ConfigFolderMB(), common.GetCorrectBeaconID(beaconID), DefaultDBFolder)
 }
 
 // Certs returns all custom certs currently being trusted by drand.

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -361,6 +361,8 @@ func (bp *BeaconProcess) getBeaconID() string {
 
 // getChainHash return the HashChain in hex format as a string
 func (bp *BeaconProcess) getChainHash() string {
+	bp.state.Lock()
+	defer bp.state.Unlock()
 	if bp.group != nil {
 		info := chain.NewChainInfo(bp.group)
 		return info.HashString()

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -104,6 +104,8 @@ func NewBeaconProcess(log dlog.Logger, store key.Store, beaconID string, opts *C
 // pre-existing distributed share.
 // Returns 'true' if this BeaconProcess is a fresh run, returns 'false' otherwise
 func (bp *BeaconProcess) Load() (bool, error) {
+	bp.state.Lock()
+	defer bp.state.Unlock()
 	if bp.isFreshRun() {
 		return true, nil
 	}

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -114,6 +114,13 @@ func (bp *BeaconProcess) Load() (bool, error) {
 		return false, err
 	}
 
+	if bp.group != nil {
+		bp.state.Lock()
+		info := chain.NewChainInfo(bp.group)
+		bp.chainHash = info.Hash()
+		bp.state.Unlock()
+	}
+
 	checkGroup(bp.log, bp.group)
 	bp.share, err = bp.store.LoadShare()
 	if err != nil {

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -368,9 +368,10 @@ func (bp *BeaconProcess) getBeaconID() string {
 
 // getChainHash return the HashChain in hex format as a string
 func (bp *BeaconProcess) getChainHash() []byte {
-	bp.state.Lock()
-	defer bp.state.Unlock()
 	if len(bp.chainHash) == 0 && bp.group != nil {
+		// we only lock the state in the case it's not yet set and we set it since we only set it in Load() otherwise
+		bp.state.Lock()
+		defer bp.state.Unlock()
 		info := chain.NewChainInfo(bp.group)
 		bp.chainHash = info.Hash()
 	}

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -1154,6 +1154,7 @@ func (bp *BeaconProcess) StartFollowChain(req *drand.StartFollowRequest, stream 
 // chainInfoFromPeers attempts to fetch chain info from one of the passed peers.
 func chainInfoFromPeers(ctx context.Context, privGateway *net.PrivateGateway,
 	peers []net.Peer, l log.Logger, version commonutils.Version, beaconID string) (*chain.Info, error) {
+	// we first craft our request
 	request := new(drand.ChainInfoRequest)
 	request.Metadata = &common.Metadata{BeaconID: beaconID, NodeVersion: version.ToProto()}
 

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -113,7 +113,7 @@ func (bp *BeaconProcess) InitReshare(c context.Context, in *drand.InitResharePac
 		return nil, err
 	}
 
-	oldBeaconID := commonutils.GetCorrectBeaconID(oldGroup.ID)
+	oldBeaconID := commonutils.GetCanonicalBeaconID(oldGroup.ID)
 
 	if !commonutils.CompareBeaconIDs(oldBeaconID, bp.getBeaconID()) {
 		return nil, fmt.Errorf("beacon ID mismatch: "+
@@ -342,7 +342,7 @@ func (bp *BeaconProcess) leaderRunSetup(newSetup func(d *BeaconProcess) (*setupM
 // runDKG setups the proper structures and protocol to run the DKG and waits
 // until it finishes. If leader is true, this node sends the first packet.
 func (bp *BeaconProcess) runDKG(leader bool, group *key.Group, timeout uint32, randomness *drand.EntropyInfo) (*key.Group, error) {
-	beaconID := commonutils.GetCorrectBeaconID(group.ID)
+	beaconID := commonutils.GetCanonicalBeaconID(group.ID)
 
 	reader, user := extractEntropy(randomness)
 	config := &dkg.Config{
@@ -426,7 +426,7 @@ func (bp *BeaconProcess) cleanupDKG() {
 // first packet so other nodes will start as soon as they receive it.
 // nolint:funlen
 func (bp *BeaconProcess) runResharing(leader bool, oldGroup, newGroup *key.Group, timeout uint32) (*key.Group, error) {
-	oldBeaconID := commonutils.GetCorrectBeaconID(oldGroup.ID)
+	oldBeaconID := commonutils.GetCanonicalBeaconID(oldGroup.ID)
 
 	oldNode := oldGroup.Find(bp.priv.Public)
 	oldPresent := oldNode != nil

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/drand/kyber/encrypt/ecies"
+
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/chain/beacon"
 	"github.com/drand/drand/entropy"
@@ -13,7 +15,6 @@ import (
 	"github.com/drand/drand/net"
 	"github.com/drand/drand/protobuf/common"
 	"github.com/drand/drand/protobuf/drand"
-	"github.com/drand/kyber/encrypt/ecies"
 )
 
 // BroadcastDKG is the public method to call during a DKG protocol.
@@ -123,7 +124,7 @@ func (bp *BeaconProcess) PublicRandStream(req *drand.PublicRandRequest, stream d
 	proxyReq := &proxyRequest{
 		req,
 	}
-  // make sure we have the correct metadata
+	// make sure we have the correct metadata
 	proxyReq.Metadata = bp.newMetadata()
 	proxyStr := &proxyStream{stream}
 	bp.state.Unlock()
@@ -227,7 +228,7 @@ func (bp *BeaconProcess) SyncChain(req *drand.SyncRequest, stream drand.Protocol
 
 	if b == nil {
 		bp.log.Errorw("Received a SyncRequest, but no beacon handler is set yet", "request", req)
-    return fmt.Errorf("no beacon handler available")
+		return fmt.Errorf("no beacon handler available")
 	}
 
 	return beacon.SyncChain(bp.log, bp.beacon.Store(), req, stream)

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -115,7 +115,7 @@ func (p *proxyStream) Send(b *drand.BeaconPacket) error {
 // PublicRandStream exports a stream of new beacons as they are generated over gRPC
 func (bp *BeaconProcess) PublicRandStream(req *drand.PublicRandRequest, stream drand.Public_PublicRandStreamServer) error {
 	bp.state.Lock()
-	if bp.beacon == nil || bp.group == nil {
+	if bp.beacon == nil {
 		bp.state.Unlock()
 		return errors.New("beacon has not started on this node yet")
 	}
@@ -222,10 +222,6 @@ func (bp *BeaconProcess) SyncChain(req *drand.SyncRequest, stream drand.Protocol
 	bp.state.Lock()
 	b := bp.beacon
 	bp.state.Unlock()
-
-	// for compatibility with older nodes not sending properly the beaconID
-	req.Metadata = bp.newMetadata()
-
 	if b == nil {
 		bp.log.Errorw("Received a SyncRequest, but no beacon handler is set yet", "request", req)
 		return fmt.Errorf("no beacon handler available")

--- a/core/drand_daemon.go
+++ b/core/drand_daemon.go
@@ -154,6 +154,7 @@ func (dd *DrandDaemon) init() error {
 
 // InstantiateBeaconProcess creates a new BeaconProcess linked to beacon with id 'beaconID'
 func (dd *DrandDaemon) InstantiateBeaconProcess(beaconID string, store key.Store) (*BeaconProcess, error) {
+	beaconID = common.GetCorrectBeaconID(beaconID)
 	// we add the BeaconID to our logger's name. Notice the BeaconID never changes.
 	logger := dd.log.Named(beaconID)
 	bp, err := NewBeaconProcess(logger, store, beaconID, dd.opts, dd.privGateway, dd.pubGateway)

--- a/core/drand_daemon.go
+++ b/core/drand_daemon.go
@@ -62,10 +62,8 @@ func NewDrandDaemon(c *Config) (*DrandDaemon, error) {
 
 	// Add callback to register a new handler for http server after finishing DKG successfully
 	c.dkgCallback = func(share *key.Share, group *key.Group) {
-		beaconID := group.ID
-		if beaconID == "" {
-			beaconID = common.DefaultBeaconID
-		}
+		beaconID := common.GetCorrectBeaconID(group.ID)
+
 		drandDaemon.state.Lock()
 		bp, isPresent := drandDaemon.beaconProcesses[beaconID]
 		drandDaemon.state.Unlock()
@@ -182,9 +180,7 @@ func (dd *DrandDaemon) InstantiateBeaconProcess(beaconID string, store key.Store
 
 // RemoveBeaconProcess remove a BeaconProcess linked to beacon with id 'beaconID'
 func (dd *DrandDaemon) RemoveBeaconProcess(beaconID string, bp *BeaconProcess) {
-	if beaconID == "" {
-		beaconID = common.DefaultBeaconID
-	}
+	beaconID = common.GetCorrectBeaconID(beaconID)
 
 	chainHash := ""
 	if bp.group != nil {

--- a/core/drand_daemon.go
+++ b/core/drand_daemon.go
@@ -155,13 +155,9 @@ func (dd *DrandDaemon) init() error {
 
 // InstantiateBeaconProcess creates a new BeaconProcess linked to beacon with id 'beaconID'
 func (dd *DrandDaemon) InstantiateBeaconProcess(beaconID string, store key.Store) (*BeaconProcess, error) {
-	if beaconID == "" {
-		beaconID = common.DefaultBeaconID
-	}
-
 	// we add the BeaconID to our logger's name. Notice the BeaconID never changes.
 	logger := dd.log.Named(beaconID)
-	bp, err := NewBeaconProcess(logger, store, dd.opts, dd.privGateway, dd.pubGateway)
+	bp, err := NewBeaconProcess(logger, store, beaconID, dd.opts, dd.privGateway, dd.pubGateway)
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +241,7 @@ func (dd *DrandDaemon) RemoveBeaconHandler(beaconID string, bp *BeaconProcess) {
 	}
 }
 
-// LoadBeacons checks for existing stores and creates the corresponding BeaconProcess
+// LoadBeaconsFromDisk checks for existing stores and creates the corresponding BeaconProcess
 // accordingly to each stored BeaconID
 func (dd *DrandDaemon) LoadBeaconsFromDisk(metricsFlag string) error {
 	// Load possible existing stores

--- a/core/drand_daemon.go
+++ b/core/drand_daemon.go
@@ -62,7 +62,7 @@ func NewDrandDaemon(c *Config) (*DrandDaemon, error) {
 
 	// Add callback to register a new handler for http server after finishing DKG successfully
 	c.dkgCallback = func(share *key.Share, group *key.Group) {
-		beaconID := common.GetCorrectBeaconID(group.ID)
+		beaconID := common.GetCanonicalBeaconID(group.ID)
 
 		drandDaemon.state.Lock()
 		bp, isPresent := drandDaemon.beaconProcesses[beaconID]
@@ -154,7 +154,7 @@ func (dd *DrandDaemon) init() error {
 
 // InstantiateBeaconProcess creates a new BeaconProcess linked to beacon with id 'beaconID'
 func (dd *DrandDaemon) InstantiateBeaconProcess(beaconID string, store key.Store) (*BeaconProcess, error) {
-	beaconID = common.GetCorrectBeaconID(beaconID)
+	beaconID = common.GetCanonicalBeaconID(beaconID)
 	// we add the BeaconID to our logger's name. Notice the BeaconID never changes.
 	logger := dd.log.Named(beaconID)
 	bp, err := NewBeaconProcess(logger, store, beaconID, dd.opts, dd.privGateway, dd.pubGateway)
@@ -181,7 +181,7 @@ func (dd *DrandDaemon) InstantiateBeaconProcess(beaconID string, store key.Store
 
 // RemoveBeaconProcess remove a BeaconProcess linked to beacon with id 'beaconID'
 func (dd *DrandDaemon) RemoveBeaconProcess(beaconID string, bp *BeaconProcess) {
-	beaconID = common.GetCorrectBeaconID(beaconID)
+	beaconID = common.GetCanonicalBeaconID(beaconID)
 
 	chainHash := ""
 	if bp.group != nil {

--- a/core/drand_daemon_helper.go
+++ b/core/drand_daemon_helper.go
@@ -29,12 +29,12 @@ func (dd *DrandDaemon) readBeaconID(metadata *protoCommon.Metadata) (string, err
 			metadata.BeaconID = beaconIDByHash
 		} else {
 			// for the case where our node is still waiting for the chain hash to be set
-			if rcvBeaconID == "" {
-				rcvBeaconID = common.DefaultBeaconID
-			}
+			rcvBeaconID = common.GetCorrectBeaconID(rcvBeaconID)
 			for id, bp := range dd.beaconProcesses {
 				// we only accept to proceed with an unknown chain hash if one beacon process hasn't run DKG yet
 				if id == rcvBeaconID && bp.group == nil {
+					// we make sure that the beacon id is not empty
+					metadata.BeaconID = rcvBeaconID
 					return id, nil
 				}
 			}
@@ -44,9 +44,13 @@ func (dd *DrandDaemon) readBeaconID(metadata *protoCommon.Metadata) (string, err
 	}
 
 	// if we didn't match on a chain hash, and have the empty string, then it's the default beacon
-	if rcvBeaconID == "" {
-		rcvBeaconID = common.DefaultBeaconID
+	rcvBeaconID = common.GetCorrectBeaconID(rcvBeaconID)
+	// make sure the metadata use a correct beacon id
+	if metadata == nil {
+		metadata = &protoCommon.Metadata{}
 	}
+	// we explicitly set the beacon id on the metadata in case it changed because of GetCorrectBeaconID
+	metadata.BeaconID = rcvBeaconID
 
 	return rcvBeaconID, nil
 }

--- a/core/drand_daemon_helper.go
+++ b/core/drand_daemon_helper.go
@@ -24,9 +24,6 @@ func (dd *DrandDaemon) readBeaconID(metadata *protoCommon.Metadata) (string, err
 				return "", fmt.Errorf("invalid chain hash: '%s' != '%s'", rcvBeaconID, beaconIDByHash)
 			}
 			rcvBeaconID = beaconIDByHash
-
-			// set beacon id found from chain hash on message to make it available for everyone
-			metadata.BeaconID = beaconIDByHash
 		} else {
 			// for the case where our node is still waiting for the chain hash to be set
 			rcvBeaconID = common.GetCanonicalBeaconID(rcvBeaconID)

--- a/core/drand_daemon_helper.go
+++ b/core/drand_daemon_helper.go
@@ -29,7 +29,7 @@ func (dd *DrandDaemon) readBeaconID(metadata *protoCommon.Metadata) (string, err
 			metadata.BeaconID = beaconIDByHash
 		} else {
 			// for the case where our node is still waiting for the chain hash to be set
-			rcvBeaconID = common.GetCorrectBeaconID(rcvBeaconID)
+			rcvBeaconID = common.GetCanonicalBeaconID(rcvBeaconID)
 			for id, bp := range dd.beaconProcesses {
 				// we only accept to proceed with an unknown chain hash if one beacon process hasn't run DKG yet
 				if id == rcvBeaconID && bp.group == nil {
@@ -44,12 +44,12 @@ func (dd *DrandDaemon) readBeaconID(metadata *protoCommon.Metadata) (string, err
 	}
 
 	// if we didn't match on a chain hash, and have the empty string, then it's the default beacon
-	rcvBeaconID = common.GetCorrectBeaconID(rcvBeaconID)
+	rcvBeaconID = common.GetCanonicalBeaconID(rcvBeaconID)
 	// make sure the metadata use a correct beacon id
 	if metadata == nil {
 		metadata = &protoCommon.Metadata{}
 	}
-	// we explicitly set the beacon id on the metadata in case it changed because of GetCorrectBeaconID
+	// we explicitly set the beacon id on the metadata in case it changed because of GetCanonicalBeaconID
 	metadata.BeaconID = rcvBeaconID
 
 	return rcvBeaconID, nil

--- a/core/drand_daemon_public.go
+++ b/core/drand_daemon_public.go
@@ -100,8 +100,7 @@ func (dd *DrandDaemon) PushDKGInfo(ctx context.Context, in *drand.DKGInfoPacket)
 // SyncChain is a inter-node protocol that replies to a syncing request from a
 // given round
 func (dd *DrandDaemon) SyncChain(in *drand.SyncRequest, stream drand.Protocol_SyncChainServer) error {
-	metadata := in.GetMetadata()
-	bp, err := dd.getBeaconProcessFromRequest(metadata)
+	bp, err := dd.getBeaconProcessFromRequest(in.GetMetadata())
 	if err != nil {
 		return err
 	}

--- a/core/drand_daemon_public.go
+++ b/core/drand_daemon_public.go
@@ -106,17 +106,6 @@ func (dd *DrandDaemon) SyncChain(in *drand.SyncRequest, stream drand.Protocol_Sy
 		return err
 	}
 
-	// for compatibility with older nodes not sending properly the beaconID and metadata with SyncRequests
-	if metadata == nil {
-		in.Metadata = common.NewMetadata(bp.version.ToProto())
-	}
-	if in.GetMetadata().GetBeaconID() == "" {
-		in.Metadata.BeaconID, err = dd.readBeaconID(metadata)
-		if err != nil {
-			return err
-		}
-	}
-
 	return bp.SyncChain(in, stream)
 }
 

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -552,7 +552,7 @@ func TestDrandPublicChainInfo(t *testing.T) {
 
 	for i, node := range dt.nodes {
 		d := node.drand
-		t.Logf("Getting chaing info from node %d \n", i)
+		t.Logf("Getting chain info from node %d \n", i)
 		received, err := client.ChainInfo(d.priv.Public)
 
 		require.NoError(t, err, fmt.Sprintf("addr %s", node.addr))

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -9,16 +9,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/drand/drand/common"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/common/scheme"
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/net"
 	"github.com/drand/drand/protobuf/drand"
-	"github.com/stretchr/testify/require"
+	"github.com/drand/drand/test"
 )
 
 func setFDLimit(t *testing.T) {
@@ -43,7 +42,7 @@ var testDkgTimeout = 2 * time.Second
 func TestRunDKG(t *testing.T) {
 	n := 4
 	expectedBeaconPeriod := 5 * time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, key.DefaultThreshold(n), expectedBeaconPeriod, sch, beaconID)
 	defer dt.Cleanup()
@@ -69,7 +68,7 @@ func TestRunDKGLarge(t *testing.T) {
 
 	n := 22
 	expectedBeaconPeriod := 5 * time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, key.DefaultThreshold(n), expectedBeaconPeriod, sch, beaconID)
 	defer dt.Cleanup()
@@ -91,7 +90,7 @@ func TestRunDKGLarge(t *testing.T) {
 func TestDrandDKGFresh(t *testing.T) {
 	n := 4
 	beaconPeriod := 1 * time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, key.DefaultThreshold(n), beaconPeriod, sch, beaconID)
 	defer dt.Cleanup()
@@ -140,7 +139,7 @@ func TestRunDKGBroadcastDeny(t *testing.T) {
 	n := 4
 	thr := 3
 	beaconPeriod := 1 * time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, beaconPeriod, sch, beaconID)
 	defer dt.Cleanup()
@@ -180,7 +179,7 @@ func TestRunDKGReshareForce(t *testing.T) {
 	oldThreshold := 3
 	timeout := 1 * time.Second
 	beaconPeriod := 2 * time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, oldNodes, oldThreshold, beaconPeriod, sch, beaconID)
 	defer dt.Cleanup()
@@ -259,7 +258,7 @@ func TestRunDKGReshareAbsentNode(t *testing.T) {
 	oldNodes, newNodes := 3, 4
 	oldThreshold, newThreshold := 2, 3
 	timeout, beaconPeriod := 1*time.Second, 2*time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, oldNodes, oldThreshold, beaconPeriod, sch, beaconID)
 	defer dt.Cleanup()
@@ -318,7 +317,7 @@ func TestRunDKGReshareTimeout(t *testing.T) {
 	oldNodes, newNodes, oldThreshold, newThreshold := 3, 4, 2, 3
 	timeout, beaconPeriod := 1*time.Second, 2*time.Second
 	offline := 1
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, oldNodes, oldThreshold, beaconPeriod, sch, beaconID)
 	defer dt.Cleanup()
@@ -440,7 +439,7 @@ func TestRunDKGResharePreempt(t *testing.T) {
 	Thr := 2
 	timeout := 1 * time.Second
 	beaconPeriod := 2 * time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, oldN, Thr, beaconPeriod, sch, beaconID)
 	defer dt.Cleanup()
@@ -540,7 +539,7 @@ func TestDrandPublicChainInfo(t *testing.T) {
 	n := 10
 	thr := key.DefaultThreshold(n)
 	p := 1 * time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, p, sch, beaconID)
 	defer dt.Cleanup()
@@ -596,7 +595,7 @@ func TestDrandPublicRand(t *testing.T) {
 	n := 4
 	thr := key.DefaultThreshold(n)
 	p := 1 * time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, p, sch, beaconID)
 	defer dt.Cleanup()
@@ -661,7 +660,7 @@ func TestDrandPublicStream(t *testing.T) {
 	n := 4
 	thr := key.DefaultThreshold(n)
 	p := 1 * time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, p, sch, beaconID)
 	defer dt.Cleanup()
@@ -773,7 +772,7 @@ func expectChanFail(t *testing.T, errCh chan error) {
 // nolint:funlen
 func TestDrandFollowChain(t *testing.T) {
 	n, p := 4, 1*time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, key.DefaultThreshold(n), p, sch, beaconID)
 	defer dt.Cleanup()
@@ -863,7 +862,7 @@ func TestDrandFollowChain(t *testing.T) {
 		cancel()
 
 		// check if the beacon is in the database
-		store, err := newNode.drand.createBoltStore(beaconID)
+		store, err := newNode.drand.createBoltStore()
 		require.NoError(t, err)
 		defer store.Close()
 
@@ -881,7 +880,7 @@ func TestDrandPublicStreamProxy(t *testing.T) {
 	n := 4
 	thr := key.DefaultThreshold(n)
 	p := 1 * time.Second
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, p, sch, beaconID)
 	defer dt.Cleanup()

--- a/core/group_setup.go
+++ b/core/group_setup.go
@@ -130,6 +130,7 @@ func newReshareSetup(
 	// period isn't included for resharing since we keep the same period
 	beaconPeriod := uint32(oldGroup.Period.Seconds())
 	schemeID := oldGroup.Scheme.ID
+	// we know it was properly set and verified earlier
 	beaconID := oldGroup.ID
 
 	catchupPeriod := in.CatchupPeriod
@@ -313,7 +314,7 @@ type setupReceiver struct {
 
 func newSetupReceiver(version commonutils.Version, l log.Logger, c clock.Clock,
 	client net.ProtocolClient, in *drand.SetupInfoPacket) (*setupReceiver, error) {
-	beaconID := in.GetMetadata().GetBeaconID()
+	beaconID := commonutils.GetCorrectBeaconID(in.GetMetadata().GetBeaconID())
 
 	setup := &setupReceiver{
 		ch:       make(chan *dkgGroup, 1),

--- a/core/group_setup.go
+++ b/core/group_setup.go
@@ -314,7 +314,7 @@ type setupReceiver struct {
 
 func newSetupReceiver(version commonutils.Version, l log.Logger, c clock.Clock,
 	client net.ProtocolClient, in *drand.SetupInfoPacket) (*setupReceiver, error) {
-	beaconID := commonutils.GetCorrectBeaconID(in.GetMetadata().GetBeaconID())
+	beaconID := commonutils.GetCanonicalBeaconID(in.GetMetadata().GetBeaconID())
 
 	setup := &setupReceiver{
 		ch:       make(chan *dkgGroup, 1),

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -200,7 +200,7 @@ func getSleepDuration() time.Duration {
 // specified period
 func NewDrandTestScenario(t *testing.T, n, thr int, period time.Duration, sch scheme.Scheme, beaconID string) *DrandTestScenario {
 	dt := new(DrandTestScenario)
-	beaconID = common.GetCorrectBeaconID(beaconID)
+	beaconID = common.GetCanonicalBeaconID(beaconID)
 
 	daemons, drands, _, dir, certPaths := BatchNewDrand(
 		t, n, false, sch, beaconID, WithCallOption(grpc.WaitForReady(true)),

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -431,7 +431,7 @@ func (d *DrandTestScenario) SetMockClock(t *testing.T, targetUnixTime int64) {
 		d.t.Logf("ALREADY PASSED")
 	}
 
-	t.Logf("Set genesis time: %d", d.Now().Unix())
+	t.Logf("Set time to genesis time: %d", d.Now().Unix())
 }
 
 // AdvanceMockClock advances the clock of all drand by the given duration

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -92,6 +92,7 @@ type DrandTestScenario struct {
 func BatchNewDrand(t *testing.T, n int, insecure bool, sch scheme.Scheme, beaconID string, opts ...ConfigOption) (
 	daemons []*DrandDaemon, drands []*BeaconProcess, group *key.Group, dir string, certPaths []string,
 ) {
+	t.Logf("Creating %d nodes for beaconID %s", n, beaconID)
 	var privs []*key.Pair
 	if insecure {
 		privs, group = test.BatchIdentities(n, sch, beaconID)

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/drand/drand/common"
+
 	"github.com/drand/drand/common/scheme"
 	"github.com/drand/kyber/share/dkg"
 
@@ -198,6 +200,7 @@ func getSleepDuration() time.Duration {
 // specified period
 func NewDrandTestScenario(t *testing.T, n, thr int, period time.Duration, sch scheme.Scheme, beaconID string) *DrandTestScenario {
 	dt := new(DrandTestScenario)
+	beaconID = common.GetCorrectBeaconID(beaconID)
 
 	daemons, drands, _, dir, certPaths := BatchNewDrand(
 		t, n, false, sch, beaconID, WithCallOption(grpc.WaitForReady(true)),
@@ -284,7 +287,7 @@ func (d *DrandTestScenario) RunDKG() *key.Group {
 		group, err := key.GroupFromProto(groupPacket)
 		require.NoError(d.t, err)
 
-		d.t.Logf("[RunDKG] Leader    Finished. GenesisSeed %x", group.Hash())
+		d.t.Logf("[RunDKG] Leader    Finished. GroupHash %x", group.Hash())
 
 		// We need to make sure the daemon is running before continuing
 		d.waitRunning(controlClient, leaderNode)
@@ -301,7 +304,7 @@ func (d *DrandTestScenario) RunDKG() *key.Group {
 			group, err := key.GroupFromProto(groupPacket)
 			require.NoError(d.t, err)
 
-			d.t.Logf("[RunDKG] NonLeader %s Finished. GenesisSeed %x", n.GetAddr(), group.Hash())
+			d.t.Logf("[RunDKG] NonLeader %s Finished. GroupHash %x", n.GetAddr(), group.Hash())
 
 			// We need to make sure the daemon is running before continuing
 			d.waitRunning(client, n)

--- a/demo/demo_test.go
+++ b/demo/demo_test.go
@@ -1,10 +1,9 @@
 package main
 
 import (
+	"github.com/drand/drand/test"
 	"testing"
 	"time"
-
-	"github.com/drand/drand/common"
 
 	"github.com/drand/drand/common/scheme"
 
@@ -20,7 +19,7 @@ func TestLocalOrchestration(t *testing.T) {
 			t.Fatal("[DEBUG]", "Deadline reached")
 		})
 
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	o := lib.NewOrchestrator(3, 2, "4s", true, "", false, sch, beaconID, true)
 	defer o.Shutdown()

--- a/demo/lib/orchestrator.go
+++ b/demo/lib/orchestrator.go
@@ -70,7 +70,7 @@ func NewOrchestrator(n int, thr int, period string, tls bool, binary string, wit
 	fmt.Printf("[+] Simulation global folder: %s\n", basePath)
 	checkErr(os.MkdirAll(basePath, 0740))
 	certFolder := path.Join(basePath, "certs")
-	beaconID = common.GetCorrectBeaconID(beaconID)
+	beaconID = common.GetCanonicalBeaconID(beaconID)
 
 	checkErr(os.MkdirAll(certFolder, 0740))
 	nodes, paths := createNodes(n, 1, period, basePath, certFolder, tls, binary, sch, beaconID, isCandidate)
@@ -93,7 +93,7 @@ func NewOrchestrator(n int, thr int, period string, tls bool, binary string, wit
 		withCurl:          withCurl,
 		binary:            binary,
 		isBinaryCandidate: isCandidate,
-		beaconID:          common.GetCorrectBeaconID(beaconID),
+		beaconID:          common.GetCanonicalBeaconID(beaconID),
 	}
 	return e
 }

--- a/demo/lib/orchestrator.go
+++ b/demo/lib/orchestrator.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"bytes"
 	"fmt"
+	"github.com/drand/drand/common"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -69,6 +70,7 @@ func NewOrchestrator(n int, thr int, period string, tls bool, binary string, wit
 	fmt.Printf("[+] Simulation global folder: %s\n", basePath)
 	checkErr(os.MkdirAll(basePath, 0740))
 	certFolder := path.Join(basePath, "certs")
+	beaconID = common.GetCorrectBeaconID(beaconID)
 
 	checkErr(os.MkdirAll(certFolder, 0740))
 	nodes, paths := createNodes(n, 1, period, basePath, certFolder, tls, binary, sch, beaconID, isCandidate)
@@ -91,7 +93,7 @@ func NewOrchestrator(n int, thr int, period string, tls bool, binary string, wit
 		withCurl:          withCurl,
 		binary:            binary,
 		isBinaryCandidate: isCandidate,
-		beaconID:          beaconID,
+		beaconID:          common.GetCorrectBeaconID(beaconID),
 	}
 	return e
 }

--- a/demo/main.go
+++ b/demo/main.go
@@ -3,14 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/drand/drand/test"
 	"os"
 	"os/exec"
 	"os/signal"
 	"strings"
 	"syscall"
 	"time"
-
-	"github.com/drand/drand/common"
 
 	"github.com/drand/drand/common/scheme"
 	"github.com/drand/drand/demo/lib"
@@ -45,7 +44,7 @@ func main() {
 	nRound, n := 2, 6
 	thr, newThr := 4, 5
 	period := "10s"
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	orch := lib.NewOrchestrator(n, thr, period, true, *binaryF, !*noCurl, sch, beaconID, true)
 	// NOTE: this line should be before "StartNewNodes". The reason it is here

--- a/demo/node/node_inprocess.go
+++ b/demo/node/node_inprocess.go
@@ -318,7 +318,7 @@ func (l *LocalNode) PrintLog() {
 	fmt.Printf("[-] Printing logs of node %s:\n", l.PrivateAddr())
 	buff, err := os.ReadFile(l.logPath)
 	if err != nil {
-		fmt.Printf("[-] Can't read logs !\n\n")
+		fmt.Printf("[-] Can't read logs at %s !\n\n", l.logPath)
 		return
 	}
 	os.Stdout.Write([]byte(buff))

--- a/demo/node/node_subprocess.go
+++ b/demo/node/node_subprocess.go
@@ -355,7 +355,7 @@ func (n *NodeProc) PrintLog() {
 	fmt.Printf("[-] Printing logs of node %s:\n", n.privAddr)
 	buff, err := os.ReadFile(n.logPath)
 	if err != nil {
-		fmt.Printf("[-] Can't read logs !\n\n")
+		fmt.Printf("[-] Can't read logs at %s !\n\n", n.logPath)
 		return
 	}
 	os.Stdout.Write([]byte(buff))

--- a/demo/regression/main.go
+++ b/demo/regression/main.go
@@ -3,12 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/drand/drand/test"
 	"os"
 	"os/signal"
 	"syscall"
 	"text/template"
-
-	"github.com/drand/drand/common"
 
 	"github.com/drand/drand/common/scheme"
 	"github.com/drand/drand/demo/lib"
@@ -85,7 +84,7 @@ func main() {
 	n := 5
 	thr := 4
 	period := "10s"
-	sch, beaconID := scheme.GetSchemeFromEnv(), common.GetBeaconIDFromEnv()
+	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	orch := lib.NewOrchestrator(n, thr, period, true, *build, false, sch, beaconID, false)
 	orch.UpdateBinary(*candidate, 2, true)

--- a/key/group.go
+++ b/key/group.go
@@ -254,7 +254,8 @@ func (g *Group) FromTOML(i interface{}) (err error) {
 		}
 	}
 
-	g.ID = gt.ID
+	// for backward compatibility we make sure to write "default" as beacon id if not set
+	g.ID = commonutils.GetCorrectBeaconID(gt.ID)
 
 	return nil
 }
@@ -454,7 +455,7 @@ func (g *Group) ToProto(version commonutils.Version) *proto.GroupPacket {
 	out.SchemeID = g.Scheme.ID
 
 	out.Metadata = common.NewMetadata(version.ToProto())
-	out.Metadata.BeaconID = g.ID
+	out.Metadata.BeaconID = commonutils.GetCorrectBeaconID(g.ID)
 
 	if g.PublicKey != nil {
 		var coeffs = make([][]byte, len(g.PublicKey.Coefficients))

--- a/key/group.go
+++ b/key/group.go
@@ -255,7 +255,7 @@ func (g *Group) FromTOML(i interface{}) (err error) {
 	}
 
 	// for backward compatibility we make sure to write "default" as beacon id if not set
-	g.ID = commonutils.GetCorrectBeaconID(gt.ID)
+	g.ID = commonutils.GetCanonicalBeaconID(gt.ID)
 
 	return nil
 }
@@ -455,7 +455,7 @@ func (g *Group) ToProto(version commonutils.Version) *proto.GroupPacket {
 	out.SchemeID = g.Scheme.ID
 
 	out.Metadata = common.NewMetadata(version.ToProto())
-	out.Metadata.BeaconID = commonutils.GetCorrectBeaconID(g.ID)
+	out.Metadata.BeaconID = commonutils.GetCanonicalBeaconID(g.ID)
 
 	if g.PublicKey != nil {
 		var coeffs = make([][]byte, len(g.PublicKey.Coefficients))

--- a/key/store.go
+++ b/key/store.go
@@ -92,11 +92,9 @@ func NewFileStores(baseFolder string) (map[string]Store, error) {
 }
 
 // NewFileStore is used to create the config folder and all the subfolders.
-// If a folder alredy exists, we simply check the rights
+// If a folder already exists, we simply check the rights
 func NewFileStore(baseFolder, beaconID string) Store {
-	if beaconID == "" {
-		beaconID = common.DefaultBeaconID
-	}
+	beaconID = common.GetCorrectBeaconID(beaconID)
 
 	store := &fileStore{baseFolder: baseFolder, beaconID: beaconID}
 

--- a/key/store.go
+++ b/key/store.go
@@ -94,7 +94,7 @@ func NewFileStores(baseFolder string) (map[string]Store, error) {
 // NewFileStore is used to create the config folder and all the subfolders.
 // If a folder already exists, we simply check the rights
 func NewFileStore(baseFolder, beaconID string) Store {
-	beaconID = common.GetCorrectBeaconID(beaconID)
+	beaconID = common.GetCanonicalBeaconID(beaconID)
 
 	store := &fileStore{baseFolder: baseFolder, beaconID: beaconID}
 

--- a/key/store_test.go
+++ b/key/store_test.go
@@ -5,17 +5,18 @@ import (
 	"path"
 	"testing"
 
-	"github.com/drand/drand/common"
-
 	kyber "github.com/drand/kyber"
 	"github.com/drand/kyber/share"
 	"github.com/stretchr/testify/require"
+
+	commonutils "github.com/drand/drand/common"
 )
 
 func TestKeysSaveLoad(t *testing.T) {
 	n := 4
 	ps, group := BatchIdentities(n)
-	beaconID := common.GetBeaconIDFromEnv()
+	// we don't use the function from the test package here to avoid a circular dependency
+	beaconID := commonutils.GetCorrectBeaconID(os.Getenv("BEACON_ID"))
 
 	tmp := os.TempDir()
 	tmp = path.Join(tmp, "drand-key")

--- a/key/store_test.go
+++ b/key/store_test.go
@@ -16,7 +16,7 @@ func TestKeysSaveLoad(t *testing.T) {
 	n := 4
 	ps, group := BatchIdentities(n)
 	// we don't use the function from the test package here to avoid a circular dependency
-	beaconID := commonutils.GetCorrectBeaconID(os.Getenv("BEACON_ID"))
+	beaconID := commonutils.GetCanonicalBeaconID(os.Getenv("BEACON_ID"))
 
 	tmp := os.TempDir()
 	tmp = path.Join(tmp, "drand-key")

--- a/test/test.go
+++ b/test/test.go
@@ -128,7 +128,7 @@ func GenerateIDs(n int) []*key.Pair {
 
 // BatchIdentities generates n insecure identities
 func BatchIdentities(n int, sch scheme.Scheme, beaconID string) ([]*key.Pair, *key.Group) {
-	beaconID = commonutils.GetCorrectBeaconID(beaconID)
+	beaconID = commonutils.GetCanonicalBeaconID(beaconID)
 	privs := GenerateIDs(n)
 	thr := key.MinimumT(n)
 	var dpub []kyber.Point
@@ -180,5 +180,5 @@ func StringToPoint(s string) (kyber.Point, error) {
 // GetBeaconIDFromEnv read beacon id from an environmental variable.
 func GetBeaconIDFromEnv() string {
 	beaconID := os.Getenv("BEACON_ID")
-	return commonutils.GetCorrectBeaconID(beaconID)
+	return commonutils.GetCanonicalBeaconID(beaconID)
 }

--- a/test/test.go
+++ b/test/test.go
@@ -4,7 +4,9 @@ package test
 
 import (
 	"encoding/hex"
+	commonutils "github.com/drand/drand/common"
 	n "net"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -126,6 +128,7 @@ func GenerateIDs(n int) []*key.Pair {
 
 // BatchIdentities generates n insecure identities
 func BatchIdentities(n int, sch scheme.Scheme, beaconID string) ([]*key.Pair, *key.Group) {
+	beaconID = commonutils.GetCorrectBeaconID(beaconID)
 	privs := GenerateIDs(n)
 	thr := key.MinimumT(n)
 	var dpub []kyber.Point
@@ -172,4 +175,10 @@ func StringToPoint(s string) (kyber.Point, error) {
 	}
 	p := g.Point()
 	return p, p.UnmarshalBinary(buff)
+}
+
+// GetBeaconIDFromEnv read beacon id from an environmental variable.
+func GetBeaconIDFromEnv() string {
+	beaconID := os.Getenv("BEACON_ID")
+	return commonutils.GetCorrectBeaconID(beaconID)
 }


### PR DESCRIPTION
This should resolve our current issues where the beaconID or the chainhash are not properly handled in packet's metadata.