### PR TITLE
fixed default port selection in keygen

### DIFF
--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -632,7 +632,7 @@ func askPort(c *cli.Context) string {
 		}
 
 		_, err = strconv.Atoi(port)
-		if err != nil || len(port) < 3 || len(port) > 4 {
+		if err != nil || len(port) < 4 || len(port) > 6 {
 			continue
 		}
 

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -625,18 +625,18 @@ func askPort(c *cli.Context) string {
 			continue
 		}
 
-		port := strings.TrimSpace(input)
-		if port == "" {
+		portStr := strings.TrimSpace(input)
+		if portStr == "" {
 			fmt.Fprintln(output, "Default port selected")
 			return defaultPort
 		}
 
-		_, err = strconv.Atoi(port)
-		if err != nil || len(port) < 4 || len(port) > 6 {
+		port, err := strconv.Atoi(portStr)
+		if err != nil || port < 1000 || port > 65536 {
 			continue
 		}
 
-		return port
+		return portStr
 	}
 }
 

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -63,7 +63,7 @@ var folderFlag = &cli.StringFlag{
 
 var verboseFlag = &cli.BoolFlag{
 	Name:  "verbose",
-	Usage: "If set, verbosity is at the debug level.",
+	Usage: "If set, verbosity is at the debug level",
 }
 
 var tlsCertFlag = &cli.StringFlag{
@@ -119,46 +119,46 @@ var roundFlag = &cli.IntFlag{
 
 var certsDirFlag = &cli.StringFlag{
 	Name:  "certs-dir",
-	Usage: "directory containing trusted certificates (PEM format). Useful for testing and self signed certificates.",
+	Usage: "directory containing trusted certificates (PEM format). Useful for testing and self signed certificates",
 }
 
 var outFlag = &cli.StringFlag{
 	Name:  "out",
-	Usage: "save the group file into a separate file instead of stdout.",
+	Usage: "save the group file into a separate file instead of stdout",
 }
 
 var periodFlag = &cli.StringFlag{
 	Name:  "period",
-	Usage: "period to set when doing a setup.",
+	Usage: "period to set when doing a setup",
 }
 
 var catchupPeriodFlag = &cli.StringFlag{
 	Name:  "catchup-period",
-	Usage: "Minimum period while in catchup. Set only by the leader of share / reshares.",
+	Usage: "Minimum period while in catchup. Set only by the leader of share / reshares",
 	Value: "0s",
 }
 
 var thresholdFlag = &cli.IntFlag{
 	Name:  "threshold",
-	Usage: "threshold to use for the DKG.",
+	Usage: "threshold to use for the DKG",
 }
 
 var shareNodeFlag = &cli.IntFlag{
 	Name:  "nodes",
-	Usage: "number of nodes expected.",
+	Usage: "number of nodes expected",
 }
 
 var transitionFlag = &cli.BoolFlag{
 	Name:    "reshare",
 	Aliases: []string{"transition"},
 	Usage: "When set, this flag indicates the share operation is a resharing. " +
-		"The node will use the currently stored group as the basis for the resharing.",
+		"The node will use the currently stored group as the basis for the resharing",
 }
 
 var forceFlag = &cli.BoolFlag{
 	Name:    "force",
 	Aliases: []string{"f"},
-	Usage:   "When set, this flag forces the daemon to start a new reshare operation." + "By default, it does not allow to restart one.",
+	Usage:   "When set, this flag forces the daemon to start a new reshare operation." + "By default, it does not allow to restart one",
 }
 
 // secret flag is the "manual" security when the "leader"/coordinator creates the
@@ -174,18 +174,18 @@ var secretFlag = &cli.StringFlag{
 
 var connectFlag = &cli.StringFlag{
 	Name:  "connect",
-	Usage: "Address of the coordinator that will assemble the public keys and start the DKG.",
+	Usage: "Address of the coordinator that will assemble the public keys and start the DKG",
 }
 
 var leaderFlag = &cli.BoolFlag{
 	Name:  "leader",
-	Usage: "Specify if this node should act as the leader for setting up the group.",
+	Usage: "Specify if this node should act as the leader for setting up the group",
 }
 
 var beaconOffset = &cli.IntFlag{
 	Name: "beacon-delay",
 	Usage: "Leader uses this flag to specify the genesis time or transition time as a delay from when " +
-		" group is ready to run the share protocol.",
+		" group is ready to run the share protocol",
 }
 
 var oldGroupFlag = &cli.StringFlag{
@@ -208,7 +208,7 @@ var timeoutFlag = &cli.StringFlag{
 var pushFlag = &cli.BoolFlag{
 	Name: "push",
 	Usage: "Push mode forces the daemon to start making beacon requests to the other node, " +
-		"instead of waiting the other nodes contact it to catch-up on the round.",
+		"instead of waiting the other nodes contact it to catch-up on the round",
 }
 
 var sourceFlag = &cli.StringFlag{
@@ -239,20 +239,20 @@ var hashOnly = &cli.BoolFlag{
 
 var hashInfoReq = &cli.StringFlag{
 	Name:     "chain-hash",
-	Usage:    "The hash of the chain info, used to validate integrity of the received group info.",
+	Usage:    "The hash of the chain info, used to validate integrity of the received group info",
 	Required: true,
 }
 
 var hashInfoNoReq = &cli.StringFlag{
 	Name:  "chain-hash",
-	Usage: "The hash of the chain info.",
+	Usage: "The hash of the chain info",
 }
 
 // using a simple string flag because the StringSliceFlag is not intuitive
 // see https://github.com/urfave/cli/issues/62
 var syncNodeFlag = &cli.StringFlag{
 	Name: "sync-nodes",
-	Usage: "<ADDRESS:PORT>,<...> of (multiple) reachable drand daemon(s.). " +
+	Usage: "<ADDRESS:PORT>,<...> of (multiple) reachable drand daemon(s). " +
 		"When checking our local database, using our local daemon address will result in a dry run.",
 	Required: true,
 }
@@ -265,13 +265,13 @@ var followFlag = &cli.BoolFlag{
 var upToFlag = &cli.IntFlag{
 	Name: "up-to",
 	Usage: "Specify a round at which the drand daemon will stop syncing the chain, " +
-		"typically used to bootstrap a new node in chained mode.",
+		"typically used to bootstrap a new node in chained mode",
 	Value: 0,
 }
 
 var schemeFlag = &cli.StringFlag{
 	Name:  "scheme",
-	Usage: "Indicates a set of values drand will use to configure the randomness generation process.",
+	Usage: "Indicates a set of values drand will use to configure the randomness generation process",
 	Value: scheme.DefaultSchemeID,
 }
 
@@ -282,7 +282,7 @@ var jsonFlag = &cli.BoolFlag{
 
 var beaconIDFlag = &cli.StringFlag{
 	Name:  "id",
-	Usage: "Indicates the id for the randomness generation process which will be started.",
+	Usage: "Indicates the id for the randomness generation process which will be started",
 	Value: "",
 }
 var listIdsFlag = &cli.BoolFlag{
@@ -293,7 +293,7 @@ var listIdsFlag = &cli.BoolFlag{
 
 var allBeaconsFlag = &cli.BoolFlag{
 	Name:  "all",
-	Usage: "Indicates if we have to interact with all beacons chains.",
+	Usage: "Indicates if we have to interact with all beacons chains",
 	Value: false,
 }
 
@@ -335,13 +335,13 @@ var appCommands = []*cli.Command{
 	},
 	{
 		Name:   "load",
-		Usage:  "Launch a sharing protocol from filesystem.",
+		Usage:  "Launch a sharing protocol from filesystem",
 		Flags:  toArray(controlFlag, beaconIDFlag),
 		Action: loadCmd,
 	},
 	{
 		Name:  "sync",
-		Usage: "sync your local randomness chain with other nodes and validate your local beacon chain.",
+		Usage: "sync your local randomness chain with other nodes and validate your local beacon chain",
 		Flags: toArray(folderFlag, controlFlag, hashInfoNoReq, syncNodeFlag,
 			tlsCertFlag, insecureFlag, upToFlag, beaconIDFlag, followFlag),
 		Action: syncCmd,

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -625,7 +625,7 @@ func askPort(c *cli.Context) string {
 			continue
 		}
 
-		port := strings.TrimSuffix(input, "\n")
+		port := strings.Replace(input, "\n", "", 1)
 		if port == "" {
 			fmt.Fprintln(output, "Default port selected")
 			return defaultPort

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -625,7 +625,7 @@ func askPort(c *cli.Context) string {
 			continue
 		}
 
-		port := strings.Replace(input, "\n", "", 1)
+		port := strings.TrimSpace(input)
 		if port == "" {
 			fmt.Fprintln(output, "Default port selected")
 			return defaultPort

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -620,8 +620,8 @@ func askPort(c *cli.Context) string {
 		fmt.Fprintf(output, "No valid port given. Please, choose a port number (or ENTER for default port 8080): ")
 
 		reader := bufio.NewReader(c.App.Reader)
-		input, portErr := reader.ReadString('\n')
-		if portErr != nil {
+		input, err := reader.ReadString('\n')
+		if err != nil {
 			continue
 		}
 
@@ -631,8 +631,8 @@ func askPort(c *cli.Context) string {
 			return defaultPort
 		}
 
-		_, intConversionErr := strconv.Atoi(port)
-		if len(port) < 3 || len(port) > 4 || intConversionErr != nil {
+		_, err = strconv.Atoi(port)
+		if err != nil || len(port) < 3 || len(port) > 4 {
 			continue
 		}
 

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -63,7 +63,7 @@ var folderFlag = &cli.StringFlag{
 
 var verboseFlag = &cli.BoolFlag{
 	Name:  "verbose",
-	Usage: "If set, verbosity is at the debug level",
+	Usage: "If set, verbosity is at the debug level.",
 }
 
 var tlsCertFlag = &cli.StringFlag{
@@ -119,46 +119,46 @@ var roundFlag = &cli.IntFlag{
 
 var certsDirFlag = &cli.StringFlag{
 	Name:  "certs-dir",
-	Usage: "directory containing trusted certificates (PEM format). Useful for testing and self signed certificates",
+	Usage: "directory containing trusted certificates (PEM format). Useful for testing and self signed certificates.",
 }
 
 var outFlag = &cli.StringFlag{
 	Name:  "out",
-	Usage: "save the group file into a separate file instead of stdout",
+	Usage: "save the group file into a separate file instead of stdout.",
 }
 
 var periodFlag = &cli.StringFlag{
 	Name:  "period",
-	Usage: "period to set when doing a setup",
+	Usage: "period to set when doing a setup.",
 }
 
 var catchupPeriodFlag = &cli.StringFlag{
 	Name:  "catchup-period",
-	Usage: "Minimum period while in catchup. Set only by the leader of share / reshares",
+	Usage: "Minimum period while in catchup. Set only by the leader of share / reshares.",
 	Value: "0s",
 }
 
 var thresholdFlag = &cli.IntFlag{
 	Name:  "threshold",
-	Usage: "threshold to use for the DKG",
+	Usage: "threshold to use for the DKG.",
 }
 
 var shareNodeFlag = &cli.IntFlag{
 	Name:  "nodes",
-	Usage: "number of nodes expected",
+	Usage: "number of nodes expected.",
 }
 
 var transitionFlag = &cli.BoolFlag{
 	Name:    "reshare",
 	Aliases: []string{"transition"},
 	Usage: "When set, this flag indicates the share operation is a resharing. " +
-		"The node will use the currently stored group as the basis for the resharing",
+		"The node will use the currently stored group as the basis for the resharing.",
 }
 
 var forceFlag = &cli.BoolFlag{
 	Name:    "force",
 	Aliases: []string{"f"},
-	Usage:   "When set, this flag forces the daemon to start a new reshare operation." + "By default, it does not allow to restart one",
+	Usage:   "When set, this flag forces the daemon to start a new reshare operation." + "By default, it does not allow to restart one.",
 }
 
 // secret flag is the "manual" security when the "leader"/coordinator creates the
@@ -174,18 +174,18 @@ var secretFlag = &cli.StringFlag{
 
 var connectFlag = &cli.StringFlag{
 	Name:  "connect",
-	Usage: "Address of the coordinator that will assemble the public keys and start the DKG",
+	Usage: "Address of the coordinator that will assemble the public keys and start the DKG.",
 }
 
 var leaderFlag = &cli.BoolFlag{
 	Name:  "leader",
-	Usage: "Specify if this node should act as the leader for setting up the group",
+	Usage: "Specify if this node should act as the leader for setting up the group.",
 }
 
 var beaconOffset = &cli.IntFlag{
 	Name: "beacon-delay",
 	Usage: "Leader uses this flag to specify the genesis time or transition time as a delay from when " +
-		" group is ready to run the share protocol",
+		" group is ready to run the share protocol.",
 }
 
 var oldGroupFlag = &cli.StringFlag{
@@ -208,7 +208,7 @@ var timeoutFlag = &cli.StringFlag{
 var pushFlag = &cli.BoolFlag{
 	Name: "push",
 	Usage: "Push mode forces the daemon to start making beacon requests to the other node, " +
-		"instead of waiting the other nodes contact it to catch-up on the round",
+		"instead of waiting the other nodes contact it to catch-up on the round.",
 }
 
 var sourceFlag = &cli.StringFlag{
@@ -239,20 +239,20 @@ var hashOnly = &cli.BoolFlag{
 
 var hashInfoReq = &cli.StringFlag{
 	Name:     "chain-hash",
-	Usage:    "The hash of the chain info, used to validate integrity of the received group info",
+	Usage:    "The hash of the chain info, used to validate integrity of the received group info.",
 	Required: true,
 }
 
 var hashInfoNoReq = &cli.StringFlag{
 	Name:  "chain-hash",
-	Usage: "The hash of the chain info",
+	Usage: "The hash of the chain info.",
 }
 
 // using a simple string flag because the StringSliceFlag is not intuitive
 // see https://github.com/urfave/cli/issues/62
 var syncNodeFlag = &cli.StringFlag{
 	Name: "sync-nodes",
-	Usage: "<ADDRESS:PORT>,<...> of (multiple) reachable drand daemon(s). " +
+	Usage: "<ADDRESS:PORT>,<...> of (multiple) reachable drand daemon(s.). " +
 		"When checking our local database, using our local daemon address will result in a dry run.",
 	Required: true,
 }
@@ -265,13 +265,13 @@ var followFlag = &cli.BoolFlag{
 var upToFlag = &cli.IntFlag{
 	Name: "up-to",
 	Usage: "Specify a round at which the drand daemon will stop syncing the chain, " +
-		"typically used to bootstrap a new node in chained mode",
+		"typically used to bootstrap a new node in chained mode.",
 	Value: 0,
 }
 
 var schemeFlag = &cli.StringFlag{
 	Name:  "scheme",
-	Usage: "Indicates a set of values drand will use to configure the randomness generation process",
+	Usage: "Indicates a set of values drand will use to configure the randomness generation process.",
 	Value: scheme.DefaultSchemeID,
 }
 
@@ -282,18 +282,18 @@ var jsonFlag = &cli.BoolFlag{
 
 var beaconIDFlag = &cli.StringFlag{
 	Name:  "id",
-	Usage: "Indicates the id for the randomness generation process which will be started",
+	Usage: "Indicates the id for the randomness generation process which will be started.",
 	Value: "",
 }
 var listIdsFlag = &cli.BoolFlag{
 	Name:  "list-ids",
-	Usage: "Indicates if it only have to list the running beacon ids instead of the statuses",
+	Usage: "Indicates if it only have to list the running beacon ids instead of the statuses.",
 	Value: false,
 }
 
 var allBeaconsFlag = &cli.BoolFlag{
 	Name:  "all",
-	Usage: "Indicates if we have to interact with all beacons chains",
+	Usage: "Indicates if we have to interact with all beacons chains.",
 	Value: false,
 }
 
@@ -335,13 +335,13 @@ var appCommands = []*cli.Command{
 	},
 	{
 		Name:   "load",
-		Usage:  "Launch a sharing protocol from filesystem",
+		Usage:  "Launch a sharing protocol from filesystem.",
 		Flags:  toArray(controlFlag, beaconIDFlag),
 		Action: loadCmd,
 	},
 	{
 		Name:  "sync",
-		Usage: "sync your local randomness chain with other nodes and validate your local beacon chain",
+		Usage: "sync your local randomness chain with other nodes and validate your local beacon chain.",
 		Flags: toArray(folderFlag, controlFlag, hashInfoNoReq, syncNodeFlag,
 			tlsCertFlag, insecureFlag, upToFlag, beaconIDFlag, followFlag),
 		Action: syncCmd,
@@ -579,7 +579,7 @@ func resetCmd(c *cli.Context) error {
 
 	fmt.Fprintf(output, "You are about to delete your local share, group file and generated random beacons. "+
 		"Are you sure you wish to perform this operation? [y/N]")
-	reader := bufio.NewReader(os.Stdin)
+	reader := bufio.NewReader(c.App.Reader)
 
 	answer, err := reader.ReadString('\n')
 	if err != nil {
@@ -615,21 +615,28 @@ func resetCmd(c *cli.Context) error {
 	return nil
 }
 
-func askPort() string {
+func askPort(c *cli.Context) string {
 	for {
-		var port string
 		fmt.Fprintf(output, "No valid port given. Please, choose a port number (or ENTER for default port 8080): ")
-		if _, err := fmt.Scanf("%s\n", &port); err != nil {
+
+		reader := bufio.NewReader(c.App.Reader)
+		input, portErr := reader.ReadString('\n')
+		if portErr != nil {
 			continue
 		}
+
+		port := strings.TrimSuffix(input, "\n")
 		if port == "" {
+			fmt.Fprintln(output, "Default port selected")
 			return defaultPort
 		}
-		_, err := strconv.Atoi(port)
-		if len(port) > 2 && len(port) < 5 && err == nil {
-			return port
+
+		_, intConversionErr := strconv.Atoi(port)
+		if len(port) < 3 || len(port) > 4 || intConversionErr != nil {
+			continue
 		}
-		return askPort()
+
+		return port
 	}
 }
 
@@ -685,7 +692,7 @@ func keygenCmd(c *cli.Context) error {
 	var validID = regexp.MustCompile(`:\d+$`)
 	if !validID.MatchString(addr) {
 		fmt.Println("Invalid port.")
-		addr = addr + ":" + askPort()
+		addr = addr + ":" + askPort(c)
 	}
 
 	var priv *key.Pair

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -802,37 +802,18 @@ func TestEmptyPortSelectionUsesDefaultDuringKeygen(t *testing.T) {
 	require.NoError(t, app.Run(args))
 }
 
-func TestInvalidPortSelectionRepromptsDuringKeygen(t *testing.T) {
+func TestValidPortSelectionSucceedsDuringKeygen(t *testing.T) {
 	beaconID := test.GetBeaconIDFromEnv()
 
 	tmp, err := os.MkdirTemp("", "drand-cli-*")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmp)
 	app := CLI()
-	finished := false
 
-	go func() {
-		args := []string{"drand", "generate-keypair", "--folder", tmp, "--id", beaconID, "127.0.0.1"}
-		err := app.Run(args)
-		if err != nil {
-			finished = false
-		} else {
-			finished = true
-		}
-	}()
-
-	// sleeping isn't very nice, but the CLI spin/waits, so it's all we've got!
-	app.Reader = strings.NewReader("888\n")
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, finished, false)
-
-	app.Reader = strings.NewReader("8888888\n")
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, finished, false)
-
+	args := []string{"drand", "generate-keypair", "--folder", tmp, "--id", beaconID, "127.0.0.1"}
 	app.Reader = strings.NewReader("8080\n")
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, finished, true)
+
+	require.NoError(t, app.Run(args))
 }
 
 type drandInstance struct {

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	gnet "net"
 	"os"
@@ -824,15 +823,15 @@ func TestInvalidPortSelectionRepromptsDuringKeygen(t *testing.T) {
 
 	// sleeping isn't very nice, but the CLI spin/waits, so it's all we've got!
 	app.Reader = strings.NewReader("888\n")
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, finished, false)
 
 	app.Reader = strings.NewReader("8888888\n")
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, finished, false)
 
 	app.Reader = strings.NewReader("8080\n")
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	assert.Equal(t, finished, true)
 }
 

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -800,6 +800,7 @@ func TestEmptyPortSelectionUsesDefaultDuringKeygen(t *testing.T) {
 	app.Reader = strings.NewReader("\n")
 
 	require.NoError(t, app.Run(args))
+	fmt.Println("Success")
 }
 
 type drandInstance struct {

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -800,7 +800,6 @@ func TestEmptyPortSelectionUsesDefaultDuringKeygen(t *testing.T) {
 	app.Reader = strings.NewReader("\n")
 
 	require.NoError(t, app.Run(args))
-	fmt.Println("Success")
 }
 
 type drandInstance struct {

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -786,6 +786,22 @@ func TestDrandStatus(t *testing.T) {
 	}
 }
 
+func TestEmptyPortSelectionUsesDefaultDuringKeygen(t *testing.T) {
+	beaconID := test.GetBeaconIDFromEnv()
+
+	tmp, err := os.MkdirTemp("", "drand-cli-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmp)
+	app := CLI()
+
+	// args are missing a port for the node address
+	args := []string{"drand", "generate-keypair", "--folder", tmp, "--id", beaconID, "127.0.0.1"}
+	// after being prompted for a port, the 'user' hits enter to select the default
+	app.Reader = strings.NewReader("\n")
+
+	require.NoError(t, app.Run(args))
+}
+
 type drandInstance struct {
 	path     string
 	ctrlPort string

--- a/go.mod
+++ b/go.mod
@@ -149,6 +149,7 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/weaveworks/promrus v1.2.0 // indirect
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
+	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.dedis.ch/fixbuf v1.0.3 // indirect
 	go.dedis.ch/protobuf v1.0.11 // indirect
 	go.uber.org/atomic v1.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,6 @@ require (
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/weaveworks/promrus v1.2.0 // indirect
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
-	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.dedis.ch/fixbuf v1.0.3 // indirect
 	go.dedis.ch/protobuf v1.0.11 // indirect
 	go.uber.org/atomic v1.10.0 // indirect


### PR DESCRIPTION
Fixed a bug where empty input to select the default port during keygen
would repeatedly prompt for input rather than select the default port
(8080)

Updated to the latest urfave CLI in order to enable manipulation of the
CLI `Reader` for testing

Modified some sections of the CLI to use the `Reader` from the `App`
rather than assuming it is always stdin

Modified some of the prompts to end in a full stop for consistency