### PR TITLE
Send group size and threshold metrics when DKG/reshare starts

### DIFF
--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -682,8 +682,6 @@ func (bp *BeaconProcess) setupAutomaticResharing(_ context.Context, oldGroup *ke
 	}
 
 	metrics.ReshareStateChange(metrics.ReshareWaiting, bp.getBeaconID(), in.GetInfo().GetLeader())
-	metrics.GroupSize.WithLabelValues(bp.getBeaconID()).Set(float64(in.Info.Nodes))
-	metrics.GroupThreshold.WithLabelValues(bp.getBeaconID()).Set(float64(in.Info.Threshold))
 
 	// we wait only a certain amount of time for the prepare phase
 	nc, cancel := context.WithTimeout(context.Background(), MaxWaitPrepareDKG)


### PR DESCRIPTION
@AnomalRoil @willscott I *think* I have set these up correctly, please do a sanity check whether this is the correct place to send the metrics when the DKG/reshare starts