### PR TITLE
Bump version and cleanup tempdir usage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -133,7 +133,6 @@ linters:
     # -wrapcheck
     # -wsl
 
-
 linters-settings:
   dupl:
     threshold: 100

--- a/chain/beacon/sync_manager.go
+++ b/chain/beacon/sync_manager.go
@@ -42,7 +42,6 @@ type SyncManager struct {
 	// updated with each new beacon we receive from sync
 	newSync chan *chain.Beacon
 	done    chan bool
-	isDone  bool
 	mu      sync.Mutex
 	// we need to know our current daemon address
 	nodeAddr string
@@ -86,7 +85,6 @@ func NewSyncManager(c *SyncConfig) *SyncManager {
 		factor:        syncExpiryFactor,
 		newReq:        make(chan requestInfo, syncQueueRequest),
 		newSync:       make(chan *chain.Beacon, 1),
-		isDone:        false,
 		done:          make(chan bool, 1),
 	}
 }
@@ -94,10 +92,6 @@ func NewSyncManager(c *SyncConfig) *SyncManager {
 func (s *SyncManager) Stop() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.isDone {
-		return
-	}
-	s.isDone = true
 	close(s.done)
 }
 

--- a/common/version.go
+++ b/common/version.go
@@ -13,8 +13,8 @@ import (
 var version = Version{
 	Major:      1,
 	Minor:      4,
-	Patch:      6,
-	Prerelease: "testnet",
+	Patch:      7,
+	Prerelease: "",
 }
 
 // Set via -ldflags. Example:

--- a/core/broadcast.go
+++ b/core/broadcast.go
@@ -241,7 +241,8 @@ func senderQueueSize(nodes int) int {
 	if nodes > maxQueueSize {
 		return maxQueueSize
 	}
-	return nodes
+	// we have 3 steps
+	return nodes * 3 //nolint:gomnd
 }
 
 // dispatcher maintains a list of worker assigned one destination and pushes the

--- a/core/broadcast_test.go
+++ b/core/broadcast_test.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -67,9 +66,8 @@ func TestBroadcastSet(t *testing.T) {
 func TestBroadcast(t *testing.T) {
 	n := 5
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
-	_, drands, group, dir, _ := BatchNewDrand(t, n, true, sch, beaconID)
-	defer os.RemoveAll(dir)
-	defer CloseAllDrands(drands)
+	//nolint:dogsled
+	_, drands, group, _, _ := BatchNewDrand(t, n, true, sch, beaconID)
 
 	// channel that will receive all broadcasted packets
 	incPackets := make(chan *packInfo)
@@ -99,7 +97,7 @@ func TestBroadcast(t *testing.T) {
 		for i := 0; i < exp; i++ {
 			select {
 			case info := <-incPackets:
-				t.Logf("received packet from %s, %d out of %d", info.id, i, exp)
+				t.Logf("received packet from %s, %d out of %d", info.id, i+1, exp)
 				received[info.id] = true
 			case <-time.After(5 * time.Second):
 				require.True(t, false, "test failed to continue")

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -283,8 +283,21 @@ func (bp *BeaconProcess) transition(oldGroup *key.Group, oldPresent, newPresent 
 
 // Stop simply stops all drand operations.
 func (bp *BeaconProcess) Stop(ctx context.Context) {
+	select {
+	case <-bp.exitCh:
+		bp.log.Errorw("Trying to stop an already stopping beacon process", "id", bp.getBeaconID())
+		return
+	default:
+		bp.log.Debugw("Stopping BeaconProcess", "id", bp.getBeaconID())
+	}
 	bp.StopBeacon()
-	bp.exitCh <- true
+	// we wait until we can send on the channel or the context got canceled
+	select {
+	case bp.exitCh <- true:
+		close(bp.exitCh)
+	case <-ctx.Done():
+		bp.log.Warnw("Context canceled, BeaconProcess exitCh probably blocked")
+	}
 }
 
 // WaitExit returns a channel that signals when drand stops its operations
@@ -367,7 +380,7 @@ func (bp *BeaconProcess) isFreshRun() bool {
 
 	isFresh := errG != nil || errS != nil
 
-	bp.log.Warnw("errors while loading group or share", "error group", errG, "error share", errS, "will run as fresh run", isFresh)
+	bp.log.Debugw("Status when loading group or share", "group error", errG, "share error", errS, "will run as fresh run", isFresh)
 
 	return isFresh
 }

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -75,7 +75,7 @@ func (bp *BeaconProcess) PublicRand(c context.Context, in *drand.PublicRandReque
 		bp.log.Debugw("", "public_rand", "unstored_beacon", "round", in.GetRound(), "from", addr)
 		return nil, fmt.Errorf("can't retrieve beacon: %w %s", err, beaconResp)
 	}
-	bp.log.Infow("", "public_rand", addr, "round", beaconResp.Round, "reply", beaconResp.String())
+	bp.log.Debugw("", "public_rand", addr, "round", beaconResp.Round, "reply", beaconResp.String())
 
 	response := beaconToProto(beaconResp)
 	response.Metadata = bp.newMetadata()

--- a/core/drand_beacon_test.go
+++ b/core/drand_beacon_test.go
@@ -2,38 +2,18 @@ package core
 
 import (
 	"context"
-	"net"
-	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/drand/drand/common/scheme"
 	"github.com/drand/drand/log"
 	"github.com/drand/drand/test"
-	"github.com/stretchr/testify/assert"
-
-	"github.com/stretchr/testify/require"
 )
 
-func TestNoPanicWhenDrandDaemonPortInUse(t *testing.T) {
-	// bind a random port on localhost
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err, "Failed to bind port for testing")
-	defer listener.Close()
-	inUsePort := listener.Addr().(*net.TCPAddr).Port
-
-	// configure the daemon to try and bind the same port
-	config := NewConfig()
-	config.insecure = true
-	config.controlPort = strconv.Itoa(inUsePort)
-	config.privateListenAddr = "127.0.0.1:0"
-
-	// an error is returned during daemon creation instead of panicking
-	_, err = NewDrandDaemon(config)
-	require.Error(t, err)
-}
-
-func TestDrandDaemon_Stop(t *testing.T) {
+func TestBeaconProcess_Stop(t *testing.T) {
 	sch := scheme.GetSchemeFromEnv()
 	privs, _ := test.BatchIdentities(1, sch, t.Name())
 
@@ -42,8 +22,8 @@ func TestDrandDaemon_Stop(t *testing.T) {
 	confOptions := []ConfigOption{
 		WithConfigFolder(t.TempDir()),
 		WithPrivateListenAddress("127.0.0.1:0"),
-		WithInsecure(),
 		WithControlPort(port),
+		WithInsecure(),
 		WithLogLevel(log.LogDebug, false),
 	}
 
@@ -61,14 +41,8 @@ func TestDrandDaemon_Stop(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	dd.Stop(ctx)
-	if closing, ok := <-dd.WaitExit(); !ok || !closing {
-		t.Fatal("Expecting to receive from exit channel")
-	}
-	if _, ok := <-dd.WaitExit(); ok {
-		t.Fatal("Expecting exit channel to be closed")
-	}
-	if closing, ok := <-proc.WaitExit(); !ok || !closing {
+	proc.Stop(ctx)
+	if closed, ok := <-proc.WaitExit(); !ok || !closed {
 		t.Fatal("Expecting to receive from exit channel")
 	}
 	if _, ok := <-proc.WaitExit(); ok {
@@ -76,5 +50,5 @@ func TestDrandDaemon_Stop(t *testing.T) {
 	}
 	proc.Stop(ctx)
 	time.Sleep(250 * time.Millisecond)
-	dd.Stop(ctx)
+	proc.Stop(ctx)
 }

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -90,7 +90,6 @@ func TestRunDKG(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, key.DefaultThreshold(n), expectedBeaconPeriod, sch, beaconID)
-	defer dt.Cleanup()
 
 	group := dt.RunDKG()
 
@@ -116,7 +115,6 @@ func TestRunDKGLarge(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, key.DefaultThreshold(n), expectedBeaconPeriod, sch, beaconID)
-	defer dt.Cleanup()
 
 	group := dt.RunDKG()
 
@@ -138,7 +136,6 @@ func TestDrandDKGFresh(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, key.DefaultThreshold(n), beaconPeriod, sch, beaconID)
-	defer dt.Cleanup()
 
 	// Run DKG
 	finalGroup := dt.RunDKG()
@@ -187,7 +184,6 @@ func TestRunDKGBroadcastDeny(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, beaconPeriod, sch, beaconID)
-	defer dt.Cleanup()
 
 	// close connection between a pair of nodes
 	node1 := dt.nodes[1]
@@ -227,7 +223,6 @@ func TestRunDKGReshareForce(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, oldNodes, oldThreshold, beaconPeriod, sch, beaconID)
-	defer dt.Cleanup()
 
 	group1 := dt.RunDKG()
 
@@ -306,7 +301,6 @@ func TestRunDKGReshareAbsentNode(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, oldNodes, oldThreshold, beaconPeriod, sch, beaconID)
-	defer dt.Cleanup()
 
 	group1 := dt.RunDKG()
 
@@ -334,8 +328,9 @@ func TestRunDKGReshareAbsentNode(t *testing.T) {
 	leader := 0
 
 	dt.nodes[leader].drand.setupCB = func(g *key.Group) {
-		t.Logf("Stopping node %d \n", nodeIndexToStop)
+		t.Logf("Stopping node for test: %s \n", nodeToStop.addr)
 		nodeToStop.daemon.Stop(context.Background())
+		<-nodeToStop.daemon.WaitExit()
 		t.Logf("Node %d stopped \n", nodeIndexToStop)
 	}
 
@@ -368,7 +363,6 @@ func TestRunDKGReshareTimeout(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, oldNodes, oldThreshold, beaconPeriod, sch, beaconID)
-	defer dt.Cleanup()
 
 	group1 := dt.RunDKG()
 
@@ -493,7 +487,6 @@ func TestRunDKGResharePreempt(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, oldN, Thr, beaconPeriod, sch, beaconID)
-	defer dt.Cleanup()
 
 	group1 := dt.RunDKG()
 
@@ -593,7 +586,6 @@ func TestDrandPublicChainInfo(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, p, sch, beaconID)
-	defer dt.Cleanup()
 
 	group := dt.RunDKG()
 
@@ -649,7 +641,6 @@ func TestDrandPublicRand(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, p, sch, beaconID)
-	defer dt.Cleanup()
 
 	group := dt.RunDKG()
 
@@ -714,7 +705,6 @@ func TestDrandPublicStream(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, p, sch, beaconID)
-	defer dt.Cleanup()
 
 	group := dt.RunDKG()
 
@@ -827,7 +817,6 @@ func TestDrandFollowChain(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, key.DefaultThreshold(n), p, sch, beaconID)
-	defer dt.Cleanup()
 
 	group := dt.RunDKG()
 	rootID := dt.nodes[0].drand.priv.Public
@@ -939,7 +928,6 @@ func TestDrandCheckChain(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, key.DefaultThreshold(n), p, sch, beaconID)
-	defer dt.Cleanup()
 
 	group := dt.RunDKG()
 	rootID := dt.nodes[0].drand.priv.Public
@@ -1064,7 +1052,6 @@ func TestDrandPublicStreamProxy(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, p, sch, beaconID)
-	defer dt.Cleanup()
 
 	group := dt.RunDKG()
 
@@ -1174,7 +1161,6 @@ func TestReshareWithoutOldGroupFailsButNoSegfault(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, p, sch, beaconID)
-	defer dt.Cleanup()
 	_ = dt.RunDKG()
 
 	resharePacket := drand.InitResharePacket{
@@ -1205,7 +1191,6 @@ func TestModifyingGroupFileManuallyDoesNotSegfault(t *testing.T) {
 	sch, beaconID := scheme.GetSchemeFromEnv(), test.GetBeaconIDFromEnv()
 
 	dt := NewDrandTestScenario(t, n, thr, p, sch, beaconID)
-	defer dt.Cleanup()
 
 	node := dt.nodes[0]
 	dir := dt.dir

--- a/demo/lib/orchestrator.go
+++ b/demo/lib/orchestrator.go
@@ -63,14 +63,15 @@ type Orchestrator struct {
 
 func NewOrchestrator(n int, thr int, period string, tls bool, binary string, withCurl bool, sch scheme.Scheme, beaconID string, isCandidate bool) *Orchestrator {
 	basePath := path.Join(os.TempDir(), "drand-full")
+	// cleanup the basePath before doing anything
 	os.RemoveAll(basePath)
 
 	fmt.Printf("[+] Simulation global folder: %s\n", basePath)
-	checkErr(os.MkdirAll(basePath, 0740))
+	checkErr(os.MkdirAll(basePath, 0o740))
 	certFolder := path.Join(basePath, "certs")
 	beaconID = common.GetCanonicalBeaconID(beaconID)
 
-	checkErr(os.MkdirAll(certFolder, 0740))
+	checkErr(os.MkdirAll(certFolder, 0o740))
 	nodes, paths := createNodes(n, 1, period, basePath, certFolder, tls, binary, sch, beaconID, isCandidate)
 
 	periodD, err := time.ParseDuration(period)

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -1,7 +1,6 @@
 package fs
 
 import (
-	"os"
 	"path"
 	"testing"
 
@@ -9,9 +8,8 @@ import (
 )
 
 func TestSecureDirAlreadyHere(t *testing.T) {
-	tmpPath := path.Join(os.TempDir(), "config")
-	os.Mkdir(tmpPath, 0740)
-	defer os.RemoveAll(tmpPath)
+	tmpPath := path.Join(t.TempDir(), "config")
+
 	fpath := CreateSecureFolder(tmpPath)
 	require.NotNil(t, fpath)
 
@@ -52,7 +50,7 @@ func TestSecureDirAlreadyHere(t *testing.T) {
 }
 
 func TestCopyFolder(t *testing.T) {
-	tmpPath := path.Join(os.TempDir(), "tmp")
+	tmpPath := path.Join(t.TempDir(), "tmp")
 	folder1Path := path.Join(tmpPath, "folder1")
 	subFolder1Path := path.Join(folder1Path, "folder1")
 

--- a/key/group_test.go
+++ b/key/group_test.go
@@ -136,11 +136,10 @@ func TestGroupSaveLoad(t *testing.T) {
 	require.NotNil(t, gtoml.PublicKey)
 
 	// faking distributed public key coefficients
-	groupFile, err := os.CreateTemp("", "group.toml")
+	groupFile, err := os.CreateTemp(t.TempDir(), "group.toml")
 	require.NoError(t, err)
 	groupPath := groupFile.Name()
 	groupFile.Close()
-	defer os.RemoveAll(groupPath)
 
 	require.NoError(t, Save(groupPath, group, false))
 	// load the seed after

--- a/key/store_test.go
+++ b/key/store_test.go
@@ -18,11 +18,7 @@ func TestKeysSaveLoad(t *testing.T) {
 	// we don't use the function from the test package here to avoid a circular dependency
 	beaconID := commonutils.GetCanonicalBeaconID(os.Getenv("BEACON_ID"))
 
-	tmp := os.TempDir()
-	tmp = path.Join(tmp, "drand-key")
-
-	os.RemoveAll(tmp)
-	defer os.RemoveAll(tmp)
+	tmp := path.Join(t.TempDir(), "drand-key")
 
 	store := NewFileStore(tmp, beaconID).(*fileStore)
 	require.Equal(t, tmp, store.baseFolder)

--- a/lp2p/addrutil.go
+++ b/lp2p/addrutil.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/transport"
 	ma "github.com/multiformats/go-multiaddr"
 	madns "github.com/multiformats/go-multiaddr-dns"
 )
@@ -16,7 +17,7 @@ const (
 )
 
 // resolveAddresses resolves addresses in parallel
-func resolveAddresses(ctx context.Context, addrs []ma.Multiaddr, resolver *madns.Resolver) ([]peer.AddrInfo, error) {
+func resolveAddresses(ctx context.Context, addrs []ma.Multiaddr, resolver transport.Resolver) ([]peer.AddrInfo, error) {
 	ctx, cancel := context.WithTimeout(ctx, dnsResolveTimeout)
 	defer cancel()
 

--- a/lp2p/client/client.go
+++ b/lp2p/client/client.go
@@ -181,7 +181,7 @@ func (c *Client) Watch(ctx context.Context) <-chan client.Result {
 				}
 				select {
 				case outerCh <- dat:
-					c.log.Debug("processed random message")
+					c.log.Debugw("processed random beacon", "round", dat.Round())
 				default:
 					c.log.Warnw("", "gossip client", "randomness notification dropped due to a full channel")
 				}

--- a/lp2p/relaynode.go
+++ b/lp2p/relaynode.go
@@ -73,7 +73,7 @@ func NewGossipRelayNode(l log.Logger, cfg *GossipRelayConfig) (*GossipRelayNode,
 	for _, a := range addrs {
 		l.Infow("", "relay_node", "has addr", "addr", fmt.Sprintf("%s/p2p/%s", a, h.ID()))
 	}
-
+	l.Infow("Joining PubSubTopic", "chainhash", cfg.ChainHash)
 	t, err := ps.Join(PubSubTopic(cfg.ChainHash))
 	if err != nil {
 		return nil, fmt.Errorf("joining topic: %w", err)

--- a/net/gateway_test.go
+++ b/net/gateway_test.go
@@ -86,9 +86,9 @@ func testListenerTLS(t *testing.T) {
 	}
 	hostAddr := "127.0.0.1"
 
-	tmpDir := path.Join(os.TempDir(), "drand-net")
+	tmpDir := path.Join(t.TempDir(), "drand-net")
 	require.NoError(t, os.MkdirAll(tmpDir, 0766))
-	defer os.RemoveAll(tmpDir)
+
 	certPath := path.Join(tmpDir, "server.crt")
 	keyPath := path.Join(tmpDir, "server.key")
 	if httpscerts.Check(certPath, keyPath) != nil {

--- a/test/mock/grpcserver.go
+++ b/test/mock/grpcserver.go
@@ -109,6 +109,7 @@ func (s *Server) EmitRand(closeStream bool) {
 	stream := s.stream
 	done := s.streamDone
 	s.l.Unlock()
+
 	if closeStream {
 		close(done)
 		fmt.Println("MOCK SERVER: closing stream upon request")
@@ -131,7 +132,7 @@ func (s *Server) EmitRand(closeStream bool) {
 		fmt.Println("MOCK SERVER: stream send error:", err)
 		return
 	}
-	fmt.Println("MOCK SERVER: emit round done")
+	fmt.Println("MOCK SERVER: emit round done", resp.Round)
 }
 
 func testValid(d *Data) {


### PR DESCRIPTION
This is doing a couple of different things:
- Bump the version to 1.4.7
- Address some linter complaints
- Make sure we are consistently deleting temporary files
- Make sure nodes are shutdown after each test