### PR TITLE
Show full path of duplicate keypair

### DIFF
--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -690,7 +690,8 @@ func keygenCmd(c *cli.Context) error {
 	fileStore := key.NewFileStore(config.ConfigFolderMB(), beaconID)
 
 	if _, err := fileStore.LoadKeyPair(); err == nil {
-		fmt.Fprintf(output, "Keypair already present in `%s`.\nRemove them before generating new one\n", config.ConfigFolderMB())
+		keyDirectory := path.Join(config.ConfigFolderMB(), beaconID)
+		fmt.Fprintf(output, "Keypair already present in `%s`.\nRemove them before generating new one\n", keyDirectory)
 		return nil
 	}
 	if err := fileStore.SaveKeyPair(priv); err != nil {


### PR DESCRIPTION
putting the --id flag after the cmd args ignores it (see: https://github.com/urfave/cli/issues/585), but it isn't clear
where the command actually looked for the keypair