### PR TITLE
No panic on creation of drand daemon on bound port

### DIFF
--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -357,7 +357,7 @@ func TestStartWithoutGroup(t *testing.T) {
 	initDKGArgs := []string{"drand", "share", "--control", ctrlPort1, "--id", beaconID}
 	require.Error(t, CLI().Run(initDKGArgs))
 
-	fmt.Println("--- DRAND STOP --- (failing instanace)")
+	fmt.Println("--- DRAND STOP --- (failing instance)")
 	CLI().Run([]string{"drand", "stop", "--control", ctrlPort1})
 
 	fmt.Println(" --- DRAND GROUP ---")

--- a/core/drand_daemon.go
+++ b/core/drand_daemon.go
@@ -136,7 +136,11 @@ func (dd *DrandDaemon) init() error {
 	}
 
 	p := c.ControlPort()
-	dd.control = net.NewTCPGrpcControlListener(dd, p)
+	dd.control, err = net.NewTCPGrpcControlListener(dd, p)
+
+	if err != nil {
+		return err
+	}
 	go dd.control.Start()
 
 	dd.log.Infow("DrandDaemon initialized",

--- a/core/drand_daemon_test.go
+++ b/core/drand_daemon_test.go
@@ -1,0 +1,27 @@
+package core
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoPanicWhenDrandDaemonPortInUse(t *testing.T) {
+	// bind a random port on localhost
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "Failed to bind port for testing")
+	defer listener.Close()
+	inUsePort := listener.Addr().(*net.TCPAddr).Port
+
+	// configure the daemon to try and bind the same port
+	config := NewConfig()
+	config.insecure = true
+	config.controlPort = strconv.Itoa(inUsePort)
+	config.privateListenAddr = "127.0.0.1:0"
+
+	// an error is returned during daemon creation instead of panicking
+	_, err = NewDrandDaemon(config)
+	require.Error(t, err)
+}

--- a/net/control.go
+++ b/net/control.go
@@ -26,15 +26,15 @@ type ControlListener struct {
 }
 
 // NewTCPGrpcControlListener registers the pairing between a ControlServer and a grpc server
-func NewTCPGrpcControlListener(s control.ControlServer, controlAddr string) ControlListener {
+func NewTCPGrpcControlListener(s control.ControlServer, controlAddr string) (ControlListener, error) {
 	lis, err := net.Listen(controlListenAddr(controlAddr))
 	if err != nil {
 		log.DefaultLogger().Errorw("", "grpc listener", "failure", "err", err)
-		return ControlListener{}
+		return ControlListener{}, err
 	}
 	grpcServer := grpc.NewServer()
 	control.RegisterControlServer(grpcServer, s)
-	return ControlListener{conns: grpcServer, lis: lis}
+	return ControlListener{conns: grpcServer, lis: lis}, nil
 }
 
 // Start the listener for the control commands

--- a/net/control_test.go
+++ b/net/control_test.go
@@ -34,7 +34,12 @@ func TestControlUnix(t *testing.T) {
 	}
 	defer os.RemoveAll(name)
 	s := testnet.EmptyServer{}
-	service := NewTCPGrpcControlListener(&s, "unix://"+name+"/sock")
+	service, err := NewTCPGrpcControlListener(&s, "unix://"+name+"/sock")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	client, err := NewControlClient("unix://" + name + "/sock")
 
 	if err != nil {


### PR DESCRIPTION
- attempting to set a control port that has already been bound no
  longer panics

resolves #1019