### PR TITLE
Using a RW mutex on BeaconProcess

### DIFF
--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -24,7 +24,7 @@ func (bp *BeaconProcess) BroadcastDKG(c context.Context, in *drand.DKGPacket) (*
 	if bp.dkgInfo == nil {
 		bp.state.Unlock()
 		// TODO: make sure the DKG refactor removes this racy Broadcast issue
-		bp.opts.clock.Sleep(time.Second)
+		bp.opts.clock.Sleep(time.Millisecond)
 		bp.state.Lock()
 		if bp.dkgInfo == nil {
 			return nil, fmt.Errorf("drand: no dkg running and yet received a DKGPacket for beacon %s from node %s", bp.beaconID, addr)

--- a/core/drand_daemon_helper.go
+++ b/core/drand_daemon_helper.go
@@ -27,9 +27,9 @@ func (dd *DrandDaemon) readBeaconID(metadata *protoCommon.Metadata) (string, err
 			// for the case where our node is still waiting for the chain hash to be set
 			rcvBeaconID = common.GetCanonicalBeaconID(rcvBeaconID)
 			for id, bp := range dd.beaconProcesses {
-				bp.state.Lock()
+				bp.state.RLock()
 				group := bp.group
-				bp.state.Unlock()
+				bp.state.RUnlock()
 
 				// we only accept to proceed with an unknown chain hash if one beacon process hasn't run DKG yet
 				if id == rcvBeaconID && group == nil {


### PR DESCRIPTION
In order to avoid blocking necessarily on SyncChain or ChainInfo requests, which slows down Partial aggregation.