### PR TITLE
Fixed segfault if nodeId out of range

### DIFF
--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -120,7 +120,14 @@ func (h *Handler) ProcessPartialBeacon(c context.Context, p *proto.PartialBeacon
 	if idx < 0 {
 		return nil, fmt.Errorf("invalid index %d in partial with msg %v", idx, msg)
 	}
-	nodeName := h.crypto.GetGroup().Node(uint32(idx)).Address()
+
+	node := h.crypto.GetGroup().Node(uint32(idx))
+
+	if node == nil {
+		return nil, fmt.Errorf("attempted to process beacon from node of index %d, but it was not in the group file", uint32(idx))
+	}
+
+	nodeName := node.Address()
 	// verify if request is valid
 	if err := key.Scheme.VerifyPartial(h.crypto.GetPub(), msg, p.GetPartialSig()); err != nil {
 		h.l.Errorw("",

--- a/chain/beacon/sync_manager.go
+++ b/chain/beacon/sync_manager.go
@@ -157,6 +157,7 @@ func (s *SyncManager) Run() {
 				lastCtx, cancel = context.WithCancel(context.Background())
 				go s.Sync(lastCtx, request) // nolint
 			}
+
 		case <-s.newSync:
 			// just received a new beacon from sync, we keep track of this time
 			lastRoundTime = int(s.clock.Now().Unix())

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -307,7 +307,8 @@ func TestRunDKGReshareAbsentNode(t *testing.T) {
 	group1 := dt.RunDKG()
 
 	dt.SetMockClock(t, group1.GenesisTime)
-	dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	err := dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	require.NoError(t, err)
 
 	// move to genesis time - so nodes start to make a round
 	// dt.AdvanceMockClock(t,offsetGenesis)
@@ -324,13 +325,14 @@ func TestRunDKGReshareAbsentNode(t *testing.T) {
 	dt.SetupNewNodes(t, nodesToAdd)
 
 	// we want to stop one node right after the group is created
-	nodeToStop := 1
+	nodeIndexToStop := 1
+	nodeToStop := dt.nodes[nodeIndexToStop]
 	leader := 0
 
 	dt.nodes[leader].drand.setupCB = func(g *key.Group) {
-		t.Logf("Stopping node %d \n", nodeToStop)
-		dt.nodes[nodeToStop].daemon.Stop(context.Background())
-		t.Logf("Node %d stopped \n", nodeToStop)
+		t.Logf("Stopping node %d \n", nodeIndexToStop)
+		nodeToStop.daemon.Stop(context.Background())
+		t.Logf("Node %d stopped \n", nodeIndexToStop)
 	}
 
 	t.Log("Setup reshare done. Starting reshare... Ignoring reshare errors")
@@ -345,8 +347,8 @@ func TestRunDKGReshareAbsentNode(t *testing.T) {
 	require.NotNil(t, newGroup)
 
 	// the node that had stopped must not be in the group
-	t.Logf("Check node %d is not included in the group \n", nodeToStop)
-	missingPublic := dt.nodes[nodeToStop].drand.priv.Public
+	t.Logf("Check node %d is not included in the group \n", nodeIndexToStop)
+	missingPublic := nodeToStop.drand.priv.Public
 	require.Nil(t, newGroup.Find(missingPublic), "missing public is found", missingPublic)
 }
 


### PR DESCRIPTION
If a node joins the DKG but goes unresponsive before completion, its
index can be missing from the group file.  If it comes back online
and starts sharing partial signatures, it can cause a segfault on the
nodes still in the network