### PR TITLE
Fixing 2 tests & add code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*       @AnomalRoil @CluEleSsUK @nikkolasg @willscott

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -202,7 +202,7 @@ func (bp *BeaconProcess) SyncChain(req *drand.SyncRequest, stream drand.Protocol
 		bp.state.Unlock()
 		return fmt.Errorf("no beacon handler available")
 	}
-	store := bp.beacon.Store()
+	store := b.Store()
 	// we cannot just defer Unlock because beacon.SyncChain can run for a long time
 	bp.state.Unlock()
 

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -196,14 +196,17 @@ func (bp *BeaconProcess) SyncChain(req *drand.SyncRequest, stream drand.Protocol
 	bp.state.Lock()
 	b := bp.beacon
 	c := bp.chainHash
+	logger := bp.log.Named("SyncChain")
+	store := bp.beacon.Store()
+	// we cannot just defer Unlock because beacon.SyncChain can run for a long time
 	bp.state.Unlock()
 	if b == nil || len(c) == 0 {
-		bp.log.Errorw("Received a SyncRequest, but no beacon handler is set yet", "request", req)
+		logger.Errorw("Received a SyncRequest, but no beacon handler is set yet", "request", req)
 		return fmt.Errorf("no beacon handler available")
 	}
 
 	// TODO: consider re-running the SyncChain command if we get a ErrNoBeaconStored back as it could be a follow cmd
-	return beacon.SyncChain(bp.log.Named("SyncChain"), bp.beacon.Store(), req, stream)
+	return beacon.SyncChain(logger, store, req, stream)
 }
 
 // GetIdentity returns the identity of this drand node

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -405,20 +405,8 @@ func TestRunDKGReshareTimeout(t *testing.T) {
 	}()
 	time.Sleep(3 * time.Second)
 
-	// XXX: this isn't always the case: it can already have reached past this at this point because of the above Sleep.
-	t.Log("Move to response phase")
-	dt.AdvanceMockClock(t, timeout)
-
 	// TODO: How to remove this sleep? How to check when a node is at this stage
 	// at this point in time, nodes should have gotten all deals and send back their responses to all nodes
-	time.Sleep(getSleepDuration())
-
-	t.Log("Move to justification phase")
-	dt.AdvanceMockClock(t, timeout)
-
-	// TODO: How to remove this sleep? How to check when a node is at this stage
-	// at this time, all nodes received the responses of each other nodes but
-	// there is one node missing so they expect justifications
 	time.Sleep(getSleepDuration())
 
 	// TODO: How to remove this sleep? How to check when a node is at this stage
@@ -426,9 +414,6 @@ func TestRunDKGReshareTimeout(t *testing.T) {
 	dt.AdvanceMockClock(t, timeout)
 
 	time.Sleep(getSleepDuration())
-	// at this time they received no justification from the missing node so he's
-	// excluded of the group and the dkg should finish
-	// time.Sleep(10 * time.Second)
 
 	var resharedGroup *key.Group
 	select {


### PR DESCRIPTION
This is fixing #1119.
It also fixes another problem that arose in https://github.com/drand/drand/actions/runs/3903064598/jobs/6666924292#step:5:14291 where the TestRunDKGReshareTimeout was actually already past its transition time for the second group because it was running too many `AdvanceMockClock` while the `dt.RunReshare` was also running these.

This also adds a CODEOWNERS file to the repo.