### PR TITLE
Refactor shutdown order

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Integration tests
         env:
           DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: make test-integration-postgres
+        run: make test-integration-memdb
 
   test_chained-postgres:
     runs-on: ubuntu-latest
@@ -167,7 +167,7 @@ jobs:
       - name: Integration tests
         env:
           DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=pedersen-bls-unchained make test-integration-postgres
+        run: SCHEME_ID=pedersen-bls-unchained make test-integration-memdb
 
   test_unchained-postgres:
     runs-on: ubuntu-latest

--- a/chain/beacon/chain.go
+++ b/chain/beacon/chain.go
@@ -110,6 +110,13 @@ var partialCacheStoreLimit = 3
 // runAggregator runs a continuous loop that tries to aggregate partial
 // signatures when it can
 func (c *chainStore) runAggregator() {
+	// TODO (dlsniper): This should be flagged in a different way
+	select {
+	case <-c.done:
+		return
+	default:
+	}
+
 	lastBeacon, err := c.Last(context.Background())
 	if err != nil {
 		c.l.Fatalw("", "chain_aggregator", "loading", "last_beacon", err)

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -431,8 +431,8 @@ func (h *Handler) Stop() {
 	}
 	close(h.close)
 
-	h.chain.Stop()
 	h.ticker.Stop()
+	h.chain.Stop()
 
 	h.stopped = true
 	h.running = false

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -330,8 +330,8 @@ func (b *BeaconTest) StopBeacon(i int) {
 		if !n.started {
 			return
 		}
-		n.listener.Stop(context.Background())
 		n.handler.Stop()
+		n.listener.Stop(context.Background())
 		n.started = false
 	}
 	delete(b.nodes, j)

--- a/client/aggregator.go
+++ b/client/aggregator.go
@@ -104,7 +104,7 @@ func (c *watchAggregator) startAutoWatch(full bool) {
 			}
 			t := time.NewTimer(c.autoWatchRetry)
 			select {
-			case <-t.C:
+			case <-t.C: //TODO: (dlsniper)HUH??
 			case <-ctx.Done():
 				t.Stop()
 			}

--- a/client/aggregator.go
+++ b/client/aggregator.go
@@ -104,9 +104,11 @@ func (c *watchAggregator) startAutoWatch(full bool) {
 			}
 			t := time.NewTimer(c.autoWatchRetry)
 			select {
-			case <-t.C: //TODO: (dlsniper)HUH??
+			case <-t.C:
 			case <-ctx.Done():
-				t.Stop()
+				if !t.Stop() {
+					<-t.C
+				}
 			}
 			c.log.Infow("", "watch_aggregator", "retrying auto watch")
 		}

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -428,7 +428,7 @@ var appCommands = []*cli.Command{
 				err2 := loadCmd(c)
 				if err2 != nil {
 					fmt.Fprintf(os.Stdout, "Keys couldn't be loaded on drand daemon. If it is not running, "+
-						"these new keys will loaded on startup. Err: %s", err2)
+						"these new keys will loaded on startup. Err: %s\n", err2)
 				}
 			}
 			return err

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -428,7 +428,7 @@ var appCommands = []*cli.Command{
 				err2 := loadCmd(c)
 				if err2 != nil {
 					fmt.Fprintf(os.Stdout, "Keys couldn't be loaded on drand daemon. If it is not running, "+
-						"these new keys will loaded on startup. Err: %s\n", err2)
+						"these new keys will be loaded on startup. Err: %s\n", err2)
 				}
 			}
 			return err

--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -740,7 +740,10 @@ func TestDrandReloadBeacon(t *testing.T) {
 		for _, inst := range instances {
 			// We want to ignore this error, at least until the stop command won't return an error
 			// when correctly running the stop command.
-			_ = inst.stopAll()
+			t.Logf("stopping instance %v\n", inst.addr)
+			err := inst.stopAll()
+			require.NoError(t, err)
+			t.Logf("stopped instance %v\n", inst.addr)
 		}
 	}()
 

--- a/core/drand_beacon_test.go
+++ b/core/drand_beacon_test.go
@@ -49,13 +49,58 @@ func TestBeaconProcess_Stop(t *testing.T) {
 	require.True(t, closed, "Expecting to receive from exit channel")
 
 	_, ok = <-proc.WaitExit()
-	require.Falsef(t, ok, "Expecting exit channel to be closed")
+	require.False(t, ok, "Expecting exit channel to be closed")
+}
 
-	proc.Stop(ctx)
-	<-proc.WaitExit()
+func TestBeaconProcess_Stop_MultiBeaconOneBeaconAlreadyStopped(t *testing.T) {
+	sch := scheme.GetSchemeFromEnv()
+	privs, _ := test.BatchIdentities(1, sch, t.Name())
+
+	port := test.FreePort()
+
+	confOptions := []ConfigOption{
+		WithConfigFolder(t.TempDir()),
+		WithPrivateListenAddress("127.0.0.1:0"),
+		WithControlPort(port),
+		WithInsecure(),
+		WithLogLevel(log.LogDebug, false),
+	}
+
+	confOptions = append(confOptions, WithTestDB(t, test.ComputeDBName())...)
+
+	dd, err := NewDrandDaemon(NewConfig(confOptions...))
+	require.NoError(t, err)
+
+	store := test.NewKeyStore()
+	assert.NoError(t, store.SaveKeyPair(privs[0]))
+	proc, err := dd.InstantiateBeaconProcess(t.Name(), store)
+	require.NoError(t, err)
+	require.NotNil(t, proc)
+
+	proc2, err := dd.InstantiateBeaconProcess(t.Name()+"second", store)
+	require.NoError(t, err)
+	require.NotNil(t, proc2)
 
 	time.Sleep(250 * time.Millisecond)
 
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
 	proc.Stop(ctx)
-	<-proc.WaitExit()
+	closed, ok := <-proc.WaitExit()
+	require.True(t, ok, "Expecting to receive from exit channel")
+	require.True(t, closed, "Expecting to receive from exit channel")
+
+	_, ok = <-proc.WaitExit()
+	require.False(t, ok, "Expecting exit channel to be closed")
+
+	time.Sleep(250*time.Millisecond)
+
+	dd.Stop(ctx)
+	closed, ok = <-dd.WaitExit()
+	require.True(t, ok)
+	require.True(t, closed)
+
+	_, ok = <-dd.WaitExit()
+	require.False(t, ok, "Expecting exit channel to be closed")
 }

--- a/core/drand_beacon_test.go
+++ b/core/drand_beacon_test.go
@@ -94,7 +94,7 @@ func TestBeaconProcess_Stop_MultiBeaconOneBeaconAlreadyStopped(t *testing.T) {
 	_, ok = <-proc.WaitExit()
 	require.False(t, ok, "Expecting exit channel to be closed")
 
-	time.Sleep(250*time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 
 	dd.Stop(ctx)
 	closed, ok = <-dd.WaitExit()

--- a/core/drand_beacon_test.go
+++ b/core/drand_beacon_test.go
@@ -44,13 +44,18 @@ func TestBeaconProcess_Stop(t *testing.T) {
 	defer cancel()
 
 	proc.Stop(ctx)
-	if closed, ok := <-proc.WaitExit(); !ok || !closed {
-		t.Fatal("Expecting to receive from exit channel")
-	}
-	if _, ok := <-proc.WaitExit(); ok {
-		t.Fatal("Expecting exit channel to be closed")
-	}
+	closed, ok := <-proc.WaitExit()
+	require.True(t, ok, "Expecting to receive from exit channel")
+	require.True(t, closed, "Expecting to receive from exit channel")
+
+	_, ok = <-proc.WaitExit()
+	require.Falsef(t, ok, "Expecting exit channel to be closed")
+
 	proc.Stop(ctx)
+	<-proc.WaitExit()
+
 	time.Sleep(250 * time.Millisecond)
+
 	proc.Stop(ctx)
+	<-proc.WaitExit()
 }

--- a/core/drand_daemon.go
+++ b/core/drand_daemon.go
@@ -233,12 +233,14 @@ func (dd *DrandDaemon) AddBeaconHandler(beaconID string, bp *BeaconProcess) {
 // RemoveBeaconHandler removes a handler linked to beacon with chain hash from http server used to
 // expose public services
 func (dd *DrandDaemon) RemoveBeaconHandler(beaconID string, bp *BeaconProcess) {
-	if bp.group != nil {
-		info := chain.NewChainInfo(bp.group)
-		dd.handler.RemoveBeaconHandler(info.HashString())
-		if common.IsDefaultBeaconID(beaconID) {
-			dd.handler.RemoveBeaconHandler(common.DefaultChainHash)
-		}
+	if bp.group == nil {
+		return
+	}
+
+	info := chain.NewChainInfo(bp.group)
+	dd.handler.RemoveBeaconHandler(info.HashString())
+	if common.IsDefaultBeaconID(beaconID) {
+		dd.handler.RemoveBeaconHandler(common.DefaultChainHash)
 	}
 }
 

--- a/core/drand_daemon_control.go
+++ b/core/drand_daemon_control.go
@@ -156,7 +156,6 @@ func (dd *DrandDaemon) Shutdown(ctx context.Context, in *drand.ShutdownRequest) 
 			return nil, err
 		}
 
-		// TODO dlsniper: Check out
 		dd.RemoveBeaconHandler(beaconID, bp)
 
 		bp.Stop(ctx)

--- a/core/drand_daemon_control.go
+++ b/core/drand_daemon_control.go
@@ -252,8 +252,6 @@ func (dd *DrandDaemon) Stop(ctx context.Context) {
 		bp.Stop(ctx)
 	}
 
-	// TODO (dlsniper): Should we wait here for all BPs to finish or run ahead and close the daemon?
-	//  I lean towards waiting for all beacons. However, one might hang.
 	for _, bp := range dd.beaconProcesses {
 		dd.log.Debugw("waiting for beaconProcess to finish", "id", bp.getBeaconID())
 

--- a/core/drand_daemon_test.go
+++ b/core/drand_daemon_test.go
@@ -77,8 +77,10 @@ func TestDrandDaemon_Stop(t *testing.T) {
 
 	t.Logf("running proc.WaitExit()")
 	_, ok = <-proc.WaitExit()
-	require.False(t, ok, "If we block the exit of drandDaemon by waiting for all beacons to exit, then this should return false as we consume the value already")
+	require.False(t, ok, "If we block the exit of drandDaemon by waiting for all beacons to exit,"+
+		"then this should return false as we consume the value already")
 
+	//nolint:gocritic // Dear linter, I do want to have this code commented at least during code review. I know what I'm doing.
 	/*
 		// Uncomment all the code below if we do not block on exit of drandDaemon
 		t.Logf("running proc.WaitExit()")

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -434,6 +434,8 @@ func (d *DrandTestScenario) StopMockNode(nodeAddr string, newGroup bool) {
 
 	dr := node.drand
 	dr.Stop(context.Background())
+	<-dr.WaitExit()
+
 	d.t.Logf("[drand] stop %s", dr.priv.Public.Address())
 
 	controlClient, err := net.NewControlClient(dr.opts.controlPort)

--- a/demo/demo_test.go
+++ b/demo/demo_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestLocalOrchestration(t *testing.T) {
-	// Let us have a 5 minutes deadline since the CI is slow
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	// Let us have a 10 minutes deadline since the CI is slow
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	testFinished := make(chan struct{})

--- a/demo/demo_test.go
+++ b/demo/demo_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestLocalOrchestration(t *testing.T) {
-	// Let us have a 3 minutes deadline since the CI is slow
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	// Let us have a 5 minutes deadline since the CI is slow
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	testFinished := make(chan struct{})

--- a/net/control.go
+++ b/net/control.go
@@ -55,7 +55,8 @@ func (g *ControlListener) Stop() {
 	}()
 	select {
 	case <-stopped:
-	case <-time.After(5*time.Second):
+	//nolint:gomnd // We want to forcefully terminate this in 5 seconds.
+	case <-time.After(5 * time.Second):
 		g.conns.Stop()
 	}
 

--- a/net/gateway.go
+++ b/net/gateway.go
@@ -27,10 +27,10 @@ func (g *PrivateGateway) StartAll() {
 
 // StopAll stops the control and public functionalities of the node
 func (g *PrivateGateway) StopAll(ctx context.Context) {
-	g.Listener.Stop(ctx)
 	if s, ok := g.ProtocolClient.(Stoppable); ok {
 		s.Stop()
 	}
+	g.Listener.Stop(ctx)
 }
 
 // Listener is the active listener for incoming requests.

--- a/net/listener.go
+++ b/net/listener.go
@@ -204,6 +204,6 @@ func (g *grpcListener) Start() {
 }
 
 func (g *grpcListener) Stop(ctx context.Context) {
-	_ = g.lis.Close()
 	g.grpcServer.Stop()
+	_ = g.lis.Close()
 }


### PR DESCRIPTION
This PR refactors the order of shutdown calls to allow the clients to exit, then they get the connection terminated.
When stopping a BeaconProcess, it now waits for the process to stop before exiting completely.
For the Daemon, the connection will try to end gracefully, then, if it fails, we'll forcefully terminate it, replicating the existing behavior. The change is that we try to close the connections first, then terminate the network listener, not the other way around.

Finally, it fixes the GitHub Actions runners.