### PR TITLE
Allow old nodes to sync

### DIFF
--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/drand/drand/key"
 	"github.com/drand/drand/log"
 	"github.com/drand/drand/net"
+	pbCommon "github.com/drand/drand/protobuf/common"
 	"github.com/drand/drand/protobuf/drand"
 	"github.com/drand/drand/test"
 	testnet "github.com/drand/drand/test/net"
@@ -26,6 +27,7 @@ import (
 	"github.com/drand/kyber/share"
 	"github.com/drand/kyber/util/random"
 	clock "github.com/jonboulle/clockwork"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -624,6 +626,27 @@ func TestProcessingPartialBeaconWithNonExistentIndexDoesntSegfault(t *testing.T)
 	}
 	_, err := bt.nodes[0].handler.ProcessPartialBeacon(context.Background(), &packet)
 	require.Error(t, err, "attempted to process beacon from node of index 25958, but it was not in the group file")
+}
+
+func TestSyncChainWithoutMetadata(t *testing.T) {
+	logger := log.NewLogger(nil, log.LogDebug).Named("BeaconTest")
+	expectedBeaconID := "someGreatBeacon"
+
+	require.Equal(t, beaconIDToSync(logger, TestSyncRequest{round: 1, metadata: nil}, "127.0.0.1"), "default")
+	require.Equal(t, beaconIDToSync(logger, TestSyncRequest{round: 1, metadata: &pbCommon.Metadata{BeaconID: expectedBeaconID}}, "127.0.0.1"), expectedBeaconID)
+}
+
+type TestSyncRequest struct {
+	round    uint64
+	metadata *pbCommon.Metadata
+}
+
+func (t TestSyncRequest) GetFromRound() uint64 {
+	return t.round
+}
+
+func (t TestSyncRequest) GetMetadata() *pbCommon.Metadata {
+	return t.metadata
 }
 
 func (b *BeaconTest) CallbackFor(i int, fn func(*chain.Beacon)) {

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -632,8 +632,16 @@ func TestSyncChainWithoutMetadata(t *testing.T) {
 	logger := log.NewLogger(nil, log.LogDebug).Named("BeaconTest")
 	expectedBeaconID := "someGreatBeacon"
 
-	require.Equal(t, beaconIDToSync(logger, TestSyncRequest{round: 1, metadata: nil}, "127.0.0.1"), "default")
-	require.Equal(t, beaconIDToSync(logger, TestSyncRequest{round: 1, metadata: &pbCommon.Metadata{BeaconID: expectedBeaconID}}, "127.0.0.1"), expectedBeaconID)
+	require.Equal(
+		t,
+		beaconIDToSync(logger, TestSyncRequest{round: 1, metadata: nil}, "127.0.0.1"),
+		"default",
+	)
+	require.Equal(
+		t,
+		beaconIDToSync(logger, TestSyncRequest{round: 1, metadata: &pbCommon.Metadata{BeaconID: expectedBeaconID}}, "127.0.0.1"),
+		expectedBeaconID,
+	)
 }
 
 type TestSyncRequest struct {

--- a/chain/beacon/sync_manager.go
+++ b/chain/beacon/sync_manager.go
@@ -518,6 +518,8 @@ func SyncChain(l log.Logger, store CallbackStore, req SyncRequest, stream SyncSt
 	}
 }
 
+// Versions prior to 1.4 did not support multibeacon and thus did not have attached metadata.
+// This function resolves the `beaconId` given a `SyncRequest`
 func beaconIDToSync(logger log.Logger, req SyncRequest, addr string) string {
 	// this should only happen if the requester is on a version < 1.4
 	if req.GetMetadata() == nil {


### PR DESCRIPTION
Old nodes don't have a metadata object, as they did not support
multibeacon
Assume these nodes wish to sync default.