### PR TITLE
Force flag -f alias migrated to new format

### DIFF
--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -84,8 +84,9 @@ var tlsKeyFlag = &cli.StringFlag{
 }
 
 var insecureFlag = &cli.BoolFlag{
-	Name:  "tls-disable",
-	Usage: "Disable TLS for all communications (not recommended).",
+	Name:    "tls-disable",
+	Aliases: []string{"insecure"},
+	Usage:   "Disable TLS for all communications (not recommended).",
 }
 
 var controlFlag = &cli.StringFlag{
@@ -157,8 +158,9 @@ var transitionFlag = &cli.BoolFlag{
 }
 
 var forceFlag = &cli.BoolFlag{
-	Name:  "force, f",
-	Usage: "When set, this flag forces the daemon to start a new reshare operation." + "By default, it does not allow to restart one",
+	Name:    "force",
+	Aliases: []string{"f"},
+	Usage:   "When set, this flag forces the daemon to start a new reshare operation." + "By default, it does not allow to restart one",
 }
 
 // secret flag is the "manual" security when the "leader"/coordinator creates the
@@ -241,11 +243,6 @@ var hashInfoReq = &cli.StringFlag{
 	Name:     "chain-hash",
 	Usage:    "The hash of the chain info, used to validate integrity of the received group info",
 	Required: true,
-}
-
-var hashInfoNoReq = &cli.StringFlag{
-	Name:  "chain-hash",
-	Usage: "The hash of the chain info",
 }
 
 // using a simple string flag because the StringSliceFlag is not intuitive
@@ -342,7 +339,7 @@ var appCommands = []*cli.Command{
 	{
 		Name:  "sync",
 		Usage: "sync your local randomness chain with other nodes and validate your local beacon chain",
-		Flags: toArray(folderFlag, controlFlag, hashInfoNoReq, syncNodeFlag,
+		Flags: toArray(folderFlag, controlFlag, hashInfoReq, syncNodeFlag,
 			tlsCertFlag, insecureFlag, upToFlag, beaconIDFlag, followFlag),
 		Action: syncCmd,
 	},
@@ -408,7 +405,7 @@ var appCommands = []*cli.Command{
 				Name:      "chain-info",
 				Usage:     "Get the binding chain information that this node participates to",
 				ArgsUsage: "`ADDRESS1` `ADDRESS2` ... provides the addresses of the node to try to contact to.",
-				Flags:     toArray(tlsCertFlag, insecureFlag, hashOnly, hashInfoNoReq),
+				Flags:     toArray(tlsCertFlag, insecureFlag, hashOnly, hashInfoReq),
 				Action:    getChainInfo,
 			},
 		},

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -245,6 +245,11 @@ var hashInfoReq = &cli.StringFlag{
 	Required: true,
 }
 
+var hashInfoNoReq = &cli.StringFlag{
+	Name:  "chain-hash",
+	Usage: "The hash of the chain info",
+}
+
 // using a simple string flag because the StringSliceFlag is not intuitive
 // see https://github.com/urfave/cli/issues/62
 var syncNodeFlag = &cli.StringFlag{
@@ -339,7 +344,7 @@ var appCommands = []*cli.Command{
 	{
 		Name:  "sync",
 		Usage: "sync your local randomness chain with other nodes and validate your local beacon chain",
-		Flags: toArray(folderFlag, controlFlag, hashInfoReq, syncNodeFlag,
+		Flags: toArray(folderFlag, controlFlag, hashInfoNoReq, syncNodeFlag,
 			tlsCertFlag, insecureFlag, upToFlag, beaconIDFlag, followFlag),
 		Action: syncCmd,
 	},
@@ -405,7 +410,7 @@ var appCommands = []*cli.Command{
 				Name:      "chain-info",
 				Usage:     "Get the binding chain information that this node participates to",
 				ArgsUsage: "`ADDRESS1` `ADDRESS2` ... provides the addresses of the node to try to contact to.",
-				Flags:     toArray(tlsCertFlag, insecureFlag, hashOnly, hashInfoReq),
+				Flags:     toArray(tlsCertFlag, insecureFlag, hashOnly, hashInfoNoReq),
 				Action:    getChainInfo,
 			},
 		},

--- a/cmd/drand-cli/public.go
+++ b/cmd/drand-cli/public.go
@@ -106,8 +106,8 @@ func getPublicRandomness(c *cli.Context) error {
 func getChainInfo(c *cli.Context) error {
 	var err error
 	chainHash := make([]byte, 0)
-	if c.IsSet(hashInfoNoReq.Name) {
-		if chainHash, err = hex.DecodeString(c.String(hashInfoNoReq.Name)); err != nil {
+	if c.IsSet(hashInfoReq.Name) {
+		if chainHash, err = hex.DecodeString(c.String(hashInfoReq.Name)); err != nil {
 			return fmt.Errorf("invalid chain hash given: %w", err)
 		}
 	}

--- a/cmd/drand-cli/public.go
+++ b/cmd/drand-cli/public.go
@@ -106,7 +106,7 @@ func getPublicRandomness(c *cli.Context) error {
 func getChainInfo(c *cli.Context) error {
 	var err error
 	chainHash := make([]byte, 0)
-	if c.IsSet(hashInfoReq.Name) {
+	if c.IsSet(hashInfoNoReq.Name) {
 		if chainHash, err = hex.DecodeString(c.String(hashInfoReq.Name)); err != nil {
 			return fmt.Errorf("invalid chain hash given: %w", err)
 		}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -26,22 +26,21 @@ func HomeFolder() string {
 // CreateSecureFolder checks if the folder exists and has the appropriate permission rights. In case of bad permission rights
 // the empty string is returned. If the folder doesn't exist it, create it.
 func CreateSecureFolder(folder string) string {
-	if exists, _ := Exists(folder); !exists {
-		if err := os.MkdirAll(folder, defaultDirectoryPermission); err != nil {
-			panic(err)
-		}
-	} else {
-		// the folder exists already
+	if exists, _ := Exists(folder); exists {
 		info, err := os.Lstat(folder)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "Error checking stat folder: ", err)
 			return ""
 		}
-		perm := int(info.Mode().Perm())
-		if perm != int(defaultDirectoryPermission) {
+
+		if perm := int(info.Mode().Perm()); perm != defaultDirectoryPermission {
 			fmt.Fprintf(os.Stderr, "Folder different permission: %#o vs %#o \n", perm, defaultDirectoryPermission)
-			return folder
 		}
+		return folder
+	}
+
+	if err := os.MkdirAll(folder, defaultDirectoryPermission); err != nil {
+		panic(err)
 	}
 	return folder
 }


### PR DESCRIPTION
Prior versions of the cli tool allowed comma separated strings for
aliases, but they no longer work. Updated to the array alias format

despaghettified some things on my adventure