### PR TITLE
Easying the syncing issues

### DIFF
--- a/chain/beacon/callbacks_test.go
+++ b/chain/beacon/callbacks_test.go
@@ -22,8 +22,8 @@ func TestStoreCallback(t *testing.T) {
 	cb := NewCallbackStore(bbstore)
 	id1 := "superid"
 	doneCh := make(chan bool, 1)
-	cb.AddCallback(id1, func(b *chain.Beacon, closing bool) {
-		if closing {
+	cb.AddCallback(id1, func(b *chain.Beacon, closed bool) {
+		if closed {
 			return
 		}
 		doneCh <- true

--- a/chain/beacon/callbacks_test.go
+++ b/chain/beacon/callbacks_test.go
@@ -30,6 +30,7 @@ func TestStoreCallback(t *testing.T) {
 		Round: 1,
 	})
 	require.True(t, checkOne(doneCh))
+
 	cb.AddCallback(id1, func(*chain.Beacon) {})
 	cb.Put(ctx, &chain.Beacon{
 		Round: 1,

--- a/chain/beacon/callbacks_test.go
+++ b/chain/beacon/callbacks_test.go
@@ -22,7 +22,10 @@ func TestStoreCallback(t *testing.T) {
 	cb := NewCallbackStore(bbstore)
 	id1 := "superid"
 	doneCh := make(chan bool, 1)
-	cb.AddCallback(id1, func(b *chain.Beacon) {
+	cb.AddCallback(id1, func(b *chain.Beacon, closing bool) {
+		if closing {
+			return
+		}
 		doneCh <- true
 	})
 
@@ -31,7 +34,7 @@ func TestStoreCallback(t *testing.T) {
 	})
 	require.True(t, checkOne(doneCh))
 
-	cb.AddCallback(id1, func(*chain.Beacon) {})
+	cb.AddCallback(id1, func(*chain.Beacon, bool) {})
 	cb.Put(ctx, &chain.Beacon{
 		Round: 1,
 	})

--- a/chain/beacon/chainstore.go
+++ b/chain/beacon/chainstore.go
@@ -86,7 +86,10 @@ func newChainStore(l log.Logger, cf *Config, cl net.ProtocolClient, v *vault.Vau
 	}
 	// we add callbacks to notify each time a final beacon is stored on the
 	// database so to update the latest view
-	cbs.AddCallback("chainstore", func(b *chain.Beacon) {
+	cbs.AddCallback("chainstore", func(b *chain.Beacon, closing bool) {
+		if closing {
+			return
+		}
 		cs.beaconStoredAgg <- b
 	})
 	// TODO maybe look if it's worth having multiple workers there

--- a/chain/beacon/chainstore.go
+++ b/chain/beacon/chainstore.go
@@ -86,8 +86,8 @@ func newChainStore(l log.Logger, cf *Config, cl net.ProtocolClient, v *vault.Vau
 	}
 	// we add callbacks to notify each time a final beacon is stored on the
 	// database so to update the latest view
-	cbs.AddCallback("chainstore", func(b *chain.Beacon, closing bool) {
-		if closing {
+	cbs.AddCallback("chainstore", func(b *chain.Beacon, closed bool) {
+		if closed {
 			return
 		}
 		cs.beaconStoredAgg <- b

--- a/chain/beacon/chainstore.go
+++ b/chain/beacon/chainstore.go
@@ -102,9 +102,10 @@ func (c *chainStore) NewValidPartial(addr string, p *drand.PartialBeaconPacket) 
 }
 
 func (c *chainStore) Stop() {
-	c.syncm.Stop()
-	c.CallbackStore.Close(context.Background())
 	close(c.done)
+	c.syncm.Stop()
+	c.RemoveCallback("chainstore")
+	c.CallbackStore.Close(context.Background())
 }
 
 // we store partials that are up to this amount of rounds more than the last

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -463,7 +463,7 @@ func (h *Handler) StopAt(stopTime int64) error {
 }
 
 // AddCallback is a proxy method to register a callback on the backend store
-func (h *Handler) AddCallback(id string, fn func(*chain.Beacon)) {
+func (h *Handler) AddCallback(id string, fn CallbackFunc) {
 	h.chain.AddCallback(id, fn)
 }
 

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -250,8 +250,9 @@ func (h *Handler) TransitionNewGroup(newShare *key.Share, newGroup *key.Group) {
 	// register a callback such that when the round happening just before the
 	// transition is stored, then it switches the current share to the new one
 	targetRound := tRound - 1
-	h.chain.AddCallback("transition", func(b *chain.Beacon) {
-		if b.Round < targetRound {
+	h.chain.AddCallback("transition", func(b *chain.Beacon, closing bool) {
+		if closing ||
+			b.Round < targetRound {
 			return
 		}
 		h.crypto.SetInfo(newGroup, newShare)

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -250,8 +250,8 @@ func (h *Handler) TransitionNewGroup(newShare *key.Share, newGroup *key.Group) {
 	// register a callback such that when the round happening just before the
 	// transition is stored, then it switches the current share to the new one
 	targetRound := tRound - 1
-	h.chain.AddCallback("transition", func(b *chain.Beacon, closing bool) {
-		if closing ||
+	h.chain.AddCallback("transition", func(b *chain.Beacon, closed bool) {
+		if closed ||
 			b.Round < targetRound {
 			return
 		}
@@ -313,6 +313,9 @@ func (h *Handler) run(startTime int64) {
 
 	for {
 		select {
+		case <-h.close:
+			h.l.Debugw("", "beacon_loop", "finished")
+			return
 		case current = <-chanTick:
 
 			setRunning.Do(func() {
@@ -364,9 +367,6 @@ func (h *Handler) run(startTime int64) {
 					h.broadcastNextPartial(c, latest)
 				}(current, b)
 			}
-		case <-h.close:
-			h.l.Debugw("", "beacon_loop", "finished")
-			return
 		}
 	}
 }

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -400,8 +400,8 @@ func TestBeaconSync(t *testing.T) {
 
 	var counter = &sync.WaitGroup{}
 	myCallBack := func(i int) CallbackFunc {
-		return func(b *chain.Beacon, closing bool) {
-			if closing {
+		return func(b *chain.Beacon, closed bool) {
+			if closed {
 				return
 			}
 
@@ -480,8 +480,8 @@ func TestBeaconSimple(t *testing.T) {
 
 	var counter = &sync.WaitGroup{}
 	counter.Add(n)
-	myCallBack := func(b *chain.Beacon, closing bool) {
-		if closing {
+	myCallBack := func(b *chain.Beacon, closed bool) {
+		if closed {
 			return
 		}
 
@@ -543,8 +543,8 @@ func TestBeaconThreshold(t *testing.T) {
 	currentRound := uint64(0)
 	var counter sync.WaitGroup
 	myCallBack := func(i int) CallbackFunc {
-		return func(b *chain.Beacon, closing bool) {
-			if closing {
+		return func(b *chain.Beacon, closed bool) {
+			if closed {
 				return
 			}
 

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -112,7 +112,6 @@ type node struct {
 	index    int // group index
 	private  *key.Pair
 	shares   *key.Share
-	callback func(*chain.Beacon)
 	handler  *Handler
 	listener net.Listener
 	clock    clock.FakeClock
@@ -210,9 +209,6 @@ func (b *BeaconTest) CreateNode(t *testing.T, i int) {
 	version := common.GetAppVersion()
 	node.handler, err = NewHandler(net.NewGrpcClient(), store, conf, logger, version)
 	checkErr(err)
-	if node.callback != nil {
-		node.handler.AddCallback(priv.Public.Address(), node.callback)
-	}
 
 	if node.handler.addr != node.private.Public.Address() {
 		panic("createNode address mismatch")

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -206,8 +206,7 @@ func (c *callbackStore) Put(ctx context.Context, b *chain.Beacon) error {
 func (c *callbackStore) AddCallback(id string, fn CallbackFunc) {
 	c.Lock()
 	defer c.Unlock()
-	_, ok := c.callbacks[id]
-	if ok {
+	if _, exists := c.newJob[id]; exists {
 		close(c.newJob[id])
 		delete(c.newJob, id)
 	}

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -154,7 +154,7 @@ func (d *discrepancyStore) Put(ctx context.Context, b *chain.Beacon) error {
 // callbackStores keeps a list of functions to notify on new beacons
 type callbackStore struct {
 	chain.Store
-	sync.Mutex
+	sync.RWMutex
 	done      chan bool
 	callbacks map[string]func(*chain.Beacon)
 	newJob    chan cbPair
@@ -185,8 +185,8 @@ func (c *callbackStore) Put(ctx context.Context, b *chain.Beacon) error {
 		return err
 	}
 	if b.Round != 0 {
-		c.Lock()
-		defer c.Unlock()
+		c.RLock()
+		defer c.RUnlock()
 		for _, cb := range c.callbacks {
 			c.newJob <- cbPair{
 				cb: cb,

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -220,8 +220,10 @@ func (c *callbackStore) RemoveCallback(id string) {
 	c.Lock()
 	defer c.Unlock()
 	delete(c.callbacks, id)
-	close(c.newJob[id])
-	delete(c.newJob, id)
+	if _, exists := c.newJob[id]; exists {
+		close(c.newJob[id])
+		delete(c.newJob, id)
+	}
 }
 
 func (c *callbackStore) Close(ctx context.Context) error {

--- a/chain/beacon/sync_manager.go
+++ b/chain/beacon/sync_manager.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -457,7 +456,7 @@ func SyncChain(l log.Logger, store CallbackStore, req SyncRequest, stream SyncSt
 	fromRound := req.GetFromRound()
 	ctx := stream.Context()
 	addr := net.RemoteAddress(ctx)
-	id := addr + "SyncChain" + strconv.Itoa(rand.Int()) //nolint:gosec
+	id := addr + "SyncChain"
 
 	logger := l.Named("SyncChain")
 	logger.Infow("Starting SyncChain", "for", addr)

--- a/chain/beacon/sync_manager_test.go
+++ b/chain/beacon/sync_manager_test.go
@@ -1,0 +1,262 @@
+package beacon
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/drand/drand/chain"
+	"github.com/drand/drand/chain/boltdb"
+	"github.com/drand/drand/log"
+	"github.com/drand/drand/protobuf/drand"
+	"github.com/drand/drand/test"
+	dcontext "github.com/drand/drand/test/context"
+	"github.com/stretchr/testify/require"
+)
+
+type testSyncStream struct {
+	ctx        context.Context
+	l          log.Logger
+	counterMtx *sync.Mutex
+	counter    int
+	failOn     int
+}
+
+func (s *testSyncStream) Context() context.Context {
+	return s.ctx
+}
+
+func (s *testSyncStream) GetCounter() int {
+	s.counterMtx.Lock()
+	defer s.counterMtx.Unlock()
+	return s.counter
+}
+
+var errShouldFail = errors.New("should fail")
+
+func (s *testSyncStream) Send(*drand.BeaconPacket) error {
+	s.counterMtx.Lock()
+	defer s.counterMtx.Unlock()
+	s.counter++
+
+	s.l.Debugw("sending message", "i", s.counter)
+
+	if s.failOn == s.counter {
+		s.l.Debugw("stream reached expected fail counter", "i", s.counter)
+		return errShouldFail
+	}
+	if s.failOn != 0 &&
+		s.failOn < s.counter {
+		panic("shouldn't happen")
+	}
+
+	return nil
+}
+
+func createTestCBStore(t *testing.T) CallbackStore {
+	t.Helper()
+	dir := t.TempDir()
+	ctx, _, _ := dcontext.PrevSignatureMattersOnContext(t, context.Background())
+	l := test.Logger(t)
+	bbstore, err := boltdb.NewBoltStore(ctx, l, dir, nil)
+	require.NoError(t, err)
+	cb := NewCallbackStore(bbstore)
+
+	for i := uint64(0); i < 10; i++ {
+		err := cb.Put(context.Background(), &chain.Beacon{
+			PreviousSig: []byte("some sig"),
+			Round:       i,
+			Signature:   []byte("some sig"),
+		})
+		require.NoError(t, err)
+	}
+
+	return cb
+}
+
+//nolint:funlen
+func TestSyncChain(t *testing.T) {
+	t.Run("Running once", func(t *testing.T) {
+		cb := createTestCBStore(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		l := test.Logger(t)
+		stream := &testSyncStream{ctx: ctx, l: l.Named("1"), counterMtx: &sync.Mutex{}, counter: 0}
+		errChan := make(chan error)
+
+		go func() {
+			errChan <- SyncChain(l, cb, &TestSyncRequest{round: 1}, stream)
+		}()
+		select {
+		case err := <-errChan:
+			require.NoError(t, err)
+		case <-time.After(1 * time.Second):
+			cancel()
+		}
+		err := <-errChan
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 9, stream.GetCounter())
+	})
+
+	t.Run("Running once with callback advancing", func(t *testing.T) {
+		cb := createTestCBStore(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		l := test.Logger(t)
+		stream := &testSyncStream{ctx: ctx, l: l.Named("1"), counterMtx: &sync.Mutex{}, counter: 0}
+		errChan := make(chan error)
+
+		go func() {
+			errChan <- SyncChain(l, cb, &TestSyncRequest{round: 1}, stream)
+		}()
+
+		select {
+		case err := <-errChan:
+			require.NoError(t, err)
+		case <-time.After(50 * time.Millisecond):
+			for i := uint64(10); i < 15; i++ {
+				err := cb.Put(context.Background(), &chain.Beacon{
+					PreviousSig: []byte("some sig"),
+					Round:       i,
+					Signature:   []byte("some sig"),
+				})
+				require.NoError(t, err)
+			}
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}
+
+		err := <-errChan
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 14, stream.GetCounter())
+	})
+
+	t.Run("Running concurrently", func(t *testing.T) {
+		cb := createTestCBStore(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		l := test.Logger(t)
+		stream1 := &testSyncStream{ctx: ctx, l: l.Named("1"), counterMtx: &sync.Mutex{}, counter: 0}
+		stream2 := &testSyncStream{ctx: ctx, l: l.Named("2"), counterMtx: &sync.Mutex{}, counter: 0}
+
+		errChan1 := make(chan error)
+		go func() {
+			errChan1 <- SyncChain(l, cb, &TestSyncRequest{round: 1}, stream1)
+		}()
+
+		time.Sleep(50 * time.Millisecond)
+		errChan2 := make(chan error)
+		go func() {
+			errChan2 <- SyncChain(l, cb, &TestSyncRequest{round: 1}, stream2)
+		}()
+
+		select {
+		case err := <-errChan1:
+			require.NoError(t, err)
+		case err := <-errChan2:
+			require.NoError(t, err)
+		case <-time.After(50 * time.Millisecond):
+			for i := uint64(10); i < 17; i++ {
+				err := cb.Put(context.Background(), &chain.Beacon{
+					PreviousSig: []byte("some sig"),
+					Round:       i,
+					Signature:   []byte("some sig"),
+				})
+				require.NoError(t, err)
+			}
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}
+
+		err := <-errChan1
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 16, stream1.GetCounter())
+		require.Equal(t, 16, stream2.GetCounter())
+	})
+
+	t.Run("Running concurrently one stream fails", func(t *testing.T) {
+		cb := createTestCBStore(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		l := test.Logger(t)
+		stream1 := &testSyncStream{ctx: ctx, l: l.Named("1"), counterMtx: &sync.Mutex{}, counter: 0, failOn: 8}
+		stream2 := &testSyncStream{ctx: ctx, l: l.Named("2"), counterMtx: &sync.Mutex{}, counter: 0}
+
+		errChan1 := make(chan error)
+		go func() {
+			errChan1 <- SyncChain(l, cb, &TestSyncRequest{round: 1}, stream1)
+		}()
+
+		time.Sleep(50 * time.Millisecond)
+		errChan2 := make(chan error)
+		go func() {
+			errChan2 <- SyncChain(l, cb, &TestSyncRequest{round: 1}, stream2)
+		}()
+
+		select {
+		case err := <-errChan2:
+			require.NoError(t, err)
+		case <-time.After(50 * time.Millisecond):
+			cancel()
+		}
+
+		err := <-errChan1
+		require.ErrorIs(t, err, errShouldFail)
+		require.Equal(t, 8, stream1.GetCounter())
+		require.Equal(t, 9, stream2.GetCounter())
+	})
+
+	t.Run("Running concurrently one stream fails", func(t *testing.T) {
+		cb := createTestCBStore(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		l := test.Logger(t)
+		stream1 := &testSyncStream{ctx: ctx, l: l.Named("1"), counterMtx: &sync.Mutex{}, counter: 0, failOn: 13}
+		stream2 := &testSyncStream{ctx: ctx, l: l.Named("2"), counterMtx: &sync.Mutex{}, counter: 0}
+
+		errChan1 := make(chan error)
+		go func() {
+			errChan1 <- SyncChain(l, cb, &TestSyncRequest{round: 1}, stream1)
+		}()
+
+		time.Sleep(50 * time.Millisecond)
+
+		errChan2 := make(chan error)
+		go func() {
+			errChan2 <- SyncChain(l, cb, &TestSyncRequest{round: 1}, stream2)
+		}()
+
+		select {
+		case err := <-errChan2:
+			require.NoError(t, err)
+		case <-time.After(50 * time.Millisecond):
+			for i := uint64(10); i < 17; i++ {
+				err := cb.Put(context.Background(), &chain.Beacon{
+					PreviousSig: []byte("some sig"),
+					Round:       i,
+					Signature:   []byte("some sig"),
+				})
+				require.NoError(t, err)
+				// TODO: make sure the callbacks are not able to "keep running" after being removed
+				time.Sleep(5 * time.Millisecond)
+			}
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}
+		err := <-errChan1
+		require.ErrorIs(t, err, errShouldFail)
+		require.Equal(t, 13, stream1.GetCounter())
+		require.Equal(t, 16, stream2.GetCounter())
+	})
+}

--- a/common/version.go
+++ b/common/version.go
@@ -13,7 +13,7 @@ import (
 var version = Version{
 	Major:      1,
 	Minor:      5,
-	Patch:      1,
+	Patch:      2,
 	Prerelease: "testnet",
 }
 

--- a/core/broadcast.go
+++ b/core/broadcast.go
@@ -133,7 +133,7 @@ func (b *echoBroadcast) BroadcastDKG(c context.Context, p *drand.DKGPacket) erro
 		return nil
 	}
 	if err := b.verif(dkgPacket); err != nil {
-		b.l.Errorw("received invalid signature", "from", addr, "signature", dkgPacket.Sig(), "err", err)
+		b.l.Errorw("received invalid signature", "from", addr, "signature", dkgPacket.Sig(), "scheme", b.scheme, "err", err)
 		return errors.New("invalid DKGPacket")
 	}
 

--- a/core/config.go
+++ b/core/config.go
@@ -38,7 +38,6 @@ type Config struct {
 	pgDSN             string
 	pgConn            *sqlx.DB
 	memDBSize         int
-	beaconCbs         []func(*chain.Beacon)
 	dkgCallback       func(*key.Share, *key.Group)
 	certPath          string
 	keyPath           string
@@ -118,12 +117,6 @@ func (d *Config) ControlPort() string {
 // Logger returns the logger associated with this config.
 func (d *Config) Logger() log.Logger {
 	return d.logger
-}
-
-func (d *Config) callbacks(b *chain.Beacon) {
-	for _, fn := range d.beaconCbs {
-		fn(b)
-	}
 }
 
 func (d *Config) applyDkgCallback(share *key.Share, group *key.Group) {
@@ -221,22 +214,6 @@ func WithMemDBSize(bufferSize int) ConfigOption {
 func WithConfigFolder(folder string) ConfigOption {
 	return func(d *Config) {
 		d.configFolder = folder
-	}
-}
-
-// WithBeaconCallback sets a function that is called each time a new random
-// beacon is generated.
-func WithBeaconCallback(fn func(*chain.Beacon)) ConfigOption {
-	return func(d *Config) {
-		d.beaconCbs = append(d.beaconCbs, fn)
-	}
-}
-
-// WithDKGCallback sets a function that is called when the DKG finishes. It
-// passes in the share of this node and the distributed public key generated.
-func WithDKGCallback(fn func(*key.Share, *key.Group)) ConfigOption {
-	return func(d *Config) {
-		d.dkgCallback = fn
 	}
 }
 

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -314,7 +314,7 @@ func (bp *BeaconProcess) Stop(ctx context.Context) {
 	default:
 		bp.log.Debugw("Stopping BeaconProcess", "id", bp.getBeaconID())
 	}
-	bp.StopBeacon()
+
 	// we wait until we can send on the channel or the context got canceled
 	select {
 	case bp.exitCh <- true:
@@ -322,6 +322,8 @@ func (bp *BeaconProcess) Stop(ctx context.Context) {
 	case <-ctx.Done():
 		bp.log.Warnw("Context canceled, BeaconProcess exitCh probably blocked")
 	}
+
+	bp.StopBeacon()
 }
 
 // WaitExit returns a channel that signals when drand stops its operations

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -407,7 +407,6 @@ func (bp *BeaconProcess) newBeacon(ctx context.Context) (*beacon.Handler, error)
 		return nil, err
 	}
 	bp.beacon = b
-	bp.beacon.AddCallback("opts", bp.opts.callbacks)
 	// cancel any sync operations
 	if bp.syncerCancel != nil {
 		bp.syncerCancel()

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -1349,8 +1349,8 @@ func sendProgressCallback(
 
 	var plainProgressCb func(a, b uint64)
 	plainProgressCb, done = sendPlainProgressCallback(stream, logger, upTo == 0)
-	cb = func(b *chain.Beacon, closing bool) {
-		if closing {
+	cb = func(b *chain.Beacon, closed bool) {
+		if closed {
 			return
 		}
 

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -335,6 +335,7 @@ func (bp *BeaconProcess) runDKG(leader bool, group *key.Group, timeout uint32, r
 
 	reader, user := extractEntropy(randomness)
 	sch := bp.priv.Scheme()
+	bp.log.Debugw("Starting runDKG", "scheme", sch)
 	config := &dkg.Config{
 		Suite:          sch.KeyGroup.(dkg.Suite),
 		NewNodes:       group.DKGNodes(),

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -1340,7 +1340,7 @@ func sendProgressCallback(
 	info *chain.Info,
 	clk clock.Clock,
 	l log.Logger,
-) (cb func(b *chain.Beacon), done chan struct{}) {
+) (cb beacon.CallbackFunc, done chan struct{}) {
 	logger := l.Named("progressCb")
 	targ := chain.CurrentRound(clk.Now().Unix(), info.Period, info.GenesisTime)
 	if upTo != 0 && upTo < targ {
@@ -1349,7 +1349,11 @@ func sendProgressCallback(
 
 	var plainProgressCb func(a, b uint64)
 	plainProgressCb, done = sendPlainProgressCallback(stream, logger, upTo == 0)
-	cb = func(b *chain.Beacon) {
+	cb = func(b *chain.Beacon, closing bool) {
+		if closing {
+			return
+		}
+
 		plainProgressCb(b.Round, targ)
 	}
 

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -214,7 +214,6 @@ func (bp *BeaconProcess) SyncChain(req *drand.SyncRequest, stream drand.Protocol
 	// we cannot just defer Unlock because beacon.SyncChain can run for a long time
 	bp.state.RUnlock()
 
-	// TODO: consider re-running the SyncChain command if we get a ErrNoBeaconStored back as it could be a follow cmd
 	return beacon.SyncChain(logger, store, req, stream)
 }
 

--- a/core/drand_beacon_public.go
+++ b/core/drand_beacon_public.go
@@ -23,8 +23,10 @@ func (bp *BeaconProcess) BroadcastDKG(c context.Context, in *drand.DKGPacket) (*
 
 	if bp.dkgInfo == nil {
 		bp.state.Unlock()
-		// TODO: make sure the DKG refactor removes this racy Broadcast issue
-		bp.opts.clock.Sleep(time.Millisecond)
+		// TODO: make sure the DKG refactor removes this racy Broadcast issue.
+		// We do want to use time.Sleep and not the fakeClock here, since this is a workaround for
+		// the locking vs packet arrival happening concurrently
+		time.Sleep(time.Millisecond)
 		bp.state.Lock()
 		if bp.dkgInfo == nil {
 			return nil, fmt.Errorf("drand: no dkg running and yet received a DKGPacket for beacon %s from node %s", bp.beaconID, addr)

--- a/core/drand_daemon_control.go
+++ b/core/drand_daemon_control.go
@@ -280,17 +280,15 @@ func (dd *DrandDaemon) Stop(ctx context.Context) {
 	}
 	dd.privGateway.StopAll(ctx)
 	dd.log.Debugw("privGateway stopped successfully")
-	// we defer the stop of the ControlListener to avoid canceling our context already
-	defer func() {
-		// We launch this in a goroutine to allow the stop connection to exit successfully.
-		// If we wouldn't launch it in a goroutine the Stop call itself would block the shutdown
-		// procedure and we'd be in a loop.
-		// By default, the Stop call will try to terminate all connections nicely.
-		// However, after a timeout, it will forcefully close all connections and terminate.
-		go func() {
-			dd.control.Stop()
-			dd.log.Debugw("control stopped successfully")
-		}()
+
+	// We launch this in a goroutine to allow the stop connection to exit successfully.
+	// If we wouldn't launch it in a goroutine the Stop call itself would block the shutdown
+	// procedure and we'd be in a loop.
+	// By default, the Stop call will try to terminate all connections nicely.
+	// However, after a timeout, it will forcefully close all connections and terminate.
+	go func() {
+		dd.control.Stop()
+		dd.log.Debugw("control stopped successfully")
 	}()
 }
 

--- a/demo/lib/orchestrator.go
+++ b/demo/lib/orchestrator.go
@@ -622,15 +622,16 @@ func (e *Orchestrator) PrintLogs() {
 func (e *Orchestrator) Shutdown() {
 	fmt.Println("[+] Shutdown all nodes")
 	for _, no := range e.nodes {
-		fmt.Printf("\t- Stop old node %s\n", no.PrivateAddr())
-		no.Stop()
-		fmt.Println("\t- Successfully stopped Node", no.Index(), "(", no.PrivateAddr(), ")")
+		fmt.Printf("\t- Stopping old node %s\n", no.PrivateAddr())
+		go no.Stop()
 	}
 	for _, no := range e.newNodes {
-		fmt.Printf("\t- Stop new node %s\n", no.PrivateAddr())
-		no.Stop()
+		fmt.Printf("\t- Stopping new node %s\n", no.PrivateAddr())
+		go no.Stop()
 		fmt.Println("\t- Successfully stopped Node", no.Index(), "(", no.PrivateAddr(), ")")
 	}
+	fmt.Println("\t- Successfully sent Stop command to all node")
+	time.Sleep(time.Minute)
 }
 
 func runCommand(c *exec.Cmd, add ...string) []byte {


### PR DESCRIPTION
Fixes #1020

- Use a RWMutex for CallbackStore
- Have a single go routine per callback and remove callback workers entirely
- Make sure that a new callback being added with the same id will cancel and remove the old one
- Have a single SyncChain callback per remote node instead of opening a new one for each