### PR TITLE
Fixed reshare segfaults on invalid beaconId

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,10 +331,8 @@ following:
   protocol](https://eprint.iacr.org/2012/377.pdf) or an approach based on
   verifiable succinct computations (zk-SNARKs, etc).
 + Use / implement a faster pairing based library in JavaScript
-+ implemented ECIES private randomness in JavaScript (?)
 + Add more unit tests
 + Add a systemd unit file
-+ Support multiple drand instances within one node
 
 Feel free to submit feature requests or, even better, pull requests ;)
 

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -110,6 +110,7 @@ func (bp *BeaconProcess) InitDKG(c context.Context, in *drand.InitDKGPacket) (*d
 
 // InitReshare receives information about the old and new group from which to
 // operate the resharing protocol.
+// nolint:funlen
 func (bp *BeaconProcess) InitReshare(c context.Context, in *drand.InitResharePacket) (*drand.GroupPacket, error) {
 	if in.Old == nil {
 		return nil, errors.New("cannot reshare without an old group")

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -111,6 +111,10 @@ func (bp *BeaconProcess) InitDKG(c context.Context, in *drand.InitDKGPacket) (*d
 // InitReshare receives information about the old and new group from which to
 // operate the resharing protocol.
 func (bp *BeaconProcess) InitReshare(c context.Context, in *drand.InitResharePacket) (*drand.GroupPacket, error) {
+	if in.Old == nil {
+		return nil, errors.New("cannot reshare without an old group")
+	}
+
 	oldGroup, err := bp.extractGroup(in.Old)
 	if err != nil {
 		return nil, err

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -189,7 +189,7 @@ func (bp *BeaconProcess) SignalDKGParticipant(ctx context.Context, p *drand.Sign
 	bp.state.Lock()
 	if bp.manager == nil {
 		bp.state.Unlock()
-		return nil, errors.New("no manager")
+		return nil, errors.New("no DKG in progress; make sure you are using the correct --id flag for the chain")
 	}
 	addr := net.RemoteAddress(ctx)
 	// manager will verify if information are correct

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -186,11 +186,11 @@ func (bp *BeaconProcess) ChainInfo(ctx context.Context, in *drand.ChainInfoReque
 
 // SignalDKGParticipant receives a dkg signal packet from another member
 func (bp *BeaconProcess) SignalDKGParticipant(ctx context.Context, p *drand.SignalDKGPacket) (*drand.Empty, error) {
-	bp.state.Lock()
 	if bp.manager == nil {
-		bp.state.Unlock()
 		return nil, fmt.Errorf("no DKG in progress for beaconID %s", p.Metadata.BeaconID)
 	}
+
+	bp.state.Lock()
 	addr := net.RemoteAddress(ctx)
 	// manager will verify if information are correct
 	err := bp.manager.ReceivedKey(addr, p)
@@ -198,6 +198,7 @@ func (bp *BeaconProcess) SignalDKGParticipant(ctx context.Context, p *drand.Sign
 		return nil, err
 	}
 	bp.state.Unlock()
+
 	response := &drand.Empty{Metadata: bp.newMetadata()}
 	return response, nil
 }

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -186,11 +186,13 @@ func (bp *BeaconProcess) ChainInfo(ctx context.Context, in *drand.ChainInfoReque
 
 // SignalDKGParticipant receives a dkg signal packet from another member
 func (bp *BeaconProcess) SignalDKGParticipant(ctx context.Context, p *drand.SignalDKGPacket) (*drand.Empty, error) {
+	bp.state.Lock()
+
 	if bp.manager == nil {
+		bp.state.Unlock()
 		return nil, fmt.Errorf("no DKG in progress for beaconID %s", p.Metadata.BeaconID)
 	}
 
-	bp.state.Lock()
 	addr := net.RemoteAddress(ctx)
 	// manager will verify if information are correct
 	err := bp.manager.ReceivedKey(addr, p)
@@ -219,7 +221,7 @@ func (bp *BeaconProcess) PushDKGInfo(ctx context.Context, in *drand.DKGInfoPacke
 	return response, bp.receiver.PushDKGInfo(in)
 }
 
-// SyncChain is a inter-node protocol that replies to a syncing request from a
+// SyncChain is an inter-node protocol that replies to a syncing request from a
 // given round
 func (bp *BeaconProcess) SyncChain(req *drand.SyncRequest, stream drand.Protocol_SyncChainServer) error {
 	bp.state.Lock()

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -189,7 +189,7 @@ func (bp *BeaconProcess) SignalDKGParticipant(ctx context.Context, p *drand.Sign
 	bp.state.Lock()
 	if bp.manager == nil {
 		bp.state.Unlock()
-		return nil, errors.New("no DKG in progress; make sure you are using the correct --id flag for the chain")
+		return nil, fmt.Errorf("no DKG in progress for beaconID %s", p.Metadata.BeaconID)
 	}
 	addr := net.RemoteAddress(ctx)
 	// manager will verify if information are correct

--- a/core/drand_daemon_control.go
+++ b/core/drand_daemon_control.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/drand/drand/key"
@@ -52,9 +51,8 @@ func (dd *DrandDaemon) InitReshare(ctx context.Context, in *drand.InitResharePac
 	}
 
 	bp, err := dd.getBeaconProcessByID(beaconID)
-
 	if bp == nil {
-		return nil, errors.New(fmt.Sprintf("Beacon with ID %s could not be found - did you pass the id flag?", beaconID))
+		return nil, fmt.Errorf("beacon with ID %s could not be found - make sure you have passed the id flag or have a default beacon", beaconID)
 	}
 
 	if err != nil {

--- a/core/drand_daemon_control.go
+++ b/core/drand_daemon_control.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/drand/drand/key"
@@ -51,6 +52,11 @@ func (dd *DrandDaemon) InitReshare(ctx context.Context, in *drand.InitResharePac
 	}
 
 	bp, err := dd.getBeaconProcessByID(beaconID)
+
+	if bp == nil {
+		return nil, errors.New(fmt.Sprintf("Beacon with ID %s could not be found - did you pass the id flag?", beaconID))
+	}
+
 	if err != nil {
 		store, isStoreLoaded := dd.initialStores[beaconID]
 		if !isStoreLoaded {

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -1153,7 +1153,7 @@ func TestReshareWithInvalidBeaconIdInMetadataFailsButNoSegfault(t *testing.T) {
 		},
 	}
 	_, err := dt.nodes[1].daemon.InitReshare(context.Background(), &resharePacket)
-	require.Error(t, err, "Beacon with ID "+nonsenseBeaconID+" could not be found - did you pass the id flag?")
+	assert.EqualError(t, err, "beacon with ID "+nonsenseBeaconID+" could not be found - make sure you have passed the id flag or have a default beacon")
 }
 
 func TestReshareWithoutOldGroupFailsButNoSegfault(t *testing.T) {
@@ -1182,5 +1182,5 @@ func TestReshareWithoutOldGroupFailsButNoSegfault(t *testing.T) {
 	}
 
 	_, err := dt.nodes[1].daemon.InitReshare(context.Background(), &resharePacket)
-	require.Error(t, err, "cannot reshare without an old group")
+	assert.EqualError(t, err, "cannot reshare without an old group")
 }

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/drand/drand/protobuf/common"
 	"io"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/drand/drand/protobuf/common"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1128,7 +1129,7 @@ func TestReshareWithInvalidBeaconIdInMetadataFailsButNoSegfault(t *testing.T) {
 	dt := NewDrandTestScenario(t, n, thr, p, sch, beaconID)
 	_ = dt.RunDKG()
 
-	nonsenseBeaconId := "completely made up"
+	nonsenseBeaconID := "completely made up"
 	resharePacket := drand.InitResharePacket{
 		Old: &drand.GroupInfo{
 			Location: &drand.GroupInfo_Path{
@@ -1148,11 +1149,11 @@ func TestReshareWithInvalidBeaconIdInMetadataFailsButNoSegfault(t *testing.T) {
 			Force:         false,
 		},
 		Metadata: &common.Metadata{
-			BeaconID: nonsenseBeaconId,
+			BeaconID: nonsenseBeaconID,
 		},
 	}
 	_, err := dt.nodes[1].daemon.InitReshare(context.Background(), &resharePacket)
-	require.Error(t, err, "Beacon with ID "+nonsenseBeaconId+" could not be found - did you pass the id flag?")
+	require.Error(t, err, "Beacon with ID "+nonsenseBeaconID+" could not be found - did you pass the id flag?")
 }
 
 func TestReshareWithoutOldGroupFailsButNoSegfault(t *testing.T) {

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -1153,7 +1153,11 @@ func TestReshareWithInvalidBeaconIdInMetadataFailsButNoSegfault(t *testing.T) {
 		},
 	}
 	_, err := dt.nodes[1].daemon.InitReshare(context.Background(), &resharePacket)
-	assert.EqualError(t, err, "beacon with ID "+nonsenseBeaconID+" could not be found - make sure you have passed the id flag or have a default beacon")
+	assert.EqualError(
+		t,
+		err,
+		"beacon with ID "+nonsenseBeaconID+" could not be found - make sure you have passed the id flag or have a default beacon",
+	)
 }
 
 func TestReshareWithoutOldGroupFailsButNoSegfault(t *testing.T) {

--- a/net/client.go
+++ b/net/client.go
@@ -16,7 +16,7 @@ type Client interface {
 	HTTPClient
 }
 
-// Stopppable is an interface that some clients can implement to close their
+// Stoppable is an interface that some clients can implement to close their
 // operations
 type Stoppable interface {
 	Stop()


### PR DESCRIPTION
Passing an invalid beaconId or missing out the flag on a new node
without a default beacon would segfault taking down the host node.
Also, not passing an old group info to a reshare would also segfault the
host node.

Added some checks and tests for both.