### PR TITLE
Verify that a peer's metrics handler is non-nil

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -419,7 +419,7 @@ func newLazyPeerHandler(metricsHandlers []Handler) *lazyPeerHandler {
 // If there is any other error it will return false and the given error.
 func (l *lazyPeerHandler) handlerForPeer(addr string) (http.Handler, error) {
 	h, found := l.handlerCache.Load(addr)
-	if found {
+	if found && h != nil {
 		return h.(http.Handler), nil
 	}
 


### PR DESCRIPTION
From my reading this should not be necessary, but it was the cause for the panics on testnet when trying to update to commit `f9a81d`. See logs at https://my.papertrailapp.com/groups/20050302/events?focus=1481660778657517579&q=drand.testnet2.drand+