### PR TITLE
Removed a slow and unnecessary DB length check in status command

### DIFF
--- a/chain/boltdb/store.go
+++ b/chain/boltdb/store.go
@@ -49,10 +49,12 @@ func NewBoltStore(folder string, opts *bolt.Options) (chain.Store, error) {
 	}, err
 }
 
+// Len performs a big scan over the bucket and is _very_ slow - use sparingly!
 func (b *boltStore) Len() int {
 	var length = 0
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
+		// this `.Stats()` call is the particularly expensive one!
 		length = bucket.Stats().KeyN
 		return nil
 	})

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -888,7 +888,7 @@ func (bp *BeaconProcess) Status(c context.Context, in *drand.StatusRequest) (*dr
 		if err == nil && lastBeacon != nil {
 			chainStore.IsEmpty = false
 			chainStore.LastRound = lastBeacon.GetRound()
-			chainStore.Length = uint64(bp.beacon.Store().Len())
+			chainStore.Length = lastBeacon.GetRound() + 1
 		}
 	}
 


### PR DESCRIPTION
Remote status calls print out some info about each node's view of the world, including the current number of beacons in their database. The remote status call requests a beacon DB length check but does not actually use it in the corresponding CLI output.

I've replaced its value with one interpolated from the beacon count for backwards compatibility as it's in the protobuf message, but it could probably be removed