### PR TITLE
Update the Store and Cursor interfaces to accept Context and return errors

### DIFF
--- a/chain/beacon/callbacks_test.go
+++ b/chain/beacon/callbacks_test.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/chain/boltdb"
-	"github.com/drand/drand/log"
+	"github.com/drand/drand/test"
 )
 
 func TestStoreCallback(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
-	l := log.NewLogger(nil, log.LogDebug)
+	l := test.Logger(t)
 	bbstore, err := boltdb.NewBoltStore(l, dir, nil)
 	require.NoError(t, err)
 	cb := NewCallbackStore(bbstore)

--- a/chain/beacon/callbacks_test.go
+++ b/chain/beacon/callbacks_test.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/chain/boltdb"
+	"github.com/drand/drand/log"
 )
 
 func TestStoreCallback(t *testing.T) {
 	dir := t.TempDir()
-	bbstore, err := boltdb.NewBoltStore(dir, nil)
+	l := log.NewLogger(nil, log.LogDebug)
+	bbstore, err := boltdb.NewBoltStore(l, dir, nil)
 	require.NoError(t, err)
 	cb := NewCallbackStore(bbstore)
 	id1 := "superid"

--- a/chain/beacon/callbacks_test.go
+++ b/chain/beacon/callbacks_test.go
@@ -1,6 +1,7 @@
 package beacon
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 
 func TestStoreCallback(t *testing.T) {
 	dir := t.TempDir()
+	ctx := context.Background()
 	l := log.NewLogger(nil, log.LogDebug)
 	bbstore, err := boltdb.NewBoltStore(l, dir, nil)
 	require.NoError(t, err)
@@ -23,12 +25,12 @@ func TestStoreCallback(t *testing.T) {
 		doneCh <- true
 	})
 
-	cb.Put(&chain.Beacon{
+	cb.Put(ctx, &chain.Beacon{
 		Round: 1,
 	})
 	require.True(t, checkOne(doneCh))
 	cb.AddCallback(id1, func(*chain.Beacon) {})
-	cb.Put(&chain.Beacon{
+	cb.Put(ctx, &chain.Beacon{
 		Round: 1,
 	})
 	require.False(t, checkOne(doneCh))

--- a/chain/beacon/chain.go
+++ b/chain/beacon/chain.go
@@ -98,7 +98,7 @@ func (c *chainStore) NewValidPartial(addr string, p *drand.PartialBeaconPacket) 
 
 func (c *chainStore) Stop() {
 	c.syncm.Stop()
-	c.CallbackStore.Close()
+	c.CallbackStore.Close(context.Background())
 	close(c.done)
 }
 
@@ -110,7 +110,7 @@ var partialCacheStoreLimit = 3
 // runAggregator runs a continuous loop that tries to aggregate partial
 // signatures when it can
 func (c *chainStore) runAggregator() {
-	lastBeacon, err := c.Last()
+	lastBeacon, err := c.Last(context.Background())
 	if err != nil {
 		c.l.Fatalw("", "chain_aggregator", "loading", "last_beacon", err)
 	}
@@ -194,7 +194,7 @@ func (c *chainStore) tryAppend(last, newB *chain.Beacon) bool {
 		return false
 	}
 
-	if err := c.CallbackStore.Put(newB); err != nil {
+	if err := c.CallbackStore.Put(context.Background(), newB); err != nil {
 		// if round is ok but bytes are different, error will be raised
 		c.l.Errorw("", "chain_store", "error storing beacon", "err", err)
 		return false

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -73,7 +73,7 @@ func NewHandler(c net.ProtocolClient, s chain.Store, conf *Config, l log.Logger,
 	addr := conf.Public.Address()
 	crypto := newCryptoStore(conf.Group, conf.Share)
 	// insert genesis beacon
-	if err := s.Put(chain.GenesisBeacon(crypto.chain)); err != nil {
+	if err := s.Put(context.Background(), chain.GenesisBeacon(crypto.chain)); err != nil {
 		return nil, err
 	}
 
@@ -315,7 +315,7 @@ func (h *Handler) run(startTime int64) {
 				h.Unlock()
 			})
 
-			lastBeacon, err := h.chain.Last()
+			lastBeacon, err := h.chain.Last(context.Background())
 			if err != nil {
 				h.l.Errorw("", "beacon_loop", "loading_last", "err", err)
 				break

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -191,7 +191,15 @@ func (b *BeaconTest) CreateNode(t *testing.T, i int) {
 	node.private = priv
 	keyShare := findShare(idx)
 	node.shares = keyShare
-	l := log.NewLogger(nil, log.LogDebug)
+
+	logLevel := log.LogInfo
+	debugEnv, isDebug := os.LookupEnv("DRAND_TEST_LOGS")
+	if isDebug && debugEnv == "DEBUG" {
+		t.Log("Enabling LogDebug logs")
+		logLevel = log.LogDebug
+	}
+
+	l := log.NewLogger(nil, logLevel)
 	store, err := boltdb.NewBoltStore(l, b.paths[idx], nil)
 	if err != nil {
 		panic(err)

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -192,14 +192,7 @@ func (b *BeaconTest) CreateNode(t *testing.T, i int) {
 	keyShare := findShare(idx)
 	node.shares = keyShare
 
-	logLevel := log.LogInfo
-	debugEnv, isDebug := os.LookupEnv("DRAND_TEST_LOGS")
-	if isDebug && debugEnv == "DEBUG" {
-		t.Log("Enabling LogDebug logs")
-		logLevel = log.LogDebug
-	}
-
-	l := log.NewLogger(nil, logLevel)
+	l := test.Logger(t)
 	store, err := boltdb.NewBoltStore(l, b.paths[idx], nil)
 	if err != nil {
 		panic(err)

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -190,9 +190,9 @@ func (c *callbackStore) RemoveCallback(id string) {
 	delete(c.callbacks, id)
 }
 
-func (c *callbackStore) Close() {
-	c.Store.Close()
-	close(c.done)
+func (c *callbackStore) Close() error {
+	defer close(c.done)
+	return c.Store.Close()
 }
 
 func (c *callbackStore) runWorkers(n int) {

--- a/chain/beacon/store_test.go
+++ b/chain/beacon/store_test.go
@@ -3,6 +3,7 @@ package beacon
 import (
 	"bytes"
 	"context"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,7 +20,14 @@ func TestSchemeStore(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
 
-	l := log.NewLogger(nil, log.LogDebug)
+	logLevel := log.LogInfo
+	debugEnv, isDebug := os.LookupEnv("DRAND_TEST_LOGS")
+	if isDebug && debugEnv == "DEBUG" {
+		t.Log("Enabling LogDebug logs")
+		logLevel = log.LogDebug
+	}
+
+	l := log.NewLogger(nil, logLevel)
 	bstore, err := boltdb.NewBoltStore(l, dir, nil)
 	require.NoError(t, err)
 

--- a/chain/beacon/store_test.go
+++ b/chain/beacon/store_test.go
@@ -3,7 +3,6 @@ package beacon
 import (
 	"bytes"
 	"context"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,7 +10,7 @@ import (
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/chain/boltdb"
 	"github.com/drand/drand/common/scheme"
-	"github.com/drand/drand/log"
+	"github.com/drand/drand/test"
 )
 
 func TestSchemeStore(t *testing.T) {
@@ -20,14 +19,7 @@ func TestSchemeStore(t *testing.T) {
 	dir := t.TempDir()
 	ctx := context.Background()
 
-	logLevel := log.LogInfo
-	debugEnv, isDebug := os.LookupEnv("DRAND_TEST_LOGS")
-	if isDebug && debugEnv == "DEBUG" {
-		t.Log("Enabling LogDebug logs")
-		logLevel = log.LogDebug
-	}
-
-	l := log.NewLogger(nil, logLevel)
+	l := test.Logger(t)
 	bstore, err := boltdb.NewBoltStore(l, dir, nil)
 	require.NoError(t, err)
 

--- a/chain/beacon/store_test.go
+++ b/chain/beacon/store_test.go
@@ -2,6 +2,7 @@ package beacon
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,13 +17,14 @@ func TestSchemeStore(t *testing.T) {
 	sch, _ := scheme.ReadSchemeByEnv()
 
 	dir := t.TempDir()
+	ctx := context.Background()
 
 	l := log.NewLogger(nil, log.LogDebug)
 	bstore, err := boltdb.NewBoltStore(l, dir, nil)
 	require.NoError(t, err)
 
 	genesisBeacon := chain.GenesisBeacon(&chain.Info{GenesisSeed: []byte("genesis_signature")})
-	err = bstore.Put(genesisBeacon)
+	err = bstore.Put(ctx, genesisBeacon)
 	require.NoError(t, err)
 
 	ss := NewSchemeStore(bstore, sch)
@@ -32,10 +34,10 @@ func TestSchemeStore(t *testing.T) {
 		Signature:   []byte("signature_1"),
 		PreviousSig: []byte("genesis_signature"),
 	}
-	err = ss.Put(newBeacon)
+	err = ss.Put(ctx, newBeacon)
 	require.NoError(t, err)
 
-	beaconSaved, err := ss.Last()
+	beaconSaved, err := ss.Last(ctx)
 	require.NoError(t, err)
 
 	// test if store sets to nil prev signature depending on scheme
@@ -53,7 +55,7 @@ func TestSchemeStore(t *testing.T) {
 		PreviousSig: nil,
 	}
 
-	err = ss.Put(newBeacon)
+	err = ss.Put(ctx, newBeacon)
 
 	// test if store checks consistency between signature and prev signature depending on the scheme
 	if sch.DecouplePrevSig && err != nil {

--- a/chain/beacon/store_test.go
+++ b/chain/beacon/store_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/drand/drand/chain"
 	"github.com/drand/drand/chain/boltdb"
 	"github.com/drand/drand/common/scheme"
+	"github.com/drand/drand/log"
 )
 
 func TestSchemeStore(t *testing.T) {
@@ -16,7 +17,8 @@ func TestSchemeStore(t *testing.T) {
 
 	dir := t.TempDir()
 
-	bstore, err := boltdb.NewBoltStore(dir, nil)
+	l := log.NewLogger(nil, log.LogDebug)
+	bstore, err := boltdb.NewBoltStore(l, dir, nil)
 	require.NoError(t, err)
 
 	genesisBeacon := chain.GenesisBeacon(&chain.Info{GenesisSeed: []byte("genesis_signature")})

--- a/chain/beacon/sync_manager.go
+++ b/chain/beacon/sync_manager.go
@@ -119,7 +119,6 @@ func (s *SyncManager) Run() {
 	// tracks the time of the last round we successfully synced
 	lastRoundTime := 0
 	// the context being used by the current sync process
-	var lastCtx context.Context
 	ctx, cancel := context.WithCancel(context.Background())
 	for {
 		select {
@@ -146,9 +145,9 @@ func (s *SyncManager) Run() {
 				// we haven't received a new block in a while
 				// -> time to start a new sync
 				cancel()
-				lastCtx, cancel = context.WithCancel(context.Background())
+				ctx, cancel = context.WithCancel(context.Background())
 				//nolint
-				go s.Sync(lastCtx, request)
+				go s.Sync(ctx, request)
 			}
 
 		case <-s.newSync:

--- a/chain/boltdb/store.go
+++ b/chain/boltdb/store.go
@@ -1,7 +1,6 @@
 package boltdb
 
 import (
-	"errors"
 	"io"
 	"path"
 	"sync"
@@ -9,15 +8,20 @@ import (
 	bolt "go.etcd.io/bbolt"
 
 	"github.com/drand/drand/chain"
+	"github.com/drand/drand/chain/errors"
 	"github.com/drand/drand/log"
 )
 
-// boldStore implements the Store interface using the kv storage boltdb (native
+// BoltStore implements the Store interface using the kv storage boltdb (native
 // golang implementation). Internally, Beacons are stored as JSON-encoded in the
 // db file.
-type boltStore struct {
+//
+//nolint:gocritic// We do want to have a mutex here
+type BoltStore struct {
 	sync.Mutex
 	db *bolt.DB
+
+	log log.Logger
 }
 
 var beaconBucket = []byte("beacons")
@@ -29,7 +33,7 @@ const BoltFileName = "drand.db"
 const BoltStoreOpenPerm = 0660
 
 // NewBoltStore returns a Store implementation using the boltdb storage engine.
-func NewBoltStore(folder string, opts *bolt.Options) (chain.Store, error) {
+func NewBoltStore(l log.Logger, folder string, opts *bolt.Options) (*BoltStore, error) {
 	dbPath := path.Join(folder, BoltFileName)
 	db, err := bolt.Open(dbPath, BoltStoreOpenPerm, opts)
 	if err != nil {
@@ -38,19 +42,17 @@ func NewBoltStore(folder string, opts *bolt.Options) (chain.Store, error) {
 	// create the bucket already
 	err = db.Update(func(tx *bolt.Tx) error {
 		_, err := tx.CreateBucketIfNotExists(beaconBucket)
-		if err != nil {
-			return err
-		}
-		return nil
+		return err
 	})
 
-	return &boltStore{
-		db: db,
+	return &BoltStore{
+		log: l,
+		db:  db,
 	}, err
 }
 
 // Len performs a big scan over the bucket and is _very_ slow - use sparingly!
-func (b *boltStore) Len() int {
+func (b *BoltStore) Len() (int, error) {
 	var length = 0
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
@@ -59,20 +61,22 @@ func (b *boltStore) Len() int {
 		return nil
 	})
 	if err != nil {
-		log.DefaultLogger().Warnw("", "boltdb", "error getting length", "err", err)
+		b.log.Warnw("", "boltdb", "error getting length", "err", err)
 	}
-	return length
+	return length, err
 }
 
-func (b *boltStore) Close() {
-	if err := b.db.Close(); err != nil {
-		log.DefaultLogger().Errorw("", "boltdb", "close", "err", err)
+func (b *BoltStore) Close() error {
+	err := b.db.Close()
+	if err != nil {
+		b.log.Errorw("", "boltdb", "close", "err", err)
 	}
+	return err
 }
 
 // Put implements the Store interface. WARNING: It does NOT verify that this
 // beacon is not already saved in the database or not and will overwrite it.
-func (b *boltStore) Put(beacon *chain.Beacon) error {
+func (b *BoltStore) Put(beacon *chain.Beacon) error {
 	err := b.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 		key := chain.RoundToBytes(beacon.Round)
@@ -82,79 +86,59 @@ func (b *boltStore) Put(beacon *chain.Beacon) error {
 		}
 		return bucket.Put(key, buff)
 	})
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
-// ErrNoBeaconSaved is the error returned when no beacon have been saved in the
-// database yet.
-var ErrNoBeaconSaved = errors.New("beacon not found in database")
-
 // Last returns the last beacon signature saved into the db
-func (b *boltStore) Last() (*chain.Beacon, error) {
-	var beacon *chain.Beacon
+func (b *BoltStore) Last() (*chain.Beacon, error) {
+	beacon := &chain.Beacon{}
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 		cursor := bucket.Cursor()
 		_, v := cursor.Last()
 		if v == nil {
-			return ErrNoBeaconSaved
+			return errors.ErrNoBeaconStored
 		}
-		b := &chain.Beacon{}
-		if err := b.Unmarshal(v); err != nil {
-			return err
-		}
-		beacon = b
-		return nil
+		return beacon.Unmarshal(v)
 	})
 	return beacon, err
 }
 
 // Get returns the beacon saved at this round
-func (b *boltStore) Get(round uint64) (*chain.Beacon, error) {
-	var beacon *chain.Beacon
+func (b *BoltStore) Get(round uint64) (*chain.Beacon, error) {
+	beacon := &chain.Beacon{}
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 		v := bucket.Get(chain.RoundToBytes(round))
 		if v == nil {
-			return ErrNoBeaconSaved
+			return errors.ErrNoBeaconStored
 		}
-		b := &chain.Beacon{}
-		if err := b.Unmarshal(v); err != nil {
-			return err
-		}
-		beacon = b
-		return nil
+		return beacon.Unmarshal(v)
 	})
-	if err != nil {
-		return nil, err
-	}
 	return beacon, err
 }
 
-func (b *boltStore) Del(round uint64) error {
+func (b *BoltStore) Del(round uint64) error {
 	return b.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 		return bucket.Delete(chain.RoundToBytes(round))
 	})
 }
 
-func (b *boltStore) Cursor(fn func(chain.Cursor)) {
+func (b *BoltStore) Cursor(fn func(chain.Cursor) error) error {
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 		c := bucket.Cursor()
-		fn(&boltCursor{Cursor: c})
-		return nil
+		return fn(&boltCursor{Cursor: c})
 	})
 	if err != nil {
 		log.DefaultLogger().Warnw("", "boltdb", "error getting cursor", "err", err)
 	}
+	return err
 }
 
 // SaveTo saves the bolt database to an alternate file.
-func (b *boltStore) SaveTo(w io.Writer) error {
+func (b *BoltStore) SaveTo(w io.Writer) error {
 	return b.db.View(func(tx *bolt.Tx) error {
 		_, err := tx.WriteTo(w)
 		return err
@@ -165,50 +149,42 @@ type boltCursor struct {
 	*bolt.Cursor
 }
 
-func (c *boltCursor) First() *chain.Beacon {
+func (c *boltCursor) First() (*chain.Beacon, error) {
 	k, v := c.Cursor.First()
 	if k == nil {
-		return nil
+		return nil, errors.ErrNoBeaconStored
 	}
-	b := new(chain.Beacon)
-	if err := b.Unmarshal(v); err != nil {
-		return nil
-	}
-	return b
+	b := &chain.Beacon{}
+	err := b.Unmarshal(v)
+	return b, err
 }
 
-func (c *boltCursor) Next() *chain.Beacon {
+func (c *boltCursor) Next() (*chain.Beacon, error) {
 	k, v := c.Cursor.Next()
 	if k == nil {
-		return nil
+		return nil, errors.ErrNoBeaconStored
 	}
-	b := new(chain.Beacon)
-	if err := b.Unmarshal(v); err != nil {
-		return nil
-	}
-	return b
+	b := &chain.Beacon{}
+	err := b.Unmarshal(v)
+	return b, err
 }
 
-func (c *boltCursor) Seek(round uint64) *chain.Beacon {
+func (c *boltCursor) Seek(round uint64) (*chain.Beacon, error) {
 	k, v := c.Cursor.Seek(chain.RoundToBytes(round))
 	if k == nil {
-		return nil
+		return nil, errors.ErrNoBeaconStored
 	}
-	b := new(chain.Beacon)
-	if err := b.Unmarshal(v); err != nil {
-		return nil
-	}
-	return b
+	b := &chain.Beacon{}
+	err := b.Unmarshal(v)
+	return b, err
 }
 
-func (c *boltCursor) Last() *chain.Beacon {
+func (c *boltCursor) Last() (*chain.Beacon, error) {
 	k, v := c.Cursor.Last()
 	if k == nil {
-		return nil
+		return nil, errors.ErrNoBeaconStored
 	}
-	b := new(chain.Beacon)
-	if err := b.Unmarshal(v); err != nil {
-		return nil
-	}
-	return b
+	b := &chain.Beacon{}
+	err := b.Unmarshal(v)
+	return b, err
 }

--- a/chain/boltdb/store_test.go
+++ b/chain/boltdb/store_test.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/drand/drand/chain"
 	chainerrors "github.com/drand/drand/chain/errors"
-	"github.com/drand/drand/log"
+	"github.com/drand/drand/test"
 )
 
 func TestStoreBoltOrder(t *testing.T) {
 	tmp := t.TempDir()
 	ctx := context.Background()
-	l := log.NewLogger(nil, log.LogDebug)
+	l := test.Logger(t)
 	store, err := NewBoltStore(l, tmp, nil)
 	require.NoError(t, err)
 
@@ -52,7 +52,7 @@ func TestStoreBoltOrder(t *testing.T) {
 func TestStoreBolt(t *testing.T) {
 	tmp := t.TempDir()
 	ctx := context.Background()
-	l := log.NewLogger(nil, log.LogDebug)
+	l := test.Logger(t)
 
 	var sig1 = []byte{0x01, 0x02, 0x03}
 	var sig2 = []byte{0x02, 0x03, 0x04}

--- a/chain/errors/errors.go
+++ b/chain/errors/errors.go
@@ -1,0 +1,11 @@
+package errors
+
+import "errors"
+
+// ErrNoBeaconStored is the error we get when a sync is called too early and
+// there are no beacon above the requested round
+var ErrNoBeaconStored = errors.New("no beacon stored above requested round")
+
+// ErrNoBeaconSaved is the error returned when no beacon have been saved in the
+// database yet.
+var ErrNoBeaconSaved = errors.New("beacon not found in database")

--- a/chain/store.go
+++ b/chain/store.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"io"
 )
@@ -13,14 +14,14 @@ import (
 // Store is an interface to store Beacons packets where they can also be
 // retrieved to be delivered to end clients.
 type Store interface {
-	Len() (int, error)
-	Put(*Beacon) error
-	Last() (*Beacon, error)
-	Get(round uint64) (*Beacon, error)
-	Cursor(func(Cursor) error) error
-	Close() error
-	Del(round uint64) error
-	SaveTo(w io.Writer) error
+	Len(context.Context) (int, error)
+	Put(context.Context, *Beacon) error
+	Last(context.Context) (*Beacon, error)
+	Get(ctx context.Context, round uint64) (*Beacon, error)
+	Cursor(context.Context, func(context.Context, Cursor) error) error
+	Close(context.Context) error
+	Del(ctx context.Context, round uint64) error
+	SaveTo(ctx context.Context, w io.Writer) error
 }
 
 // Cursor iterates over items in sorted key order. This starts from the
@@ -33,10 +34,10 @@ type Store interface {
 //	    fmt.Printf("A %s is %s.\n", k, v)
 //	}
 type Cursor interface {
-	First() (*Beacon, error)
-	Next() (*Beacon, error)
-	Seek(round uint64) (*Beacon, error)
-	Last() (*Beacon, error)
+	First(context.Context) (*Beacon, error)
+	Next(context.Context) (*Beacon, error)
+	Seek(ctx context.Context, round uint64) (*Beacon, error)
+	Last(context.Context) (*Beacon, error)
 }
 
 // RoundToBytes serializes a round number to bytes (8 bytes fixed length big-endian).

--- a/chain/store.go
+++ b/chain/store.go
@@ -13,12 +13,12 @@ import (
 // Store is an interface to store Beacons packets where they can also be
 // retrieved to be delivered to end clients.
 type Store interface {
-	Len() int
+	Len() (int, error)
 	Put(*Beacon) error
 	Last() (*Beacon, error)
 	Get(round uint64) (*Beacon, error)
-	Cursor(func(Cursor))
-	Close()
+	Cursor(func(Cursor) error) error
+	Close() error
 	Del(round uint64) error
 	SaveTo(w io.Writer) error
 }
@@ -33,10 +33,10 @@ type Store interface {
 //	    fmt.Printf("A %s is %s.\n", k, v)
 //	}
 type Cursor interface {
-	First() *Beacon
-	Next() *Beacon
-	Seek(round uint64) *Beacon
-	Last() *Beacon
+	First() (*Beacon, error)
+	Next() (*Beacon, error)
+	Seek(round uint64) (*Beacon, error)
+	Last() (*Beacon, error)
 }
 
 // RoundToBytes serializes a round number to bytes (8 bytes fixed length big-endian).

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -856,6 +856,8 @@ func deleteBeaconCmd(c *cli.Context) error {
 		return err
 	}
 
+	l := log.NewLogger(nil, log.LogDebug)
+
 	var er error
 	for beaconID, storePath := range stores {
 		if er != nil {
@@ -863,7 +865,7 @@ func deleteBeaconCmd(c *cli.Context) error {
 		}
 		// Using an anonymous function to not leak the defer
 		er = func() error {
-			store, err := boltdb.NewBoltStore(path.Join(storePath, core.DefaultDBFolder), conf.BoltOptions())
+			store, err := boltdb.NewBoltStore(l, path.Join(storePath, core.DefaultDBFolder), conf.BoltOptions())
 			if err != nil {
 				return fmt.Errorf("beacon id [%s] - invalid bolt store creation: %w", beaconID, err)
 			}

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -858,6 +858,8 @@ func deleteBeaconCmd(c *cli.Context) error {
 
 	l := log.NewLogger(nil, log.LogDebug)
 
+	ctx := c.Context
+
 	var er error
 	for beaconID, storePath := range stores {
 		if er != nil {
@@ -869,9 +871,9 @@ func deleteBeaconCmd(c *cli.Context) error {
 			if err != nil {
 				return fmt.Errorf("beacon id [%s] - invalid bolt store creation: %w", beaconID, err)
 			}
-			defer store.Close()
+			defer store.Close(ctx)
 
-			lastBeacon, err := store.Last()
+			lastBeacon, err := store.Last(ctx)
 			if err != nil {
 				return fmt.Errorf("beacon id [%s] - can't fetch last beacon: %w", beaconID, err)
 			}
@@ -883,7 +885,7 @@ func deleteBeaconCmd(c *cli.Context) error {
 			}
 
 			for round := startRound; round <= lastBeacon.Round; round++ {
-				err := store.Del(round)
+				err := store.Del(ctx, round)
 				if err != nil {
 					return fmt.Errorf("beacon id [%s] - error deleting round %d: %w", beaconID, round, err)
 				}

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -856,7 +856,13 @@ func deleteBeaconCmd(c *cli.Context) error {
 		return err
 	}
 
-	l := log.NewLogger(nil, log.LogDebug)
+	isVerbose := c.IsSet(verboseFlag.Name)
+
+	level := log.LogError
+	if isVerbose {
+		level = log.LogDebug
+	}
+	l := log.NewLogger(nil, level)
 
 	ctx := c.Context
 
@@ -880,7 +886,7 @@ func deleteBeaconCmd(c *cli.Context) error {
 			if startRound > lastBeacon.Round {
 				return fmt.Errorf("beacon id [%s] - given round is ahead of the chain: %d", beaconID, lastBeacon.Round)
 			}
-			if c.IsSet(verboseFlag.Name) {
+			if isVerbose {
 				fmt.Printf("beacon id [%s] -  planning to delete %d beacons \n", beaconID, (lastBeacon.Round - startRound))
 			}
 
@@ -889,7 +895,7 @@ func deleteBeaconCmd(c *cli.Context) error {
 				if err != nil {
 					return fmt.Errorf("beacon id [%s] - error deleting round %d: %w", beaconID, round, err)
 				}
-				if c.IsSet(verboseFlag.Name) {
+				if isVerbose {
 					fmt.Printf("beacon id [%s] - deleted beacon round %d \n", beaconID, round)
 				}
 			}

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -85,7 +85,7 @@ func TestDeleteBeaconError(t *testing.T) {
 func TestDeleteBeacon(t *testing.T) {
 	beaconID := test.GetBeaconIDFromEnv()
 	l := log.NewLogger(nil, log.LogDebug)
-
+	ctx := context.Background()
 	tmp := path.Join(t.TempDir(), "drand")
 
 	opt := core.WithConfigFolder(tmp)
@@ -93,35 +93,35 @@ func TestDeleteBeacon(t *testing.T) {
 	fs.CreateSecureFolder(conf.DBFolder(beaconID))
 	store, err := boltdb.NewBoltStore(l, conf.DBFolder(beaconID), conf.BoltOptions())
 	require.NoError(t, err)
-	err = store.Put(&chain.Beacon{
+	err = store.Put(ctx, &chain.Beacon{
 		Round:     1,
 		Signature: []byte("Hello"),
 	})
 	require.NoError(t, err)
-	err = store.Put(&chain.Beacon{
+	err = store.Put(ctx, &chain.Beacon{
 		Round:     2,
 		Signature: []byte("Hello"),
 	})
 	require.NoError(t, err)
-	err = store.Put(&chain.Beacon{
+	err = store.Put(ctx, &chain.Beacon{
 		Round:     3,
 		Signature: []byte("Hello"),
 	})
 	require.NoError(t, err)
-	err = store.Put(&chain.Beacon{
+	err = store.Put(ctx, &chain.Beacon{
 		Round:     4,
 		Signature: []byte("hello"),
 	})
 	require.NoError(t, err)
 	// try to fetch round 3 and 4
-	b, err := store.Get(3)
+	b, err := store.Get(ctx, 3)
 	require.NoError(t, err)
 	require.NotNil(t, b)
-	b, err = store.Get(4)
+	b, err = store.Get(ctx, 4)
 	require.NoError(t, err)
 	require.NotNil(t, b)
 
-	err = store.Close()
+	err = store.Close(ctx)
 	require.NoError(t, err)
 
 	args := []string{"drand", "util", "del-beacon", "--folder", tmp, "--id", beaconID, "3"}
@@ -132,10 +132,10 @@ func TestDeleteBeacon(t *testing.T) {
 	require.NoError(t, err)
 
 	// try to fetch round 3 and 4 - it should now fail
-	_, err = store.Get(3)
+	_, err = store.Get(ctx, 3)
 	require.Error(t, err)
 
-	_, err = store.Get(4)
+	_, err = store.Get(ctx, 4)
 	require.Error(t, err)
 }
 

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/drand/drand/core"
 	"github.com/drand/drand/fs"
 	"github.com/drand/drand/key"
-	"github.com/drand/drand/log"
 	"github.com/drand/drand/test"
 	"github.com/drand/kyber"
 	"github.com/drand/kyber/share"
@@ -84,7 +83,7 @@ func TestDeleteBeaconError(t *testing.T) {
 
 func TestDeleteBeacon(t *testing.T) {
 	beaconID := test.GetBeaconIDFromEnv()
-	l := log.NewLogger(nil, log.LogDebug)
+	l := test.Logger(t)
 	ctx := context.Background()
 	tmp := path.Join(t.TempDir(), "drand")
 

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -305,13 +305,13 @@ func (bp *BeaconProcess) WaitExit() chan bool {
 	return bp.exitCh
 }
 
-func (bp *BeaconProcess) createBoltStore() (chain.Store, error) {
+func (bp *BeaconProcess) createBoltStore() (*boltdb.BoltStore, error) {
 	dbName := commonutils.GetCanonicalBeaconID(bp.beaconID)
 
 	dbPath := bp.opts.DBFolder(dbName)
 	fs.CreateSecureFolder(dbPath)
 
-	return boltdb.NewBoltStore(dbPath, bp.opts.boltOpts)
+	return boltdb.NewBoltStore(bp.log, dbPath, bp.opts.boltOpts)
 }
 
 func (bp *BeaconProcess) newBeacon() (*beacon.Handler, error) {

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -54,8 +54,8 @@ func (bp *BeaconProcess) PartialBeacon(c context.Context, in *drand.PartialBeaco
 
 // PublicRand returns a public random beacon according to the request. If the Round
 // field is 0, then it returns the last one generated.
-func (bp *BeaconProcess) PublicRand(c context.Context, in *drand.PublicRandRequest) (*drand.PublicRandResponse, error) {
-	var addr = net.RemoteAddress(c)
+func (bp *BeaconProcess) PublicRand(ctx context.Context, in *drand.PublicRandRequest) (*drand.PublicRandResponse, error) {
+	var addr = net.RemoteAddress(ctx)
 
 	bp.state.Lock()
 	defer bp.state.Unlock()
@@ -66,10 +66,10 @@ func (bp *BeaconProcess) PublicRand(c context.Context, in *drand.PublicRandReque
 	var beaconResp *chain.Beacon
 	var err error
 	if in.GetRound() == 0 {
-		beaconResp, err = bp.beacon.Store().Last()
+		beaconResp, err = bp.beacon.Store().Last(ctx)
 	} else {
 		// fetch the correct entry or the next one if not found
-		beaconResp, err = bp.beacon.Store().Get(in.GetRound())
+		beaconResp, err = bp.beacon.Store().Get(ctx, in.GetRound())
 	}
 	if err != nil || beaconResp == nil {
 		bp.log.Debugw("", "public_rand", "unstored_beacon", "round", in.GetRound(), "from", addr)
@@ -128,7 +128,7 @@ func (bp *BeaconProcess) PublicRandStream(req *drand.PublicRandRequest, stream d
 }
 
 // Home provides the address the local node is listening
-func (bp *BeaconProcess) Home(c context.Context, in *drand.HomeRequest) (*drand.HomeResponse, error) {
+func (bp *BeaconProcess) Home(c context.Context, _ *drand.HomeRequest) (*drand.HomeResponse, error) {
 	bp.log.With("module", "public").Infow("", "home", net.RemoteAddress(c))
 
 	return &drand.HomeResponse{
@@ -139,7 +139,7 @@ func (bp *BeaconProcess) Home(c context.Context, in *drand.HomeRequest) (*drand.
 }
 
 // ChainInfo replies with the chain information this node participates to
-func (bp *BeaconProcess) ChainInfo(ctx context.Context, in *drand.ChainInfoRequest) (*drand.ChainInfoPacket, error) {
+func (bp *BeaconProcess) ChainInfo(context.Context, *drand.ChainInfoRequest) (*drand.ChainInfoPacket, error) {
 	bp.state.Lock()
 	group := bp.group
 	chainHash := bp.chainHash
@@ -175,7 +175,7 @@ func (bp *BeaconProcess) SignalDKGParticipant(ctx context.Context, p *drand.Sign
 }
 
 // PushDKGInfo triggers sending DKG info to other members
-func (bp *BeaconProcess) PushDKGInfo(ctx context.Context, in *drand.DKGInfoPacket) (*drand.Empty, error) {
+func (bp *BeaconProcess) PushDKGInfo(_ context.Context, in *drand.DKGInfoPacket) (*drand.Empty, error) {
 	bp.state.Lock()
 	defer bp.state.Unlock()
 
@@ -207,7 +207,7 @@ func (bp *BeaconProcess) SyncChain(req *drand.SyncRequest, stream drand.Protocol
 }
 
 // GetIdentity returns the identity of this drand node
-func (bp *BeaconProcess) GetIdentity(ctx context.Context, req *drand.IdentityRequest) (*drand.IdentityResponse, error) {
+func (bp *BeaconProcess) GetIdentity(context.Context, *drand.IdentityRequest) (*drand.IdentityResponse, error) {
 	i := bp.priv.Public.ToProto()
 
 	response := &drand.IdentityResponse{

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -159,7 +159,8 @@ func TestDrandDKGFresh(t *testing.T) {
 	dt.StartDrand(lastNode.addr, true, false)
 
 	// The catchup process will finish when node gets the previous beacons (1st round)
-	dt.WaitUntilRound(t, lastNode, 1)
+	err := dt.WaitUntilRound(t, lastNode, 1)
+	require.NoError(t, err)
 
 	dt.AdvanceMockClock(t, beaconPeriod)
 
@@ -367,7 +368,8 @@ func TestRunDKGReshareTimeout(t *testing.T) {
 	group1 := dt.RunDKG()
 
 	dt.SetMockClock(t, group1.GenesisTime)
-	dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	err := dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	require.NoError(t, err)
 
 	// move to genesis time - so nodes start to make a round
 	// dt.AdvanceMockClock(t,offsetGenesis)
@@ -465,7 +467,9 @@ func TestRunDKGReshareTimeout(t *testing.T) {
 	resp, err := client.PublicRand(ctx, rootID, new(drand.PublicRandRequest))
 	require.NoError(t, err)
 	for _, n := range dt.resharedNodes[1:] {
-		resp2, err := client.PublicRand(ctx, n.drand.priv.Public, new(drand.PublicRandRequest))
+		// Make sure we pull the same round from the rest of the nodes as we received from the leader
+		req := &drand.PublicRandRequest{Round: resp.Round}
+		resp2, err := client.PublicRand(ctx, n.drand.priv.Public, req)
 		require.NoError(t, err)
 		require.Equal(t, resp, resp2)
 	}
@@ -491,7 +495,8 @@ func TestRunDKGResharePreempt(t *testing.T) {
 	group1 := dt.RunDKG()
 
 	dt.SetMockClock(t, group1.GenesisTime)
-	dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	err := dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	require.NoError(t, err)
 
 	// move to genesis time - so nodes start to make a round
 	t.Log("Check Beacon Length")
@@ -648,9 +653,10 @@ func TestDrandPublicRand(t *testing.T) {
 	rootID := root.priv.Public
 
 	dt.SetMockClock(t, group.GenesisTime)
-	dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	err := dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	require.NoError(t, err)
 
-	err := dt.WaitUntilRound(t, dt.nodes[0], 1)
+	err = dt.WaitUntilRound(t, dt.nodes[0], 1)
 	require.NoError(t, err)
 
 	// do a few periods
@@ -712,7 +718,8 @@ func TestDrandPublicStream(t *testing.T) {
 	rootID := root.drand.priv.Public
 
 	dt.SetMockClock(t, group.GenesisTime)
-	dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	err := dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	require.NoError(t, err)
 
 	// do a few periods
 	for i := 0; i < 3; i++ {
@@ -734,6 +741,7 @@ func TestDrandPublicStream(t *testing.T) {
 	t.Log("Getting the last round first with PublicRand method")
 	resp, err := client.PublicRand(ctx, rootID, new(drand.PublicRandRequest))
 	require.NoError(t, err)
+	require.Equal(t, uint64(4), resp.Round)
 
 	//  run streaming and expect responses
 	req := &drand.PublicRandRequest{Round: resp.GetRound()}
@@ -744,8 +752,8 @@ func TestDrandPublicStream(t *testing.T) {
 	t.Log("Waiting to receive the first round as the node should have it now...")
 	select {
 	case beacon := <-respCh:
-		t.Logf("First round rcv %d \n", resp.GetRound())
-		require.Equal(t, beacon.GetRound(), resp.GetRound())
+		t.Logf("First round rcv %d \n", beacon.GetRound())
+		require.Equal(t, resp.GetRound(), beacon.GetRound())
 
 	case <-time.After(100 * time.Millisecond):
 		t.Logf("First round NOT rcv. Timeout has passed \n")
@@ -764,7 +772,7 @@ func TestDrandPublicStream(t *testing.T) {
 
 		select {
 		case beacon := <-respCh:
-			require.Equal(t, beacon.GetRound(), round)
+			require.Equal(t, round, beacon.GetRound())
 		case <-time.After(1 * time.Second):
 			t.Logf("Round %d NOT rcv. Timeout has passed \n", round)
 			require.True(t, false, fmt.Sprintf("too late for streaming, round %d didn't reply in time", round))
@@ -822,7 +830,8 @@ func TestDrandFollowChain(t *testing.T) {
 	rootID := dt.nodes[0].drand.priv.Public
 
 	dt.SetMockClock(t, group.GenesisTime)
-	dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	err := dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	require.NoError(t, err)
 
 	// do a few periods
 	for i := 0; i < 6; i++ {
@@ -933,7 +942,8 @@ func TestDrandCheckChain(t *testing.T) {
 	rootID := dt.nodes[0].drand.priv.Public
 
 	dt.SetMockClock(t, group.GenesisTime)
-	dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	err := dt.WaitUntilChainIsServing(t, dt.nodes[0])
+	require.NoError(t, err)
 
 	// do a few periods
 	for i := 0; i < 6; i++ {

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -918,9 +918,9 @@ func TestDrandFollowChain(t *testing.T) {
 		// check if the beacon is in the database
 		store, err := newNode.drand.createBoltStore()
 		require.NoError(t, err)
-		defer store.Close()
+		defer store.Close(ctx)
 
-		lastB, err := store.Last()
+		lastB, err := store.Last(ctx)
 		require.NoError(t, err)
 		require.Equal(t, exp, lastB.Round, "found %d vs expected %d", lastB.Round, exp)
 	}
@@ -1003,14 +1003,14 @@ func TestDrandCheckChain(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Logf(" \t\t --> Opened store. Getting 4th beacon\n")
-	beac, err := store.Get(upTo - 1)
+	beac, err := store.Get(ctx, upTo-1)
 	require.NoError(t, err)
 	require.Equal(t, upTo-1, beac.Round, "found %d vs expected %d", beac.Round, upTo-1)
 
 	t.Logf(" \t\t --> Deleting 4th beacon.\n")
-	err = store.Del(upTo - 1)
+	err = store.Del(ctx, upTo-1)
 	require.NoError(t, err)
-	store.Close()
+	store.Close(ctx)
 
 	t.Logf(" \t\t --> Re-Starting node.\n")
 	dt.StartDrand(dt.nodes[0].addr, false, false)

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/drand/drand/common"
 	"github.com/drand/drand/common/scheme"
 	"github.com/drand/drand/key"
-	"github.com/drand/drand/log"
 	"github.com/drand/drand/net"
 	"github.com/drand/drand/protobuf/drand"
 	"github.com/drand/drand/test"
@@ -134,13 +133,6 @@ func BatchNewDrand(t *testing.T, n int, insecure bool, sch scheme.Scheme, beacon
 		}
 	}
 
-	logLevel := log.LogInfo
-	debugEnv, isDebug := os.LookupEnv("DRAND_TEST_LOGS")
-	if isDebug && debugEnv == "DEBUG" {
-		t.Log("Enabling LogDebug logs")
-		logLevel = log.LogDebug
-	}
-
 	for i := 0; i < n; i++ {
 		s := test.NewKeyStore()
 
@@ -159,7 +151,7 @@ func BatchNewDrand(t *testing.T, n int, insecure bool, sch scheme.Scheme, beacon
 
 		confOptions = append(confOptions,
 			WithControlPort(ports[i]),
-			WithLogLevel(logLevel, false))
+			WithLogLevel(test.LogLevel(t), false))
 		// add options in last so it overwrites the default
 		confOptions = append(confOptions, opts...)
 

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -407,7 +407,7 @@ func (d *DrandTestScenario) GetBeacon(id string, round int, newGroup bool) (*cha
 		if node.addr != id {
 			continue
 		}
-		return node.drand.beacon.Store().Get(uint64(round))
+		return node.drand.beacon.Store().Get(context.Background(), uint64(round))
 	}
 	return nil, errors.New("that should not happen")
 }

--- a/test/log.go
+++ b/test/log.go
@@ -1,0 +1,25 @@
+package test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/drand/drand/log"
+)
+
+// LogLevel returns the level to default the logger based on the DRAND_TEST_LOGS presence
+func LogLevel(t *testing.T) int {
+	logLevel := log.LogInfo
+	debugEnv, isDebug := os.LookupEnv("DRAND_TEST_LOGS")
+	if isDebug && debugEnv == "DEBUG" {
+		t.Log("Enabling LogDebug logs")
+		logLevel = log.LogDebug
+	}
+
+	return logLevel
+}
+
+// Logger returns a configured logger
+func Logger(t *testing.T) log.Logger {
+	return log.NewLogger(nil, LogLevel(t))
+}


### PR DESCRIPTION
This PR performs the following:
- Updates the bolt implementation to pass the logger directly to the implementation.
- Adds the error to the existing methods of the Store and Cursor interface. 
- Returns the type rather than the interface for the bolt storage implementation.
- Cleans up some places by adding error handling.
- Adds the Context parameter to the existing methods of the Store and Cursor interfaces.

It's a precursor for #913 and improves the system stability/usage.

In the process, some tests were identified as not passing due to not handling errors correctly.
These should be rectified in a separate PR.
They also lead to the coverage dropping a bit, since now some parts of the code are left out.