### PR TITLE
Replace go-acc with go test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,8 @@ test-integration:
 	cd demo && go build && ./demo -build -test -debug
 
 coverage:
-	go install github.com/ory/go-acc@latest
 	go get -v -t -d ./...
-	COVERAGE=true go-acc ./...
+	go test -race -v -covermode=atomic -coverpkg ./... -coverprofile=coverage.txt ./...
 
 demo:
 	cd demo && go build && ./demo -build


### PR DESCRIPTION
go-acc hides the test running.
This can result in coverage tests failing without a clear indication of where the failure happened.
`go-acc` is also rendered unneeded by the recent versions of Go, which added support for correct coverage across packages/tests.