### PR TITLE
Improve the regression testing with GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ concurrency:
 
 jobs:
   golangci:
+    strategy:
+      matrix:
+        db_type: [ "boltdb", "memdb", "postgres" ]
     name: lint
     runs-on: ubuntu-latest
     steps:
@@ -22,14 +25,4 @@ jobs:
       uses: golangci/golangci-lint-action@v3.3.1
       with:
         version: v1.50
-        args: --timeout 5m
-    - name: golangci-lint-memdb
-      uses: golangci/golangci-lint-action@v3.3.1
-      with:
-        version: v1.50
-        args: --build-tags memdb --timeout 5m
-    - name: golangci-lint-postgres
-      uses: golangci/golangci-lint-action@v3.3.1
-      with:
-        version: v1.50
-        args: --build-tags postgres --timeout 5m
+        args: --build-tags ${{ matrix.db_type }} --timeout 5m

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -44,7 +44,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Build Master
-        run: make build . && cp drand ~/go/bin/drand-existing
+        run: make build && cp drand ~/go/bin/drand-existing
 
       # Candidate branch
       - name: Checkout candidate branch
@@ -110,7 +110,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Build Master
-        run: make build . && cp drand ~/go/bin/drand-existing
+        run: make build && cp drand ~/go/bin/drand-existing
 
       # Candidate branch
       - name: Checkout candidate branch
@@ -176,7 +176,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Build Master
-        run: make build . && cp drand ~/go/bin/drand-existing
+        run: make build && cp drand ~/go/bin/drand-existing
 
       # Candidate branch
       - name: Checkout candidate branch

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -8,7 +8,6 @@ concurrency:
   group: ci-${{ github.ref }}-regression
   cancel-in-progress: true
 
-
 env:
   DISABLE_VERSION_CHECK: 1
   # TODO Remove after https://github.com/drand/drand/pull/956 is merged, this is to get around the regression test failure
@@ -18,9 +17,12 @@ env:
 
 jobs:
   regression:
+    strategy:
+      matrix:
+        db_type: ["boltdb", "memdb", "postgres"]
+        scheme_id: [ "pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-on-g1" ]
     runs-on: ubuntu-latest
     timeout-minutes: 15
-
     steps:
       # Deps
       - name: Install Go
@@ -63,150 +65,20 @@ jobs:
       # Regression test
       - name: Run regression with BoltDB backend
         id: regression-bolt
-        run: go run ./demo/regression -release ~/go/bin/drand-existing -candidate ~/go/bin/drand-candidate
+        env:
+          SCHEME_ID: ${{ matrix.scheme_id }}
+        run: go run ./demo/regression -db=${{ matrix.db_type }} -release ~/go/bin/drand-existing -candidate ~/go/bin/drand-candidate
 
       # Report
       - id: report
         if: ${{ failure() }}
         name: Save report
         run: |
-          OUTPUT=$(cat report.md)
-          OUTPUT="${OUTPUT//'%'/'%25'}"
-          OUTPUT="${OUTPUT//$'\n'/'%0A'}"
-          OUTPUT="${OUTPUT//$'\r'/'%0D'}"
-          echo "::set-output name=result::$OUTPUT"
-
-      - name: Record Comment
-        if: ${{ failure() }}
-        uses: marocchino/sticky-pull-request-comment@v2.3.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          message: ${{ steps.report.outputs.result }}
-
-  regression-memdb:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    steps:
-      # Deps
-      - name: Install Go
-        uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - name: Dir Setup
-        run: mkdir -p ~/go/bin
-
-      # Master branch
-      - name: Checkout master branch
-        uses: actions/checkout@v3.3.0
-        with:
-          ref: 'master'
-      - name: Check cache for master
-        uses: actions/cache@v3.2.3
-        id: cache_master
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Build Master
-        run: make build && cp drand ~/go/bin/drand-existing
-
-      # Candidate branch
-      - name: Checkout candidate branch
-        uses: actions/checkout@v3.3.0
-      - name: Check cache for candidate
-        uses: actions/cache@v3.2.3
-        id: cache_candidate
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Build Candidate
-        run: make build && cp drand ~/go/bin/drand-candidate
-
-      # Regression test
-      - name: Run regression with MemDB backend
-        id: regression-memdb
-        run: go run ./demo/regression -db=memdb -release ~/go/bin/drand-existing -candidate ~/go/bin/drand-candidate
-
-      # Report
-      - id: report
-        if: ${{ failure() }}
-        name: Save report
-        run: |
-          OUTPUT=$(cat report.md)
-          OUTPUT="${OUTPUT//'%'/'%25'}"
-          OUTPUT="${OUTPUT//$'\n'/'%0A'}"
-          OUTPUT="${OUTPUT//$'\r'/'%0D'}"
-          echo "::set-output name=result::$OUTPUT"
-
-      - name: Record Comment
-        if: ${{ failure() }}
-        uses: marocchino/sticky-pull-request-comment@v2.3.1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          message: ${{ steps.report.outputs.result }}
-
-  regression-postgres:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-
-    steps:
-      # Deps
-      - name: Install Go
-        uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - name: Dir Setup
-        run: mkdir -p ~/go/bin
-
-      # Master branch
-      - name: Checkout master branch
-        uses: actions/checkout@v3.3.0
-        with:
-          ref: 'master'
-      - name: Check cache for master
-        uses: actions/cache@v3.2.3
-        id: cache_master
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Build Master
-        run: make build && cp drand ~/go/bin/drand-existing
-
-      # Candidate branch
-      - name: Checkout candidate branch
-        uses: actions/checkout@v3.3.0
-      - name: Check cache for candidate
-        uses: actions/cache@v3.2.3
-        id: cache_candidate
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - name: Build Candidate
-        run: make build && cp drand ~/go/bin/drand-candidate
-
-      # Regression test
-      - name: Run regression with PostgresDB backend
-        id: regression-postgres
-        run: go run ./demo/regression -db=postgres -release ~/go/bin/drand-existing -candidate ~/go/bin/drand-candidate
-
-      # Report
-      - id: report
-        if: ${{ failure() }}
-        name: Save report
-        run: |
-          OUTPUT=$(cat report.md)
-          OUTPUT="${OUTPUT//'%'/'%25'}"
-          OUTPUT="${OUTPUT//$'\n'/'%0A'}"
-          OUTPUT="${OUTPUT//$'\r'/'%0D'}"
-          echo "::set-output name=result::$OUTPUT"
+          GITHUB_OUTPUT=$(cat report.md)
+          GITHUB_OUTPUT="${GITHUB_OUTPUT//'%'/'%25'}"
+          GITHUB_OUTPUT="${GITHUB_OUTPUT//$'\n'/'%0A'}"
+          GITHUB_OUTPUT="${GITHUB_OUTPUT//$'\r'/'%0D'}"
+          echo "{name}={value}" >> $GITHUB_OUTPUT
 
       - name: Record Comment
         if: ${{ failure() }}

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -65,10 +65,11 @@ jobs:
         run: make build && cp drand ~/go/bin/drand-candidate
 
       # Regression test
-      - name: Run regression with BoltDB backend
-        id: regression-bolt
+      - name: Run regression with ${{ matrix.db_type }} database
+        id: regression
         env:
           SCHEME_ID: ${{ matrix.scheme_id }}
+          CI: "true"
         run: go run ./demo/regression -db=${{ matrix.db_type }} -release ~/go/bin/drand-existing -candidate ~/go/bin/drand-candidate
 
       # Report

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -17,14 +17,14 @@ env:
 
 jobs:
   regression:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
     strategy:
       fail-fast: false
-      continue-on-error: true
       matrix:
         db_type: ["boltdb", "memdb", "postgres"]
         scheme_id: [ "pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-on-g1" ]
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
     steps:
       # Deps
       - name: Install Go

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -18,6 +18,8 @@ env:
 jobs:
   regression:
     strategy:
+      fail-fast: false
+      continue-on-error: true
       matrix:
         db_type: ["boltdb", "memdb", "postgres"]
         scheme_id: [ "pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-on-g1" ]
@@ -78,7 +80,6 @@ jobs:
           GITHUB_OUTPUT="${GITHUB_OUTPUT//'%'/'%25'}"
           GITHUB_OUTPUT="${GITHUB_OUTPUT//$'\n'/'%0A'}"
           GITHUB_OUTPUT="${GITHUB_OUTPUT//$'\r'/'%0D'}"
-          echo "{name}={value}" >> $GITHUB_OUTPUT
 
       - name: Record Comment
         if: ${{ failure() }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,11 +65,13 @@ jobs:
         env:
           DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
           SCHEME_ID: ${{ matrix.scheme_id }}
+          CI: "true"
         run: make test-unit-${{ matrix.db_type }}
       - name: Integration tests
         env:
           DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
           SCHEME_ID: ${{ matrix.scheme_id }}
+          CI: "true"
         run: make test-integration-${{ matrix.db_type }}
 
   coverage:
@@ -99,4 +101,5 @@ jobs:
         env:
           DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
           SCHEME_ID: ${{ matrix.scheme_id }}
+          CI: "true"
       - run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,8 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
+      continue-on-error: true
       matrix:
         db_type: [ "boltdb", "memdb", "postgres" ]
         scheme_id: [ "pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-on-g1" ]
@@ -72,6 +74,8 @@ jobs:
 
   coverage:
     strategy:
+      fail-fast: false
+      continue-on-error: true
       matrix:
         db_type: [ "boltdb", "memdb", "postgres" ]
         scheme_id: [ "pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-on-g1" ]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,8 +39,11 @@ jobs:
           make drand-relay-gossip
           make drand-relay-s3
 
-
-  test_chained:
+  test:
+    strategy:
+      matrix:
+        db_type: [ "boltdb", "memdb", "postgres" ]
+        scheme_id: [ "pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-on-g1" ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -55,229 +58,23 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: go get -v -t -d ./...
+      - run: go get -v -t -d ${{ matrix.db_type }} ./...
       - name: Unit tests
         env:
           DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: make test-unit
+          SCHEME_ID: ${{ matrix.scheme_id }}
+        run: make test-unit-${{ matrix.db_type }}
       - name: Integration tests
         env:
           DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: make test-integration
-
-  test_chained-memdb:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-      - uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - uses: actions/cache@v3.2.3
-        id: cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go get -v -t -d ./...
-      - name: Unit tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: make test-unit-memdb
-      - name: Integration tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: make test-integration-memdb
-
-  test_chained-postgres:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-      - uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - uses: actions/cache@v3.2.3
-        id: cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go get -v -t -d ./...
-      - name: Unit tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: make test-unit-postgres
-      - name: Integration tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: make test-integration-postgres
-
-  test_unchained:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-        with:
-          submodules: true
-      - uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - uses: actions/cache@v3.2.3
-        id: cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go get -v -t -d ./...
-      - name: Unit tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=pedersen-bls-unchained make test-unit
-      - name: Integration tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=pedersen-bls-unchained make test-integration
-
-  test_unchained-memdb:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-        with:
-          submodules: true
-      - uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - uses: actions/cache@v3.2.3
-        id: cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go get -v -t -d ./...
-      - name: Unit tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=pedersen-bls-unchained make test-unit-memdb
-      - name: Integration tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=pedersen-bls-unchained make test-integration-memdb
-
-  test_unchained-postgres:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-        with:
-          submodules: true
-      - uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - uses: actions/cache@v3.2.3
-        id: cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go get -v -t -d ./...
-      - name: Unit tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=pedersen-bls-unchained make test-unit-postgres
-      - name: Integration tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=pedersen-bls-unchained make test-integration-postgres
-
-  test_shortsigs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-        with:
-          submodules: true
-      - uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - uses: actions/cache@v3.2.3
-        id: cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go get -v -t -d ./...
-      - name: Unit tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=bls-unchained-on-g1 make test-unit
-      - name: Integration tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=bls-unchained-on-g1 make test-integration
-
-  test_shortsigs-memdb:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-        with:
-          submodules: true
-      - uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - uses: actions/cache@v3.2.3
-        id: cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go get -v -t -d ./...
-      - name: Unit tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=bls-unchained-on-g1 make test-unit-memdb
-      - name: Integration tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=bls-unchained-on-g1 make test-integration-memdb
-
-  test_shortsigs-postgres:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-        with:
-          submodules: true
-      - uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - uses: actions/cache@v3.2.3
-        id: cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go get -v -t -d ./...
-      - name: Unit tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=bls-unchained-on-g1 make test-unit-postgres
-      - name: Integration tests
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-        run: SCHEME_ID=bls-unchained-on-g1 make test-integration-postgres
+          SCHEME_ID: ${{ matrix.scheme_id }}
+        run: make test-integration-${{ matrix.db_type }}
 
   coverage:
+    strategy:
+      matrix:
+        db_type: [ "boltdb", "memdb", "postgres" ]
+        scheme_id: [ "pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-on-g1" ]
     runs-on: ubuntu-latest
     env:
       CI: "true"
@@ -294,51 +91,8 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: make coverage
+      - run: make coverage-${{ matrix.db_type }}
         env:
           DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-      - run: bash <(curl -s https://codecov.io/bash)
-
-  coverage-memdb:
-    runs-on: ubuntu-latest
-    env:
-      CI: "true"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-      - uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - uses: actions/cache@v3.2.3
-        id: cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: make coverage-memdb
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
-      - run: bash <(curl -s https://codecov.io/bash)
-
-  coverage-postgres:
-    runs-on: ubuntu-latest
-    env:
-      CI: "true"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.3.0
-      - uses: actions/setup-go@v3.5.0
-        with:
-          go-version: '1.19.5'
-      - uses: actions/cache@v3.2.3
-        id: cache
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: make coverage-postgres
-        env:
-          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
+          SCHEME_ID: ${{ matrix.scheme_id }}
       - run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -40,13 +40,13 @@ jobs:
           make drand-relay-s3
 
   test:
+    runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
-      continue-on-error: true
       matrix:
         db_type: [ "boltdb", "memdb", "postgres" ]
         scheme_id: [ "pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-on-g1" ]
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3.3.0
@@ -73,13 +73,13 @@ jobs:
         run: make test-integration-${{ matrix.db_type }}
 
   coverage:
+    runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
-      continue-on-error: true
       matrix:
         db_type: [ "boltdb", "memdb", "postgres" ]
         scheme_id: [ "pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-on-g1" ]
-    runs-on: ubuntu-latest
     env:
       CI: "true"
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -58,7 +58,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: go get -v -t -d ${{ matrix.db_type }} ./...
+      - run: go get -v -t -d -tags ${{ matrix.db_type }} ./...
       - name: Unit tests
         env:
           DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-.PHONY: test test-unit test-unit-memdb test-unit-postgres test-unit-cover test-unit-memdb-cover test-unit-postgres-cover test-integration test-integration-memdb test-integration-postgres demo demo-memdb demo-postgres deploy-local linter install build client drand relay-http relay-gossip relay-s3 install_deps_linux install_deps_darwin install_deps_darwin-m
+.PHONY: test test-unit test-unit-boltdb test-unit-memdb test-unit-postgres
+.PHONY: test-unit-cover test-unit-boltdb-cover test-unit-memdb-cover test-unit-postgres-cover
+.PHONY: coverage coverage-boltdb coverage-memdb coverage-postgres
+.PHONY: test-integration test-integration-boltdb test-integration-memdb test-integration-postgres
+.PHONY: demo demo-boltdb demo-memdb demo-postgres
+.PHONY: deploy-local linter install build client drand relay-http relay-gossip relay-s3
+.PHONY: install_deps_linux install_deps_darwin install_deps_darwin-m
 
 VER_PACKAGE=github.com/drand/drand/common
 CLI_PACKAGE=github.com/drand/drand/cmd/drand-cli
@@ -48,6 +54,8 @@ test: test-unit test-integration
 test-unit:
 	go test -failfast -race -short -v ./...
 
+test-unit-boltdb: test-unit
+
 test-unit-memdb:
 	go test -failfast -race -tags memdb -short -v ./...
 
@@ -56,6 +64,8 @@ test-unit-postgres:
 
 test-unit-cover:
 	go test -failfast -short -v -coverprofile=coverage.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
+
+test-unit-boltdb-cover: test-unit-cover
 
 test-unit-memdb-cover:
 	go test -failfast -short -tags memdb -v -coverprofile=coverage-memdb.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
@@ -66,6 +76,8 @@ test-unit-postgres-cover:
 test-integration:
 	go test -failfast -v ./demo
 	cd demo && go build && ./demo -build -test -debug
+
+test-integration-boltdb: test-integration
 
 test-integration-memdb:
 	go test -failfast -race -short -tags memdb -v ./...
@@ -79,6 +91,8 @@ coverage:
 	go get -v -t -d ./...
 	go test -failfast -v -covermode=atomic -coverpkg ./... -coverprofile=coverage.txt ./...
 
+coverage-boltdb: coverage
+
 coverage-memdb:
 	go get -tags=memdb -v -t -d ./...
 	go test -failfast -v -tags=memdb -covermode=atomic -coverpkg ./... -coverprofile=coverage-memdb.txt ./...
@@ -90,6 +104,8 @@ coverage-postgres:
 demo:
 	cd demo && go build && ./demo -build
 	#cd demo && sudo ./run.sh
+
+demo-boltdb: demo
 
 demo-memdb:
 	cd demo && go build && ./demo -dbtype=memdb -build


### PR DESCRIPTION
This PR addresses the following issues:
- The regression tests were running `make build .` instead of `make build`
- The regression tests were not using the unchained network, nor the new unchained on g1 network
- The regression tests were not using the GitHub Actions matrix style to compose the regression tests
- Aligns the tests and lint Actions to use the GitHub Actions matrix style of composition
- Passes https://rhysd.github.io/actionlint/ with no errors or warnings

This PR partially addresses #1118