### PR TITLE
Update GitHub Actions to their latest versions and to the latest Go stable version

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -11,19 +11,19 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
-    - uses: actions/cache@v2
+      uses: actions/checkout@v3.3.0
+    - uses: actions/cache@v3.2.3
       id: generate-dep-cache
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3.5.0
       with:
         go-version: '1.19.5'
     - name: Fetch Dependencies
       run: go get ./...
     - name: Install Protoc
-      uses: arduino/setup-protoc@v1.1.2
+      uses: arduino/setup-protoc@ab6203da1c3118e4406048171b09238ad31ad73e # pin@latest-16.02.2023
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         version: '3.19.6'

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -19,7 +19,7 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.19.2'
+        go-version: '1.19.5'
     - name: Fetch Dependencies
       run: go get ./...
     - name: Install Protoc

--- a/.github/workflows/label-syncer.yml
+++ b/.github/workflows/label-syncer.yml
@@ -10,7 +10,7 @@ jobs:
     name: Sync labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@1.0.0
-      - uses: micnncim/action-label-syncer@v1.0.0
+      - uses: actions/checkout@3.3.0
+      - uses: micnncim/action-label-syncer@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,23 +13,23 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v3.5.0
       with:
         go-version: '1.19.5'
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.3.0
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3.2.0
+      uses: golangci/golangci-lint-action@v3.3.1
       with:
         version: v1.50
         args: --timeout 5m
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3.2.0
+      uses: golangci/golangci-lint-action@v3.3.1
       with:
         version: v1.50
         args: --build-tags memdb --timeout 5m
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3.2.0
+      uses: golangci/golangci-lint-action@v3.3.1
       with:
         version: v1.50
         args: --build-tags postgres --timeout 5m

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19.2'
+        go-version: '1.19.5'
     - name: Checkout
       uses: actions/checkout@v2
     - name: golangci-lint

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # pin@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # pin@v2
         id: cache
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
-      - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # pin@v2
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # pin@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # pin@v2
+      - uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # pin@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/publish_tagged.yaml
+++ b/.github/workflows/publish_tagged.yaml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
-      - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # pin@v2
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
+      - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # pin@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # pin@v2
+      - uses: actions/cache@58c146cc91c5b9e778e71775dfe9bf1442ad9a12 # pin@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/publish_tagged.yaml
+++ b/.github/workflows/publish_tagged.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
       - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # pin@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353 # pin@v2
         id: cache
         with:

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       # Deps
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
       - name: Dir Setup
@@ -31,11 +31,11 @@ jobs:
 
       # Master branch
       - name: Checkout master branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           ref: 'master'
       - name: Check cache for master
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.3
         id: cache_master
         with:
           path: ~/go/pkg/mod
@@ -47,9 +47,9 @@ jobs:
 
       # Candidate branch
       - name: Checkout candidate branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
       - name: Check cache for candidate
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.3
         id: cache_candidate
         with:
           path: ~/go/pkg/mod
@@ -77,7 +77,7 @@ jobs:
 
       - name: Record Comment
         if: ${{ failure() }}
-        uses: marocchino/sticky-pull-request-comment@v1
+        uses: marocchino/sticky-pull-request-comment@v2.3.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: ${{ steps.report.outputs.result }}
@@ -88,7 +88,7 @@ jobs:
     steps:
       # Deps
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
       - name: Dir Setup
@@ -96,11 +96,11 @@ jobs:
 
       # Master branch
       - name: Checkout master branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           ref: 'master'
       - name: Check cache for master
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.3
         id: cache_master
         with:
           path: ~/go/pkg/mod
@@ -112,9 +112,9 @@ jobs:
 
       # Candidate branch
       - name: Checkout candidate branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
       - name: Check cache for candidate
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.3
         id: cache_candidate
         with:
           path: ~/go/pkg/mod
@@ -142,7 +142,7 @@ jobs:
 
       - name: Record Comment
         if: ${{ failure() }}
-        uses: marocchino/sticky-pull-request-comment@v1
+        uses: marocchino/sticky-pull-request-comment@v2.3.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: ${{ steps.report.outputs.result }}
@@ -153,7 +153,7 @@ jobs:
     steps:
       # Deps
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
       - name: Dir Setup
@@ -161,11 +161,11 @@ jobs:
 
       # Master branch
       - name: Checkout master branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           ref: 'master'
       - name: Check cache for master
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.3
         id: cache_master
         with:
           path: ~/go/pkg/mod
@@ -177,9 +177,9 @@ jobs:
 
       # Candidate branch
       - name: Checkout candidate branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
       - name: Check cache for candidate
-        uses: actions/cache@v2
+        uses: actions/cache@v3.2.3
         id: cache_candidate
         with:
           path: ~/go/pkg/mod
@@ -207,7 +207,7 @@ jobs:
 
       - name: Record Comment
         if: ${{ failure() }}
-        uses: marocchino/sticky-pull-request-comment@v1
+        uses: marocchino/sticky-pull-request-comment@v2.3.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           message: ${{ steps.report.outputs.result }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - name: Dir Setup
         run: mkdir -p ~/go/bin
 
@@ -90,7 +90,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - name: Dir Setup
         run: mkdir -p ~/go/bin
 
@@ -155,7 +155,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - name: Dir Setup
         run: mkdir -p ~/go/bin
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # pin@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
 
       - name: Install Protoc
         uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # pin@v1.1.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # pin@v2
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # pin@v2
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # pin@v3.5.0
         with:
           go-version: '1.19.5'
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@64c0c85d18e984422218383b81c52f8b077404d3 # pin@v1.1.2
+        uses: arduino/setup-protoc@ab6203da1c3118e4406048171b09238ad31ad73e # pin@latest-16.02.2023
         with:
           version: '3.19.6'
 
@@ -32,17 +32,17 @@ jobs:
 
       - name: Get latest release version number
         id: get_version
-        uses: battila7/get-version-action@d97fbc34ceb64d1f5d95f4dfd6dce33521ccccf5 # pin@v2
+        uses: battila7/get-version-action@d681662789c541f0777208c1f0e82f255f70b28d # pin@latest-16.01.2023
 
       - name: Parse semver string
         id: semver_parser
-        uses: booxmedialtd/ws-action-parse-semver@3576f3a20a39f8752fe0d8195f5ed384090285dc # pin@v1
+        uses: booxmedialtd/ws-action-parse-semver@7784200024d6b3fc01253e617ec0168daf603de3 # pin@v1.4.7
         with:
           input_string: ${{ steps.get_version.outputs.version }}
           version_extractor_regex: 'v(.*)$'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5a54d7e660bda43b405e8463261b3d25631ffe86 # pin@v2
+        uses: goreleaser/goreleaser-action@8f67e590f2d095516493f017008adc464e63adb1 # pin@v4.1.0
         with:
           version: latest
           args: release --rm-dist

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -97,7 +97,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -124,7 +124,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -151,7 +151,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -178,7 +178,7 @@ jobs:
           submodules: true
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -205,7 +205,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -227,7 +227,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@v2
         id: cache
         with:
@@ -249,7 +249,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.5'
       - uses: actions/cache@v2
         id: cache
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod
@@ -44,11 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod
@@ -69,11 +69,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod
@@ -94,11 +94,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod
@@ -119,13 +119,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           submodules: true
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod
@@ -146,13 +146,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           submodules: true
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod
@@ -173,13 +173,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.3.0
         with:
           submodules: true
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod
@@ -202,11 +202,11 @@ jobs:
       CI: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod
@@ -224,11 +224,11 @@ jobs:
       CI: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod
@@ -246,11 +246,11 @@ jobs:
       CI: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-go@v3.5.0
         with:
           go-version: '1.19.5'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3.2.3
         id: cache
         with:
           path: ~/go/pkg/mod

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
       - name: TOC Generator
-        uses: technote-space/toc-generator@v2.4.0
+        uses: technote-space/toc-generator@v4.3.1
         with:
           OPENING_COMMENT: "<!-- START "
           CLOSING_COMMENT: "<!-- END "


### PR DESCRIPTION
This PR updates the GitHub Actions to use their latest versions.
It prevents future issues, such as the ones signaled under the `Annotations` section in https://github.com/drand/drand/actions/runs/3930412293.

It also upgrades the Go version used to the latest stable, Go 1.19.5.