### PR TITLE
Always emit DKGDone metric when DKG is finished

### DIFF
--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -159,11 +159,6 @@ func (bp *BeaconProcess) WaitDKG() (*key.Group, error) {
 		return nil, errors.New("no dkg info set")
 	}
 
-	if bp.group != nil {
-		beaconID := bp.getBeaconID()
-		metrics.DKGStateChange(metrics.DKGWaiting, beaconID, false)
-	}
-
 	waitCh := bp.dkgInfo.proto.WaitEnd()
 	bp.log.Debugw("", "waiting_dkg_end", time.Now())
 

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -159,6 +159,13 @@ func (bp *BeaconProcess) WaitDKG() (*key.Group, error) {
 		return nil, errors.New("no dkg info set")
 	}
 
+	beaconID := bp.getBeaconID()
+	defer func() {
+		metrics.DKGStateChange(metrics.DKGDone, beaconID, false)
+	}()
+
+	metrics.DKGStateChange(metrics.DKGWaiting, beaconID, false)
+
 	waitCh := bp.dkgInfo.proto.WaitEnd()
 	bp.log.Debugw("", "waiting_dkg_end", time.Now())
 


### PR DESCRIPTION
I've checked and the DKG state metric is emitted in both places that `WaitDKG` is called, so this one is extraneous (and wrong).