### PR TITLE
Set the bucket fill percentage to 100% since we have an append-only workload

### DIFF
--- a/chain/boltdb/boltdb_test.go
+++ b/chain/boltdb/boltdb_test.go
@@ -1,0 +1,78 @@
+package boltdb_test
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+func TestStorageFormatFillPercentage(t *testing.T) {
+	tempDir := t.TempDir()
+
+	db, err := bbolt.Open(path.Join(tempDir, "formatfill.db"), 0600, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	db.MaxBatchSize = 100
+
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	var values [][]byte
+	for i := 0; i < db.MaxBatchSize*100; i++ {
+		values = append(values, []byte(fmt.Sprintf("index %d value %d", i, rnd.Int())))
+	}
+
+	bucketName := "my-test"
+
+	fillPercentages := []float64{0.5, 1.0, 0.75, 0.5}
+
+	for idx, fillPercentage := range fillPercentages {
+		err = storeValues(t, db, bucketName, idx*len(values), fillPercentage, values)
+		require.NoError(t, err)
+	}
+
+	for idx := range fillPercentages {
+		err = testStoredValues(t, db, bucketName, idx*len(values), values)
+		require.NoError(t, err)
+	}
+}
+
+func storeValues(t *testing.T, db *bbolt.DB, bucketName string, offset int, fillPercentage float64, values [][]byte) error {
+	return db.Batch(func(tx *bbolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists([]byte(bucketName))
+		require.NoError(t, err)
+
+		bucket.FillPercent = fillPercentage
+
+		newKey := make([]byte, 8)
+		for idx, val := range values {
+			binary.BigEndian.PutUint64(newKey, uint64(idx+offset))
+			require.NoError(t, bucket.Put(newKey, val))
+		}
+
+		return nil
+	})
+}
+
+func testStoredValues(t *testing.T, db *bbolt.DB, bucketName string, offset int, values [][]byte) error {
+	return db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(bucketName))
+
+		newKey := make([]byte, 8)
+		for idx := 0; idx < len(values); idx++ {
+			binary.BigEndian.PutUint64(newKey, uint64(idx+offset))
+			value := bucket.Get(newKey)
+			require.Equal(t, string(value), string(values[idx]))
+		}
+
+		return nil
+	})
+}

--- a/chain/boltdb/trimmed.go
+++ b/chain/boltdb/trimmed.go
@@ -74,6 +74,10 @@ func (b *trimmedStore) Close(context.Context) error {
 func (b *trimmedStore) Put(_ context.Context, beacon *chain.Beacon) error {
 	return b.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
+
+		// We know this will be an append-only workload, so let's use a compact db.
+		bucket.FillPercent = 1.0
+
 		key := chain.RoundToBytes(beacon.Round)
 		err := bucket.Put(key, beacon.Signature)
 		if err != nil {


### PR DESCRIPTION
This PR allows the BoltDB bucket to be as compact as possible.
When using the new DB format:
- The space usage is cut in 1/2 from ~800MB to ~400MB on an older testnet backup.
- The time required to read all beacons from the db drops from ~26ms to ~16ms.
