### PR TITLE
Remove the need for sleep while DKG is set up during TestDrandReloadBeacon

### DIFF
--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -917,7 +917,11 @@ func (d *drandInstance) stop(beaconID string) error {
 	return CLI().Run([]string{"drand", "stop", "--control", d.ctrlPort, "--id", beaconID})
 }
 
-func (d *drandInstance) shareLeader(t *testing.T, nodes, threshold, periodSeconds int, beaconID string, sch scheme.Scheme, done chan error) {
+func (d *drandInstance) shareLeader(t *testing.T,
+	nodes, threshold, periodSeconds int,
+	beaconID string,
+	sch scheme.Scheme,
+	done chan error) {
 	t.Helper()
 
 	shareArgs := []string{

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -721,6 +721,8 @@ func TestDrandReloadBeacon(t *testing.T) {
 	for i, inst := range instances {
 		if i == 0 {
 			go inst.shareLeader(t, n, n, 1, beaconID, sch, done)
+			// Wait a bit after launching the leader to launch the other nodes too.
+			time.Sleep(500 * time.Millisecond)
 		} else {
 			go inst.share(t, instances[0].addr, beaconID, done)
 		}
@@ -781,6 +783,8 @@ func TestDrandLoadNotPresentBeacon(t *testing.T) {
 	for i, inst := range instances {
 		if i == 0 {
 			go inst.shareLeader(t, n, n, 1, beaconID, sch, done)
+			// Wait a bit after launching the leader to launch the other nodes too.
+			time.Sleep(500 * time.Millisecond)
 		} else {
 			go inst.share(t, instances[0].addr, beaconID, done)
 		}


### PR DESCRIPTION
This PR removes the need for sleep during the DKG setup phase for `TestDrandReloadBeacon` and `TestDrandLoadNotPresentBeacon`.
Since it was possible for the `time.Sleep` to run faster than the DKG process, tests could fail.
With this approach, we now wait for DKG to finish before moving forward with the test.