### PR TITLE
Adding logs of disqualified nodes during DKG

### DIFF
--- a/core/broadcast.go
+++ b/core/broadcast.go
@@ -135,7 +135,7 @@ func (b *echoBroadcast) BroadcastDKG(c context.Context, p *drand.DKGPacket) (*dr
 	}
 
 	b.l.Debugw("", "echoBroadcast",
-		"received new packet to echoBroadcast", "from", addr, "type", fmt.Sprintf("%T", dkgPacket))
+		"received new packet to echoBroadcast", "from", addr, "index", dkgPacket.Index(), "type", fmt.Sprintf("%T", dkgPacket))
 	b.sendout(hash, dkgPacket, false) // we're using the rate limiting
 	b.passToApplication(dkgPacket)
 	return new(drand.Empty), nil

--- a/core/constants.go
+++ b/core/constants.go
@@ -33,7 +33,7 @@ const DefaultControlPort = "8888"
 // that by default, DKG uses the "fast sync" mode that shorten the first phase
 // and the second phase, "as fast as possible" when the protocol runs smoothly
 // (there is no malicious party).
-const DefaultDKGTimeout = 10 * time.Second
+const DefaultDKGTimeout = 15 * time.Second
 
 // EciesHash is the hash function used for the ECIES encryption used in the
 // private randomness feature.

--- a/core/constants.go
+++ b/core/constants.go
@@ -33,7 +33,7 @@ const DefaultControlPort = "8888"
 // that by default, DKG uses the "fast sync" mode that shorten the first phase
 // and the second phase, "as fast as possible" when the protocol runs smoothly
 // (there is no malicious party).
-const DefaultDKGTimeout = 15 * time.Second
+const DefaultDKGTimeout = 10 * time.Second
 
 // EciesHash is the hash function used for the ECIES encryption used in the
 // private randomness feature.

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -177,10 +177,17 @@ func (bp *BeaconProcess) WaitDKG() (*key.Group, error) {
 	// filter the nodes that are not present in the target group
 	var qualNodes []*key.Node
 	for _, node := range bp.dkgInfo.target.Nodes {
+		found := false
 		for _, qualNode := range res.Result.QUAL {
 			if qualNode.Index == node.Index {
 				qualNodes = append(qualNodes, node)
+				found = true
+				break
 			}
+		}
+
+		if !found {
+			bp.log.Debugw("disqualified node during DKG", "node", node)
 		}
 	}
 

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -937,7 +937,7 @@ func (bp *BeaconProcess) getPhaser(timeout uint32) *dkg.TimePhaser {
 	logger := bp.log
 	return dkg.NewTimePhaserFunc(func(phase dkg.Phase) {
 		bp.opts.clock.Sleep(tDuration)
-		logger.Debugw("", "phaser_finished", phase)
+		logger.Debugw("phaser timeout", "phaser_finished", phase)
 	})
 }
 

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -21,10 +21,11 @@ func (bp *BeaconProcess) BroadcastDKG(c context.Context, in *drand.DKGPacket) (*
 	bp.state.Lock()
 	defer bp.state.Unlock()
 
-	if bp.dkgInfo == nil {
-		return nil, errors.New("drand: no dkg running")
-	}
 	addr := net.RemoteAddress(c)
+
+	if bp.dkgInfo == nil {
+		return nil, fmt.Errorf("drand: no dkg running and yet received a DKGPacket for beacon %s from node %s", bp.beaconID, addr)
+	}
 
 	if !bp.dkgInfo.started {
 		bp.log.Infow("", "init_dkg", "START DKG",


### PR DESCRIPTION
This is adding a few more logs to our DKG.

Notice that the phaser will always proceed with its phases in order, just waiting its timeout time between each phases, without checking whether or not the phase was "successful" or not. 

This might be something we might want to rework in the future...