### PR TITLE
Add hidden DB configuration flags in preparation for #913

### DIFF
--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -337,6 +337,22 @@ var allBeaconsFlag = &cli.BoolFlag{
 	EnvVars: []string{"DRAND_ALL"},
 }
 
+var storageTypeFlag = &cli.StringFlag{
+	Name:    "db",
+	Usage:   "Which database engine to use. Supported values: bolt",
+	Value:   "bolt",
+	EnvVars: []string{"DRAND_DB"},
+	Hidden:  true,
+}
+
+var pgDSNFlag = &cli.StringFlag{
+	Name:    "pg-dsn",
+	Usage:   "PostgresSQL DSN configuration.",
+	Value:   "postgres://drand:drand@localhost:5432/drand?sslmode=disable&timeout=5&connect_timeout=5&search_path=drand_schema",
+	EnvVars: []string{"DRAND_PG_DSN"},
+	Hidden:  true,
+}
+
 var appCommands = []*cli.Command{
 	{
 		Name:  "start",
@@ -344,7 +360,8 @@ var appCommands = []*cli.Command{
 		Flags: toArray(folderFlag, tlsCertFlag, tlsKeyFlag,
 			insecureFlag, controlFlag, privListenFlag, pubListenFlag, metricsFlag,
 			certsDirFlag, pushFlag, verboseFlag, oldGroupFlag,
-			skipValidationFlag, jsonFlag),
+			skipValidationFlag, jsonFlag,
+			storageTypeFlag, pgDSNFlag),
 		Action: func(c *cli.Context) error {
 			banner()
 			return startCmd(c)


### PR DESCRIPTION
This PR adds the flags in #1088 as hidden flags.
This is required to allow the Regression test to pass the initial run phase, where the supplied flag, `--db` and `--pg-dsn`, are missing on the current version of the master branch.
Because they are hidden, there is no UX impact on those using the latest master and they'll be made visible when #1088 gets merged.