### PR TITLE
Improved error messaging when using invalid flags for resharing

### DIFF
--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -152,7 +152,8 @@ var shareNodeFlag = &cli.IntFlag{
 }
 
 var transitionFlag = &cli.BoolFlag{
-	Name: "transition",
+	Name:    "reshare",
+	Aliases: []string{"transition"},
 	Usage: "When set, this flag indicates the share operation is a resharing. " +
 		"The node will use the currently stored group as the basis for the resharing",
 }

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	gnet "net"
 	"os"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/drand/drand/common"
 

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	gnet "net"
 	"os"
@@ -935,18 +936,20 @@ func TestSharingWithInvalidFlagCombos(t *testing.T) {
 
 	// leader and connect flags can't be used together
 	share1 := []string{
-		"drand", "share", "--tls-disable", "--folder", tmp, "--id", beaconID, "--leader", "--connect", "127.0.0.1:9090",
+		"drand", "share", "--tls-disable", "--id", beaconID, "--leader", "--connect", "127.0.0.1:9090",
+		"--threshold", "2", "--nodes", "3", "--period", "5s",
 	}
-	require.Error(t, CLI().Run(share1), "you can't use the leader and connect flags together")
+
+	assert.EqualError(t, CLI().Run(share1), "you can't use the leader and connect flags together")
 
 	// transition and from flags can't be used together
 	share3 := []string{
-		"drand", "share", "--tls-disable", "--folder", tmp, "--id", beaconID,
-		"--connect", "127.0.0.1:9090", "--transition", "--from somepath.txt",
+		"drand", "share", "--tls-disable", "--id", beaconID, "--connect", "127.0.0.1:9090", "--transition", "--from", "somepath.txt",
 	}
-	require.Error(
+
+	assert.EqualError(
 		t,
 		CLI().Run(share3),
-		"--from flag invalid with --transition - nodes resharing should already have a secret share and group ready to use",
+		"--from flag invalid with --reshare - nodes resharing should already have a secret share and group ready to use",
 	)
 }

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -772,7 +772,7 @@ func (bp *BeaconProcess) extractGroup(old *drand.GroupInfo) (oldGroup *key.Group
 
 	currentGroup := bp.group
 	if currentGroup == nil {
-		return nil, errors.New("can't init-reshare if no old group provided - try using the --from flag")
+		return nil, errors.New("can't init-reshare if no old group provided - try providing a group file")
 	}
 
 	bp.log.With("module", "control").Debugw("", "init_reshare", "using_stored_group")

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -772,7 +772,7 @@ func (bp *BeaconProcess) extractGroup(old *drand.GroupInfo) (oldGroup *key.Group
 
 	currentGroup := bp.group
 	if currentGroup == nil {
-		return nil, errors.New("drand: can't init-reshare if no old group provided")
+		return nil, errors.New("can't init-reshare if no old group provided - try using the --from flag")
 	}
 
 	bp.log.With("module", "control").Debugw("", "init_reshare", "using_stored_group")


### PR DESCRIPTION
Improved error messaging when using invalid flags for resharing
renamed transition flag to reshare, retaining transition as an alias
