### PR TITLE
Switch to use require instead of assert

### DIFF
--- a/cmd/drand-cli/cli_test.go
+++ b/cmd/drand-cli/cli_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/kabukky/httpscerts"
 	json "github.com/nikkolasg/hexjson"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/drand/drand/chain"
@@ -1068,14 +1067,14 @@ func TestSharingWithInvalidFlagCombos(t *testing.T) {
 		"--threshold", "2", "--nodes", "3", "--period", "5s",
 	}
 
-	assert.EqualError(t, CLI().Run(share1), "you can't use the leader and connect flags together")
+	require.EqualError(t, CLI().Run(share1), "you can't use the leader and connect flags together")
 
 	// transition and from flags can't be used together
 	share3 := []string{
 		"drand", "share", "--tls-disable", "--id", beaconID, "--connect", "127.0.0.1:9090", "--transition", "--from", "somepath.txt",
 	}
 
-	assert.EqualError(
+	require.EqualError(
 		t,
 		CLI().Run(share3),
 		"--from flag invalid with --reshare - nodes resharing should already have a secret share and group ready to use",

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -139,7 +139,9 @@ func (bp *BeaconProcess) Load() (bool, error) {
 		return false, fmt.Errorf("could not restore beacon info for the given identity - this can happen if you updated the group file manually")
 	}
 	bp.index = int(thisBeacon.Index)
+	bp.state.Lock()
 	bp.log = bp.log.Named(fmt.Sprint(bp.index))
+	bp.state.Unlock()
 
 	bp.log.Debugw("", "serving", bp.priv.Public.Address())
 	metrics.DKGStateChange(metrics.DKGDone, beaconID, false)

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -138,8 +138,8 @@ func (bp *BeaconProcess) Load() (bool, error) {
 	if thisBeacon == nil {
 		return false, fmt.Errorf("could not restore beacon info for the given identity - this can happen if you updated the group file manually")
 	}
-	bp.index = int(thisBeacon.Index)
 	bp.state.Lock()
+	bp.index = int(thisBeacon.Index)
 	bp.log = bp.log.Named(fmt.Sprint(bp.index))
 	bp.state.Unlock()
 

--- a/core/drand_beacon_test.go
+++ b/core/drand_beacon_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/drand/drand/common/scheme"
@@ -33,7 +32,7 @@ func TestBeaconProcess_Stop(t *testing.T) {
 	require.NoError(t, err)
 
 	store := test.NewKeyStore()
-	assert.NoError(t, store.SaveKeyPair(privs[0]))
+	require.NoError(t, store.SaveKeyPair(privs[0]))
 	proc, err := dd.InstantiateBeaconProcess(t.Name(), store)
 	require.NoError(t, err)
 	require.NotNil(t, proc)
@@ -72,7 +71,7 @@ func TestBeaconProcess_Stop_MultiBeaconOneBeaconAlreadyStopped(t *testing.T) {
 	require.NoError(t, err)
 
 	store := test.NewKeyStore()
-	assert.NoError(t, store.SaveKeyPair(privs[0]))
+	require.NoError(t, store.SaveKeyPair(privs[0]))
 	proc, err := dd.InstantiateBeaconProcess(t.Name(), store)
 	require.NoError(t, err)
 	require.NotNil(t, proc)

--- a/core/drand_daemon_test.go
+++ b/core/drand_daemon_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/drand/drand/common/scheme"
@@ -53,7 +52,7 @@ func TestDrandDaemon_Stop(t *testing.T) {
 	require.NoError(t, err)
 
 	store := test.NewKeyStore()
-	assert.NoError(t, store.SaveKeyPair(privs[0]))
+	require.NoError(t, store.SaveKeyPair(privs[0]))
 	proc, err := dd.InstantiateBeaconProcess(t.Name(), store)
 	require.NoError(t, err)
 	require.NotNil(t, proc)

--- a/core/drand_test.go
+++ b/core/drand_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaveworks/common/fs"
 
@@ -104,11 +103,11 @@ func TestRunDKG(t *testing.T) {
 
 	t.Log(group)
 
-	assert.Equal(t, 3, group.Threshold)
-	assert.Equal(t, expectedBeaconPeriod, group.Period)
-	assert.Equal(t, time.Duration(0), group.CatchupPeriod)
-	assert.Equal(t, n, len(group.Nodes))
-	assert.Equal(t, int64(449884810), group.GenesisTime)
+	require.Equal(t, 3, group.Threshold)
+	require.Equal(t, expectedBeaconPeriod, group.Period)
+	require.Equal(t, time.Duration(0), group.CatchupPeriod)
+	require.Equal(t, n, len(group.Nodes))
+	require.Equal(t, int64(449884810), group.GenesisTime)
 }
 
 // Test dkg for a large quantity of nodes (22 nodes)
@@ -127,11 +126,11 @@ func TestRunDKGLarge(t *testing.T) {
 
 	group := dt.RunDKG()
 
-	assert.Equal(t, 12, group.Threshold)
-	assert.Equal(t, expectedBeaconPeriod, group.Period)
-	assert.Equal(t, time.Duration(0), group.CatchupPeriod)
-	assert.Equal(t, n, len(group.Nodes))
-	assert.Equal(t, int64(449884810), group.GenesisTime)
+	require.Equal(t, 12, group.Threshold)
+	require.Equal(t, expectedBeaconPeriod, group.Period)
+	require.Equal(t, time.Duration(0), group.CatchupPeriod)
+	require.Equal(t, n, len(group.Nodes))
+	require.Equal(t, int64(449884810), group.GenesisTime)
 }
 
 // Test Start/Stop after DKG
@@ -178,7 +177,7 @@ func TestDrandDKGFresh(t *testing.T) {
 
 	t.Log("Check Beacon Public")
 	response := dt.CheckPublicBeacon(lastNode.addr, false)
-	assert.Equal(t, uint64(2), response.Round)
+	require.Equal(t, uint64(2), response.Round)
 }
 
 // Test dkg when two nodes cannot broadcast messages between them. The rest of the nodes
@@ -1173,7 +1172,7 @@ func TestReshareWithInvalidBeaconIdInMetadataFailsButNoSegfault(t *testing.T) {
 		},
 	}
 	_, err := dt.nodes[1].daemon.InitReshare(context.Background(), &resharePacket)
-	assert.EqualError(
+	require.EqualError(
 		t,
 		err,
 		"beacon with ID "+nonsenseBeaconID+" could not be found - make sure you have passed the id flag or have a default beacon",
@@ -1206,7 +1205,7 @@ func TestReshareWithoutOldGroupFailsButNoSegfault(t *testing.T) {
 	}
 
 	_, err := dt.nodes[1].daemon.InitReshare(context.Background(), &resharePacket)
-	assert.EqualError(t, err, "cannot reshare without an old group")
+	require.EqualError(t, err, "cannot reshare without an old group")
 }
 
 func TestModifyingGroupFileManuallyDoesNotSegfault(t *testing.T) {
@@ -1253,5 +1252,5 @@ func TestModifyingGroupFileManuallyDoesNotSegfault(t *testing.T) {
 	// the updated TLS status will fail verification
 	_, err = node.daemon.LoadBeaconFromStore(beaconID, store)
 
-	assert.EqualError(t, err, "could not restore beacon info for the given identity - this can happen if you updated the group file manually")
+	require.EqualError(t, err, "could not restore beacon info for the given identity - this can happen if you updated the group file manually")
 }

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -13,7 +13,6 @@ import (
 
 	clock "github.com/jonboulle/clockwork"
 	"github.com/kabukky/httpscerts"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
@@ -122,11 +121,11 @@ func BatchNewDrand(t *testing.T, n int, insecure bool, sch scheme.Scheme, beacon
 
 			if httpscerts.Check(certPath, keyPath) != nil {
 				h, _, err := gnet.SplitHostPort(privs[i].Public.Address())
-				assert.NoError(t, err)
+				require.NoError(t, err)
 
 				t.Logf("generate keys for drand %d", i)
 				err = httpscerts.Generate(certPath, keyPath, h)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			certPaths[i] = certPath
 			keyPaths[i] = keyPath
@@ -136,7 +135,7 @@ func BatchNewDrand(t *testing.T, n int, insecure bool, sch scheme.Scheme, beacon
 	for i := 0; i < n; i++ {
 		s := test.NewKeyStore()
 
-		assert.NoError(t, s.SaveKeyPair(privs[i]))
+		require.NoError(t, s.SaveKeyPair(privs[i]))
 
 		// give each one their own private folder
 		confOptions := []ConfigOption{
@@ -164,10 +163,10 @@ func BatchNewDrand(t *testing.T, n int, insecure bool, sch scheme.Scheme, beacon
 		t.Logf("Creating node %d", i)
 
 		daemon, err := NewDrandDaemon(NewConfig(confOptions...))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		bp, err := daemon.InstantiateBeaconProcess(beaconID, s)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		daemons[i] = daemon
 		drands[i] = bp


### PR DESCRIPTION
This PR makes the switch from using `assert.*` functions to their `require.*` equivalent.
With this change, it's now possible to catch when some tests fail without meaningful output, caused by the `assert` call.