### PR TITLE
Change the order of stores in chain store. Improve tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ CLI_PACKAGE=github.com/drand/drand/cmd/drand-cli
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 BUILD_DATE := $(shell date -u +%d/%m/%Y@%H:%M:%S)
 
+ifneq ($(CI),)
+SHORTTEST :=
+else
+SHORTTEST := -short
+endif
+
 drand: build
 
 ####################  Lint and fmt process ##################
@@ -52,54 +58,54 @@ clean:
 test: test-unit test-integration
 
 test-unit:
-	go test -failfast -race -short -v ./...
+	go test -failfast $(SHORTTEST) -race -v ./...
 
 test-unit-boltdb: test-unit
 
 test-unit-memdb:
-	go test -failfast -race -tags memdb -short -v ./...
+	go test -failfast $(SHORTTEST) -race -v -tags memdb ./...
 
 test-unit-postgres:
-	go test -failfast -race -tags postgres -short -v ./...
+	go test -failfast $(SHORTTEST) -race -v -tags postgres ./...
 
 test-unit-cover:
-	go test -failfast -short -v -coverprofile=coverage.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
+	go test -failfast $(SHORTTEST) -v -coverprofile=coverage.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
 
 test-unit-boltdb-cover: test-unit-cover
 
 test-unit-memdb-cover:
-	go test -failfast -short -tags memdb -v -coverprofile=coverage-memdb.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
+	go test -failfast $(SHORTTEST) -v -tags memdb -coverprofile=coverage-memdb.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
 
 test-unit-postgres-cover:
-	go test -failfast -short -tags postgres -v -coverprofile=coverage-postgres.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
+	go test -failfast $(SHORTTEST) -v -tags postgres -coverprofile=coverage-postgres.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
 
 test-integration:
-	go test -failfast -v ./demo
+	go test -failfast $(SHORTTEST) -race -v ./demo
 	cd demo && go build && ./demo -build -test -debug
 
 test-integration-boltdb: test-integration
 
 test-integration-memdb:
-	go test -failfast -race -short -tags memdb -v ./...
+	go test -failfast $(SHORTTEST) -race -v -tags memdb ./...
 	cd demo && go build && ./demo -dbtype=memdb -build -test -debug
 
 test-integration-postgres:
-	go test -failfast -race -short -tags postgres -v ./...
+	go test -failfast $(SHORTTEST) -race -v -tags postgres ./...
 	cd demo && go build && ./demo -dbtype=postgres -build -test -debug
 
 coverage:
 	go get -v -t -d ./...
-	go test -failfast -v -covermode=atomic -coverpkg ./... -coverprofile=coverage.txt ./...
+	go test -failfast $(SHORTTEST) -v -covermode=atomic -coverpkg ./... -coverprofile=coverage.txt ./...
 
 coverage-boltdb: coverage
 
 coverage-memdb:
 	go get -tags=memdb -v -t -d ./...
-	go test -failfast -v -tags=memdb -covermode=atomic -coverpkg ./... -coverprofile=coverage-memdb.txt ./...
+	go test -failfast $(SHORTTEST) -v -tags=memdb -covermode=atomic -coverpkg ./... -coverprofile=coverage-memdb.txt ./...
 
 coverage-postgres:
 	go get -tags=postgres -v -t -d ./...
-	go test -failfast -v -tags=postgres -covermode=atomic -coverpkg ./... -coverprofile=coverage-postgres.txt ./...
+	go test -failfast $(SHORTTEST) -v -tags=postgres -covermode=atomic -coverpkg ./... -coverprofile=coverage-postgres.txt ./...
 
 demo:
 	cd demo && go build && ./demo -build

--- a/chain/beacon/callbacks_test.go
+++ b/chain/beacon/callbacks_test.go
@@ -19,7 +19,7 @@ func TestStoreCallback(t *testing.T) {
 	l := test.Logger(t)
 	bbstore, err := boltdb.NewBoltStore(ctx, l, dir, nil)
 	require.NoError(t, err)
-	cb := NewCallbackStore(bbstore)
+	cb := NewCallbackStore(l, bbstore)
 	id1 := "superid"
 	doneCh := make(chan bool, 1)
 	cb.AddCallback(id1, func(b *chain.Beacon, closed bool) {

--- a/chain/beacon/chainstore.go
+++ b/chain/beacon/chainstore.go
@@ -45,21 +45,22 @@ func newChainStore(l log.Logger, cf *Config, cl net.ProtocolClient, v *vault.Vau
 		return nil, err
 	}
 
+	// we can register callbacks on it
+	cbs := NewCallbackStore(l, as)
+
 	// we add a store to run some checks depending on scheme-related config
-	ss, err := NewSchemeStore(as, cf.Group.Scheme)
+	ss, err := NewSchemeStore(cbs, cf.Group.Scheme)
 	if err != nil {
 		return nil, err
 	}
+
 	// we write some stats about the timing when new beacon is saved
 	ds := newDiscrepancyStore(ss, l, v.GetGroup(), cf.Clock)
-
-	// we can register callbacks on it
-	cbs := NewCallbackStore(ds)
 
 	// we give the final append store to the sync manager
 	syncm, err := NewSyncManager(&SyncConfig{
 		Log:         l,
-		Store:       cbs,
+		Store:       ds,
 		BoltdbStore: store,
 		Info:        v.GetInfo(),
 		Client:      cl,

--- a/chain/beacon/chainstore.go
+++ b/chain/beacon/chainstore.go
@@ -123,7 +123,9 @@ func (c *chainStore) Stop() {
 var partialCacheStoreLimit = 3
 
 // runAggregator runs a continuous loop that tries to aggregate partial
-// signatures when it can
+// signatures when it can.
+//
+//nolint:gocyclo // This function should be simplified, if possible.
 func (c *chainStore) runAggregator() {
 	select {
 	case <-c.ctx.Done():

--- a/chain/beacon/chainstore.go
+++ b/chain/beacon/chainstore.go
@@ -125,7 +125,7 @@ var partialCacheStoreLimit = 3
 // runAggregator runs a continuous loop that tries to aggregate partial
 // signatures when it can.
 //
-//nolint:gocyclo // This function should be simplified, if possible.
+//nolint:gocyclo,funlen // This function should be simplified, if possible.
 func (c *chainStore) runAggregator() {
 	select {
 	case <-c.ctx.Done():
@@ -133,9 +133,7 @@ func (c *chainStore) runAggregator() {
 	default:
 		c.l.Debugw("starting chain_aggregator")
 	}
-	lastBeacon := &chain.Beacon{
-		Round: -1,
-	}
+	var lastBeacon *chain.Beacon
 
 	var cache = newPartialCache(c.l, c.crypto.Scheme)
 	for {
@@ -146,7 +144,7 @@ func (c *chainStore) runAggregator() {
 			cache.FlushRounds(lastBeacon.Round)
 		case partial := <-c.newPartials:
 			var err error
-			if lastBeacon.Round == -1 {
+			if lastBeacon == nil {
 				lastBeacon, err = c.Last(c.ctx)
 				if err != nil {
 					if errors.Is(err, context.Canceled) {

--- a/chain/beacon/chainstore.go
+++ b/chain/beacon/chainstore.go
@@ -136,10 +136,10 @@ func (c *chainStore) runAggregator() {
 	lastBeacon, err := c.Last(c.ctx)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			c.l.Errorw("", "chain_aggregator", "loading", "last_beacon", err)
+			c.l.Errorw("stopping chain_aggregator", "loading", "last_beacon", "err", err)
 			return
 		}
-		c.l.Fatalw("", "chain_aggregator", "loading", "last_beacon", err)
+		c.l.Fatalw("stopping chain_aggregator", "loading", "last_beacon", "err", err)
 	}
 
 	var cache = newPartialCache(c.l, c.crypto.Scheme)

--- a/chain/beacon/chainstore.go
+++ b/chain/beacon/chainstore.go
@@ -45,11 +45,8 @@ func newChainStore(l log.Logger, cf *Config, cl net.ProtocolClient, v *vault.Vau
 		return nil, err
 	}
 
-	// we can register callbacks on it
-	cbs := NewCallbackStore(l, as)
-
 	// we add a store to run some checks depending on scheme-related config
-	ss, err := NewSchemeStore(cbs, cf.Group.Scheme)
+	ss, err := NewSchemeStore(as, cf.Group.Scheme)
 	if err != nil {
 		return nil, err
 	}
@@ -57,10 +54,13 @@ func newChainStore(l log.Logger, cf *Config, cl net.ProtocolClient, v *vault.Vau
 	// we write some stats about the timing when new beacon is saved
 	ds := newDiscrepancyStore(ss, l, v.GetGroup(), cf.Clock)
 
+	// we can register callbacks on it
+	cbs := NewCallbackStore(l, ds)
+
 	// we give the final append store to the sync manager
 	syncm, err := NewSyncManager(&SyncConfig{
 		Log:         l,
-		Store:       ds,
+		Store:       cbs,
 		BoltdbStore: store,
 		Info:        v.GetInfo(),
 		Client:      cl,

--- a/chain/beacon/chainstore.go
+++ b/chain/beacon/chainstore.go
@@ -135,6 +135,10 @@ func (c *chainStore) runAggregator() {
 	}
 	lastBeacon, err := c.Last(c.ctx)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			c.l.Errorw("", "chain_aggregator", "loading", "last_beacon", err)
+			return
+		}
 		c.l.Fatalw("", "chain_aggregator", "loading", "last_beacon", err)
 	}
 

--- a/chain/beacon/chainstore.go
+++ b/chain/beacon/chainstore.go
@@ -39,23 +39,23 @@ type chainStore struct {
 }
 
 func newChainStore(l log.Logger, cf *Config, cl net.ProtocolClient, v *vault.Vault, store chain.Store, t *ticker) (*chainStore, error) {
-	// we make sure the chain is increasing monotonically
-	as, err := newAppendStore(store)
-	if err != nil {
-		return nil, err
-	}
+	// we write some stats about the timing when new beacon is saved
+	ds := newDiscrepancyStore(store, l, v.GetGroup(), cf.Clock)
 
 	// we add a store to run some checks depending on scheme-related config
-	ss, err := NewSchemeStore(as, cf.Group.Scheme)
+	ss, err := NewSchemeStore(ds, cf.Group.Scheme)
 	if err != nil {
 		return nil, err
 	}
 
-	// we write some stats about the timing when new beacon is saved
-	ds := newDiscrepancyStore(ss, l, v.GetGroup(), cf.Clock)
+	// we make sure the chain is increasing monotonically
+	as, err := newAppendStore(ss)
+	if err != nil {
+		return nil, err
+	}
 
 	// we can register callbacks on it
-	cbs := NewCallbackStore(l, ds)
+	cbs := NewCallbackStore(l, as)
 
 	// we give the final append store to the sync manager
 	syncm, err := NewSyncManager(&SyncConfig{

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -556,7 +556,7 @@ func TestBeaconThreshold(t *testing.T) {
 			// callbacks are called for syncing up as well so we only decrease
 			// waitgroup when it's the current round
 			if b.Round == currentRound {
-				t.Logf("florin: node %d got b.Round(%d) == currentRound(%d)", i, b.Round, currentRound)
+				t.Logf("node %d got b.Round(%d) == currentRound(%d)", i, b.Round, currentRound)
 				counter.Done()
 			}
 		}

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -556,6 +556,7 @@ func TestBeaconThreshold(t *testing.T) {
 			// callbacks are called for syncing up as well so we only decrease
 			// waitgroup when it's the current round
 			if b.Round == currentRound {
+				t.Logf("florin: node %d got b.Round(%d) == currentRound(%d)", i, b.Round, currentRound)
 				counter.Done()
 			}
 		}

--- a/chain/beacon/node_test.go
+++ b/chain/beacon/node_test.go
@@ -654,5 +654,6 @@ func (t TestSyncRequest) GetMetadata() *pbCommon.Metadata {
 
 func (b *BeaconTest) CallbackFor(i int, fn CallbackFunc) {
 	j := b.searchNode(i)
-	b.nodes[j].handler.AddCallback(b.nodes[j].private.Public.Address(), fn)
+	address := b.nodes[j].private.Public.Address()
+	b.nodes[j].handler.AddCallback(fmt.Sprintf("%s - node %d", address, i), fn)
 }

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -83,15 +83,6 @@ func NewSchemeStore(s chain.Store, sch *crypto.Scheme) (chain.Store, error) {
 func (a *schemeStore) Put(ctx context.Context, b *chain.Beacon) error {
 	a.Lock()
 	defer a.Unlock()
-	/*if b.Round == a.last.Round {
-		if bytes.Equal(a.last.Signature, b.Signature) {
-			if bytes.Equal(a.last.PreviousSig, b.PreviousSig) {
-				return nil
-			}
-			return fmt.Errorf("florin: tried to store a duplicate beacon for round %d but the previous signature was different", b.Round)
-		}
-		return fmt.Errorf("florin: tried to store a duplicate beacon for round %d but the signature was different", b.Round)
-	}*/
 
 	// If the scheme is unchained, previous signature is set to nil. In that case,
 	// relationship between signature in the previous beacon and previous signature
@@ -197,7 +188,7 @@ func (c *callbackStore) Put(ctx context.Context, b *chain.Beacon) error {
 	if err := c.Store.Put(ctx, b); err != nil {
 		return err
 	}
-	// c.l.Debugw(string(debug.Stack()), "msg", "florin: callbackStore.Put()", "round", b.Round)
+
 	if b.Round != 0 {
 		c.RLock()
 		defer c.RUnlock()

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -83,6 +83,15 @@ func NewSchemeStore(s chain.Store, sch *crypto.Scheme) (chain.Store, error) {
 func (a *schemeStore) Put(ctx context.Context, b *chain.Beacon) error {
 	a.Lock()
 	defer a.Unlock()
+	if b.Round == a.last.Round {
+		if bytes.Equal(a.last.Signature, b.Signature) {
+			if bytes.Equal(a.last.PreviousSig, b.PreviousSig) {
+				return nil
+			}
+			return fmt.Errorf("tried to store a duplicate beacon for round %d but the previous signature was different", b.Round)
+		}
+		return fmt.Errorf("tried to store a duplicate beacon for round %d but the signature was different", b.Round)
+	}
 
 	// If the scheme is unchained, previous signature is set to nil. In that case,
 	// relationship between signature in the previous beacon and previous signature

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -60,20 +60,18 @@ func (a *appendStore) Put(ctx context.Context, b *chain.Beacon) error {
 			if bytes.Equal(a.last.PreviousSig, b.PreviousSig) {
 				return fmt.Errorf("%w round %d", ErrBeaconAlreadyStored, b.Round)
 			}
-			return fmt.Errorf("florin: tried to store a duplicate beacon for round %d but the previous signature was different", b.Round)
+			return fmt.Errorf("tried to store a duplicate beacon for round %d but the previous signature was different", b.Round)
 		}
-		return fmt.Errorf("florin: tried to store a duplicate beacon for round %d but the signature was different", b.Round)
+		return fmt.Errorf("tried to store a duplicate beacon for round %d but the signature was different", b.Round)
 	}
 
 	if b.Round != a.last.Round+1 {
 		return fmt.Errorf("invalid round inserted: last %d, new %d", a.last.Round, b.Round)
 	}
 	if err := a.Store.Put(ctx, b); err != nil {
-		log.DefaultLogger().Debugw("florin: calling appendStore.Put()", "last", a.last)
 		return err
 	}
 	a.last = b
-	log.DefaultLogger().Debugw("florin: calling appendStore.Put()", "last", a.last)
 	return nil
 }
 
@@ -229,7 +227,7 @@ func (c *callbackStore) AddCallback(id string, fn CallbackFunc) {
 	c.Lock()
 	defer c.Unlock()
 	if jobChan, exists := c.newJob[id]; exists {
-		c.l.Debugw("florin: removing existing call back", "id", id, "reason", "to add a new one")
+		c.l.Debugw("removing existing call back", "id", id, "reason", "to add a new one")
 		jobChan <- cbPair{
 			cb:    c.callbacks[id],
 			b:     nil,
@@ -239,7 +237,7 @@ func (c *callbackStore) AddCallback(id string, fn CallbackFunc) {
 		delete(c.newJob, id)
 	}
 
-	c.l.Debugw("florin: adding callback", "id", id)
+	c.l.Debugw("adding callback", "id", id)
 
 	c.callbacks[id] = fn
 	c.newJob[id] = make(chan cbPair, CallbackWorkerQueue)
@@ -251,7 +249,7 @@ func (c *callbackStore) RemoveCallback(id string) {
 	defer c.Unlock()
 	delete(c.callbacks, id)
 	if _, exists := c.newJob[id]; exists {
-		c.l.Debugw("florin: removing existing call back", "id", id, "reason", "called RemoveCallback")
+		c.l.Debugw("removing existing call back", "id", id, "reason", "called RemoveCallback")
 		close(c.newJob[id])
 		delete(c.newJob, id)
 	}

--- a/chain/beacon/store.go
+++ b/chain/beacon/store.go
@@ -83,7 +83,7 @@ func NewSchemeStore(s chain.Store, sch *crypto.Scheme) (chain.Store, error) {
 func (a *schemeStore) Put(ctx context.Context, b *chain.Beacon) error {
 	a.Lock()
 	defer a.Unlock()
-	if b.Round == a.last.Round {
+	/*if b.Round == a.last.Round {
 		if bytes.Equal(a.last.Signature, b.Signature) {
 			if bytes.Equal(a.last.PreviousSig, b.PreviousSig) {
 				return nil
@@ -91,7 +91,7 @@ func (a *schemeStore) Put(ctx context.Context, b *chain.Beacon) error {
 			return fmt.Errorf("florin: tried to store a duplicate beacon for round %d but the previous signature was different", b.Round)
 		}
 		return fmt.Errorf("florin: tried to store a duplicate beacon for round %d but the signature was different", b.Round)
-	}
+	}*/
 
 	// If the scheme is unchained, previous signature is set to nil. In that case,
 	// relationship between signature in the previous beacon and previous signature

--- a/chain/beacon/sync_manager.go
+++ b/chain/beacon/sync_manager.go
@@ -417,7 +417,7 @@ func (s *SyncManager) tryNode(global context.Context, from, upTo uint64, peer ne
 				if err := s.store.Put(cnode, beacon); err != nil {
 					if errors.Is(err, ErrBeaconAlreadyStored) {
 						logger.Debugw("Put: race with aggregation", "with_peer", peer.Address(), "err", err)
-						return true
+						return beacon.Round == upTo
 					}
 
 					logger.Errorw("Put: unable to save", "with_peer", peer.Address(), "err", err)

--- a/chain/beacon/sync_manager.go
+++ b/chain/beacon/sync_manager.go
@@ -415,6 +415,11 @@ func (s *SyncManager) tryNode(global context.Context, from, upTo uint64, peer ne
 				}
 			} else {
 				if err := s.store.Put(cnode, beacon); err != nil {
+					if errors.Is(err, ErrBeaconAlreadyStored) {
+						logger.Debugw("Put: race with aggregation", "with_peer", peer.Address(), "err", err)
+						return true
+					}
+
 					logger.Errorw("Put: unable to save", "with_peer", peer.Address(), "err", err)
 					return false
 				}

--- a/chain/beacon/sync_manager_test.go
+++ b/chain/beacon/sync_manager_test.go
@@ -65,7 +65,7 @@ func createTestCBStore(t *testing.T) CallbackStore {
 	l := test.Logger(t)
 	bbstore, err := boltdb.NewBoltStore(ctx, l, dir, nil)
 	require.NoError(t, err)
-	cb := NewCallbackStore(bbstore)
+	cb := NewCallbackStore(l, bbstore)
 
 	for i := uint64(0); i < 10; i++ {
 		err := cb.Put(context.Background(), &chain.Beacon{

--- a/chain/boltdb/store.go
+++ b/chain/boltdb/store.go
@@ -51,6 +51,12 @@ func isThisATest(ctx context.Context) bool {
 
 // NewBoltStore returns a Store implementation using the boltdb storage engine.
 func NewBoltStore(ctx context.Context, l log.Logger, folder string, opts *bolt.Options) (chain.Store, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	dbPath := path.Join(folder, BoltFileName)
 
 	if shouldUseTrimmedBolt(ctx, l, dbPath, opts) {
@@ -104,7 +110,13 @@ func shouldUseTrimmedBolt(ctx context.Context, l log.Logger, sourceBeaconPath st
 }
 
 // Len performs a big scan over the bucket and is _very_ slow - use sparingly!
-func (b *BoltStore) Len(context.Context) (int, error) {
+func (b *BoltStore) Len(ctx context.Context) (int, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+
 	var length = 0
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
@@ -128,13 +140,25 @@ func (b *BoltStore) Close(context.Context) error {
 
 // Put implements the Store interface. WARNING: It does NOT verify that this
 // beacon is not already saved in the database or not and will overwrite it.
-func (b *BoltStore) Put(_ context.Context, beacon *chain.Beacon) error {
+func (b *BoltStore) Put(ctx context.Context, beacon *chain.Beacon) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	return b.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 		key := chain.RoundToBytes(beacon.Round)
 		buff, err := beacon.Marshal()
 		if err != nil {
 			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
 		}
 		err = bucket.Put(key, buff)
 		if err != nil {
@@ -145,7 +169,13 @@ func (b *BoltStore) Put(_ context.Context, beacon *chain.Beacon) error {
 }
 
 // Last returns the last beacon signature saved into the db
-func (b *BoltStore) Last(context.Context) (*chain.Beacon, error) {
+func (b *BoltStore) Last(ctx context.Context) (*chain.Beacon, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	beacon := &chain.Beacon{}
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
@@ -160,7 +190,13 @@ func (b *BoltStore) Last(context.Context) (*chain.Beacon, error) {
 }
 
 // Get returns the beacon saved at this round
-func (b *BoltStore) Get(_ context.Context, round uint64) (*chain.Beacon, error) {
+func (b *BoltStore) Get(ctx context.Context, round uint64) (*chain.Beacon, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	beacon := &chain.Beacon{}
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
@@ -173,7 +209,13 @@ func (b *BoltStore) Get(_ context.Context, round uint64) (*chain.Beacon, error) 
 	return beacon, err
 }
 
-func (b *BoltStore) Del(_ context.Context, round uint64) error {
+func (b *BoltStore) Del(ctx context.Context, round uint64) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	return b.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 		return bucket.Delete(chain.RoundToBytes(round))
@@ -181,6 +223,12 @@ func (b *BoltStore) Del(_ context.Context, round uint64) error {
 }
 
 func (b *BoltStore) Cursor(ctx context.Context, fn func(context.Context, chain.Cursor) error) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 		c := bucket.Cursor()
@@ -197,7 +245,13 @@ func (b *BoltStore) Cursor(ctx context.Context, fn func(context.Context, chain.C
 }
 
 // SaveTo saves the bolt database to an alternate file.
-func (b *BoltStore) SaveTo(_ context.Context, w io.Writer) error {
+func (b *BoltStore) SaveTo(ctx context.Context, w io.Writer) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	return b.db.View(func(tx *bolt.Tx) error {
 		_, err := tx.WriteTo(w)
 		return err
@@ -208,7 +262,13 @@ type boltCursor struct {
 	*bolt.Cursor
 }
 
-func (c *boltCursor) First(context.Context) (*chain.Beacon, error) {
+func (c *boltCursor) First(ctx context.Context) (*chain.Beacon, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	k, v := c.Cursor.First()
 	if k == nil {
 		return nil, chainerrors.ErrNoBeaconStored
@@ -220,7 +280,13 @@ func (c *boltCursor) First(context.Context) (*chain.Beacon, error) {
 
 // Next returns the next value in the database for the given cursor.
 // When reaching the end of the database, it emits the ErrNoBeaconStored error to flag that it finished the iteration.
-func (c *boltCursor) Next(context.Context) (*chain.Beacon, error) {
+func (c *boltCursor) Next(ctx context.Context) (*chain.Beacon, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	k, v := c.Cursor.Next()
 	if k == nil {
 		return nil, chainerrors.ErrNoBeaconStored
@@ -230,7 +296,13 @@ func (c *boltCursor) Next(context.Context) (*chain.Beacon, error) {
 	return b, err
 }
 
-func (c *boltCursor) Seek(_ context.Context, round uint64) (*chain.Beacon, error) {
+func (c *boltCursor) Seek(ctx context.Context, round uint64) (*chain.Beacon, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	k, v := c.Cursor.Seek(chain.RoundToBytes(round))
 	if k == nil {
 		return nil, chainerrors.ErrNoBeaconStored
@@ -240,7 +312,13 @@ func (c *boltCursor) Seek(_ context.Context, round uint64) (*chain.Beacon, error
 	return b, err
 }
 
-func (c *boltCursor) Last(context.Context) (*chain.Beacon, error) {
+func (c *boltCursor) Last(ctx context.Context) (*chain.Beacon, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	k, v := c.Cursor.Last()
 	if k == nil {
 		return nil, chainerrors.ErrNoBeaconStored

--- a/chain/boltdb/trimmed.go
+++ b/chain/boltdb/trimmed.go
@@ -28,6 +28,12 @@ type trimmedStore struct {
 
 // newTrimmedStore returns a Store implementation using the boltdb storage engine.
 func newTrimmedStore(ctx context.Context, l log.Logger, folder string, opts *bolt.Options) (*trimmedStore, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	dbPath := path.Join(folder, BoltFileName)
 	db, err := bolt.Open(dbPath, BoltStoreOpenPerm, opts)
 	if err != nil {
@@ -48,7 +54,13 @@ func newTrimmedStore(ctx context.Context, l log.Logger, folder string, opts *bol
 }
 
 // Len performs a big scan over the bucket and is _very_ slow - use sparingly!
-func (b *trimmedStore) Len(context.Context) (int, error) {
+func (b *trimmedStore) Len(ctx context.Context) (int, error) {
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	default:
+	}
+
 	var length = 0
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
@@ -72,7 +84,13 @@ func (b *trimmedStore) Close(context.Context) error {
 
 // Put implements the Store interface. WARNING: It does NOT verify that this
 // beacon is not already saved in the database or not and will overwrite it.
-func (b *trimmedStore) Put(_ context.Context, beacon *chain.Beacon) error {
+func (b *trimmedStore) Put(ctx context.Context, beacon *chain.Beacon) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	return b.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 
@@ -89,12 +107,18 @@ func (b *trimmedStore) Put(_ context.Context, beacon *chain.Beacon) error {
 }
 
 // Last returns the last beacon signature saved into the db
-func (b *trimmedStore) Last(context.Context) (*chain.Beacon, error) {
+func (b *trimmedStore) Last(ctx context.Context) (*chain.Beacon, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	beacon := chain.Beacon{}
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 		cursor := bucket.Cursor()
-		b, err := b.getCursorBeacon(bucket, cursor.Last)
+		b, err := b.getCursorBeacon(ctx, bucket, cursor.Last)
 		if err != nil {
 			return err
 		}
@@ -108,11 +132,17 @@ func (b *trimmedStore) Last(context.Context) (*chain.Beacon, error) {
 }
 
 // Get returns the beacon saved at this round
-func (b *trimmedStore) Get(_ context.Context, round uint64) (*chain.Beacon, error) {
+func (b *trimmedStore) Get(ctx context.Context, round uint64) (*chain.Beacon, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	var beacon *chain.Beacon
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
-		b, err := b.getBeacon(bucket, round, true)
+		b, err := b.getBeacon(ctx, bucket, round, true)
 		if err != nil {
 			return err
 		}
@@ -123,7 +153,13 @@ func (b *trimmedStore) Get(_ context.Context, round uint64) (*chain.Beacon, erro
 	return beacon, err
 }
 
-func (b *trimmedStore) getBeacon(bucket *bolt.Bucket, round uint64, canFetchPrevious bool) (*chain.Beacon, error) {
+func (b *trimmedStore) getBeacon(ctx context.Context, bucket *bolt.Bucket, round uint64, canFetchPrevious bool) (*chain.Beacon, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	sig := bucket.Get(chain.RoundToBytes(round))
 	if sig == nil {
 		return nil, chainerrors.ErrNoBeaconStored
@@ -138,6 +174,12 @@ func (b *trimmedStore) getBeacon(bucket *bolt.Bucket, round uint64, canFetchPrev
 	if canFetchPrevious &&
 		b.requiresPrevious &&
 		beacon.Round > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		prevSig := bucket.Get(chain.RoundToBytes(round - 1))
 		if prevSig == nil {
 			b.log.Errorw("missing previous beacon from database", "round", beacon.Round-1)
@@ -150,7 +192,13 @@ func (b *trimmedStore) getBeacon(bucket *bolt.Bucket, round uint64, canFetchPrev
 	return &beacon, nil
 }
 
-func (b *trimmedStore) Del(_ context.Context, round uint64) error {
+func (b *trimmedStore) Del(ctx context.Context, round uint64) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	return b.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 		return bucket.Delete(chain.RoundToBytes(round))
@@ -158,6 +206,12 @@ func (b *trimmedStore) Del(_ context.Context, round uint64) error {
 }
 
 func (b *trimmedStore) Cursor(ctx context.Context, fn func(context.Context, chain.Cursor) error) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
 	err := b.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(beaconBucket)
 		c := bucket.Cursor()
@@ -186,17 +240,23 @@ type trimmedBoltCursor struct {
 	store *trimmedStore
 }
 
-func (c *trimmedBoltCursor) First(context.Context) (*chain.Beacon, error) {
-	return c.store.getCursorBeacon(c.Bucket(), c.Cursor.First)
+func (c *trimmedBoltCursor) First(ctx context.Context) (*chain.Beacon, error) {
+	return c.store.getCursorBeacon(ctx, c.Bucket(), c.Cursor.First)
 }
 
 // Next returns the next value in the database for the given cursor.
 // When reaching the end of the database, it emits the ErrNoBeaconStored error to flag that it finished the iteration.
-func (c *trimmedBoltCursor) Next(context.Context) (*chain.Beacon, error) {
-	return c.store.getCursorBeacon(c.Bucket(), c.Cursor.Next)
+func (c *trimmedBoltCursor) Next(ctx context.Context) (*chain.Beacon, error) {
+	return c.store.getCursorBeacon(ctx, c.Bucket(), c.Cursor.Next)
 }
 
-func (c *trimmedBoltCursor) Seek(_ context.Context, round uint64) (*chain.Beacon, error) {
+func (c *trimmedBoltCursor) Seek(ctx context.Context, round uint64) (*chain.Beacon, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	_, v := c.Cursor.Seek(chain.RoundToBytes(round))
 	if v == nil {
 		return nil, chainerrors.ErrNoBeaconStored
@@ -209,7 +269,7 @@ func (c *trimmedBoltCursor) Seek(_ context.Context, round uint64) (*chain.Beacon
 
 	if c.store.requiresPrevious &&
 		b.Round > 0 {
-		prevBeacon, err := c.store.getBeacon(c.Bucket(), b.Round-1, false)
+		prevBeacon, err := c.store.getBeacon(ctx, c.Bucket(), b.Round-1, false)
 		if err != nil {
 			c.store.log.Errorw("missing previous beacon from database", "round", b.Round-1, "err", err)
 			return nil, chainerrors.ErrNoBeaconStored
@@ -220,13 +280,19 @@ func (c *trimmedBoltCursor) Seek(_ context.Context, round uint64) (*chain.Beacon
 	return &b, nil
 }
 
-func (c *trimmedBoltCursor) Last(context.Context) (*chain.Beacon, error) {
-	return c.store.getCursorBeacon(c.Bucket(), c.Cursor.Last)
+func (c *trimmedBoltCursor) Last(ctx context.Context) (*chain.Beacon, error) {
+	return c.store.getCursorBeacon(ctx, c.Bucket(), c.Cursor.Last)
 }
 
 type beaconCursorGetter func() (key []byte, value []byte)
 
-func (b *trimmedStore) getCursorBeacon(bucket *bolt.Bucket, get beaconCursorGetter) (*chain.Beacon, error) {
+func (b *trimmedStore) getCursorBeacon(ctx context.Context, bucket *bolt.Bucket, get beaconCursorGetter) (*chain.Beacon, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	key, sig := get()
 	if key == nil {
 		return nil, chainerrors.ErrNoBeaconStored
@@ -240,7 +306,7 @@ func (b *trimmedStore) getCursorBeacon(bucket *bolt.Bucket, get beaconCursorGett
 
 	if b.requiresPrevious &&
 		beacon.Round > 0 {
-		prevBeacon, err := b.getBeacon(bucket, beacon.Round-1, false)
+		prevBeacon, err := b.getBeacon(ctx, bucket, beacon.Round-1, false)
 		if err != nil {
 			return nil, err
 		}

--- a/chain/boltdb/trimmed_test.go
+++ b/chain/boltdb/trimmed_test.go
@@ -28,8 +28,6 @@ func TestTrimmedStoreBoltOrder(t *testing.T) {
 		// yet could be fully retrieved.
 		// However, now that we rely on the previous value actually existing in the database,
 		// this test will fail.
-		// TODO (dlsniper): Agree that this test needs to be updated to reflect the new
-		//  implementation of the Store interface.
 		t.Skipf("This test does not make sense from a chained beacon perspective.")
 	}
 

--- a/chain/postgresdb/pgdb/pgdb_test.go
+++ b/chain/postgresdb/pgdb/pgdb_test.go
@@ -46,8 +46,6 @@ func Test_OrderStorePG(t *testing.T) {
 		// yet could be fully retrieved.
 		// However, now that we rely on the previous value actually existing in the database,
 		// this test will fail.
-		// TODO (dlsniper): Agree that this test needs to be updated to reflect the new
-		//  implementation of the Store interface.
 		t.Skipf("This test does not make sense from a chained beacon perspective.")
 	}
 

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -347,8 +347,11 @@ var storageTypeFlag = &cli.StringFlag{
 }
 
 var pgDSNFlag = &cli.StringFlag{
-	Name:    "pg-dsn",
-	Usage:   "PostgreSQL DSN configuration.",
+	Name: "pg-dsn",
+	Usage: "PostgreSQL DSN configuration.\n" +
+		"Supported options are:\n" +
+		"-sslmode see: https://www.postgresql.org/docs/15/libpq-ssl.html#LIBPQ-SSL-PROTECTION\n" +
+		"-connect_timeout see: https://www.postgresql.org/docs/15/libpq-connect.html#LIBPQ-CONNECT-CONNECT-TIMEOUT\n",
 	Value:   "postgres://drand:drand@localhost:5432/drand?sslmode=disable&connect_timeout=5",
 	EnvVars: []string{"DRAND_PG_DSN"},
 }

--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -349,7 +349,7 @@ var storageTypeFlag = &cli.StringFlag{
 var pgDSNFlag = &cli.StringFlag{
 	Name:    "pg-dsn",
 	Usage:   "PostgreSQL DSN configuration.",
-	Value:   "postgres://drand:drand@localhost:5432/drand?sslmode=disable&timeout=5&connect_timeout=5",
+	Value:   "postgres://drand:drand@localhost:5432/drand?sslmode=disable&connect_timeout=5",
 	EnvVars: []string{"DRAND_PG_DSN"},
 }
 

--- a/core/drand_beacon_test.go
+++ b/core/drand_beacon_test.go
@@ -174,7 +174,7 @@ func TestMemDBBeaconJoinsNetworkAfterDKG(t *testing.T) {
 	for {
 		ts.AdvanceMockClock(t, period)
 		time.Sleep(getSleepDuration())
-		if ts.clock.Now().Unix() > newGroup.TransitionTime {
+		if ts.clock.Now().Unix() >= newGroup.TransitionTime {
 			break
 		}
 	}
@@ -189,6 +189,6 @@ func TestMemDBBeaconJoinsNetworkAfterDKG(t *testing.T) {
 	ts.AdvanceMockClock(t, period)
 	time.Sleep(getSleepDuration())
 
-	err = ts.WaitUntilRound(t, memDBNode, 10)
+	err = ts.WaitUntilRound(t, memDBNode, 9)
 	require.NoError(t, err)
 }

--- a/demo/cfg/container.go
+++ b/demo/cfg/container.go
@@ -26,7 +26,7 @@ func BootContainer() func() {
 	}
 }
 
-const defaultPgDSN = "postgres://postgres:postgres@%s/%s?sslmode=disable&timeout=5&connect_timeout=5"
+const defaultPgDSN = "postgres://postgres:postgres@%s/%s?sslmode=disable&connect_timeout=5"
 
 func ComputePgDSN(dbEngineType chain.StorageType) func() string {
 	return func() string {

--- a/demo/lib/orchestrator.go
+++ b/demo/lib/orchestrator.go
@@ -593,7 +593,10 @@ func (e *Orchestrator) StartNode(idxs ...int) {
 
 		fmt.Printf("[+] Attempting to start node %s again ...\n", foundNode.PrivateAddr())
 		// Here we send the nil values to the start method to allow the node to reconnect to the same database
-		foundNode.Start(e.certFolder, "", nil, e.memDBSize)
+		err := foundNode.Start(e.certFolder, "", nil, e.memDBSize)
+		if err != nil {
+			panic(fmt.Errorf("[-] Could not start node %s error: %v", foundNode.PrivateAddr(), err))
+		}
 		var started bool
 		for trial := 1; trial < 10; trial += 1 {
 			if foundNode.Ping() {

--- a/demo/lib/orchestrator.go
+++ b/demo/lib/orchestrator.go
@@ -247,7 +247,9 @@ func (e *Orchestrator) WaitGenesis() {
 
 func (e *Orchestrator) WaitTransition() {
 	to := time.Until(time.Unix(e.transition, 0))
-	fmt.Printf("[+] Sleeping %s until transition happens\n", to)
+	currentRound := chain.CurrentRound(e.transition, e.periodD, e.genesis)
+
+	fmt.Printf("[+] Sleeping %s until transition happens (transition time: %d) currentRound: %d\n", to, e.transition, currentRound)
 	time.Sleep(to)
 	fmt.Printf("[+] Sleeping %s after transition - leaving some time for nodes\n", afterPeriodWait)
 	time.Sleep(afterPeriodWait)

--- a/demo/postgresdb_test.go
+++ b/demo/postgresdb_test.go
@@ -33,7 +33,7 @@ func withPgDSN(t *testing.T) func() string {
 		dbName := test.ComputeDBName()
 
 		dsn := fmt.Sprintf(
-			"postgres://postgres:postgres@%s/%s?sslmode=disable&timeout=5&connect_timeout=5",
+			"postgres://postgres:postgres@%s/%s?sslmode=disable&connect_timeout=5",
 			c.Host,
 			dbName,
 		)

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/nikkolasg/hexjson v0.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
+	github.com/rogpeppe/go-internal v1.9.1-0.20230118214834-e3815afac6ff
 	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli/v2 v2.19.2
 	github.com/weaveworks/common v0.0.0-20221201103051-7c2720a9024d

--- a/go.sum
+++ b/go.sum
@@ -633,6 +633,8 @@ github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtB
 github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.9.1-0.20230118214834-e3815afac6ff h1:8sKK+bDq41BDdR3Twlwv4ufZm3+N/hmnb0QkyocX9G0=
+github.com/rogpeppe/go-internal v1.9.1-0.20230118214834-e3815afac6ff/go.mod h1:4DOBFiuQsmS6qjl8rsAMyM0e8miaqS/Wnm+9jQ5RiOU=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=

--- a/http/server.go
+++ b/http/server.go
@@ -327,7 +327,7 @@ func (h *DrandHandler) getRand(ctx context.Context, chainHash []byte, info *chai
 
 	// make sure we aren't going to ask for a round that doesn't exist yet.
 	if time.Unix(chain.TimeOfRound(info.Period, info.GenesisTime, round), 0).After(time.Now()) {
-		h.log.Warnw("requested round is after now")
+		h.log.Warnw("requested round is in the future")
 		return nil, nil
 	}
 

--- a/http/server.go
+++ b/http/server.go
@@ -327,6 +327,7 @@ func (h *DrandHandler) getRand(ctx context.Context, chainHash []byte, info *chai
 
 	// make sure we aren't going to ask for a round that doesn't exist yet.
 	if time.Unix(chain.TimeOfRound(info.Period, info.GenesisTime, round), 0).After(time.Now()) {
+		h.log.Warnw("requested round is after now")
 		return nil, nil
 	}
 

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -16,6 +16,7 @@ import (
 	nhttp "github.com/drand/drand/client/http"
 	"github.com/drand/drand/crypto"
 	"github.com/drand/drand/protobuf/drand"
+	"github.com/drand/drand/test"
 	"github.com/drand/drand/test/mock"
 )
 
@@ -49,7 +50,7 @@ func TestHTTPRelay(t *testing.T) {
 
 	c, _ := withClient(t)
 
-	handler, err := New(ctx, "", nil)
+	handler, err := New(ctx, "", test.Logger(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,12 +149,11 @@ func validateEndpoint(endpoint string, round float64) error {
 }
 
 func TestHTTPWaiting(t *testing.T) {
-	t.Skipf("this test fails too often with: server_test.go:193: shouldn't be done. unexpected status: 404")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	c, push := withClient(t)
 
-	handler, err := New(ctx, "", nil)
+	handler, err := New(ctx, "", test.Logger(t))
 	require.NoError(t, err)
 
 	info, err := c.Info(ctx)
@@ -178,6 +178,11 @@ func TestHTTPWaiting(t *testing.T) {
 
 	// 1 watch get will occur (1970 - the bad one)
 	push(false)
+
+	// Wait a bit after we send this request since DrandHandler.getRand() might not contain
+	// the expected beacon from above due to lock contention on bh.pendingLk.
+	time.Sleep(10*time.Millisecond)
+
 	done := make(chan time.Time)
 	before := time.Now()
 	go func() {
@@ -218,7 +223,7 @@ func TestHTTPWatchFuture(t *testing.T) {
 	defer cancel()
 	c, _ := withClient(t)
 
-	handler, err := New(ctx, "", nil)
+	handler, err := New(ctx, "", test.Logger(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,7 +259,7 @@ func TestHTTPHealth(t *testing.T) {
 	defer cancel()
 	c, push := withClient(t)
 
-	handler, err := New(ctx, "", nil)
+	handler, err := New(ctx, "", test.Logger(t))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/http/server_test.go
+++ b/http/server_test.go
@@ -181,7 +181,7 @@ func TestHTTPWaiting(t *testing.T) {
 
 	// Wait a bit after we send this request since DrandHandler.getRand() might not contain
 	// the expected beacon from above due to lock contention on bh.pendingLk.
-	time.Sleep(10*time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
 
 	done := make(chan time.Time)
 	before := time.Now()

--- a/test/test.go
+++ b/test/test.go
@@ -80,7 +80,7 @@ func FreeBind(a string) string {
 			if fileMtxUnlock != nil {
 				break
 			}
-			time.Sleep(3*time.Millisecond)
+			time.Sleep(3 * time.Millisecond)
 		}
 		defer fileMtxUnlock()
 
@@ -217,4 +217,3 @@ func GetBeaconIDFromEnv() string {
 	beaconID := os.Getenv("BEACON_ID")
 	return commonutils.GetCanonicalBeaconID(beaconID)
 }
-


### PR DESCRIPTION
This PR improves the following:
- It changes the order of the chain store execution.
- It returns an error if the append store declined to store the same round as the latest one.
- It fixes the tests reusing the port they requested across tests. **_!This works only in CI._** For local development, run with `CI=true` and then clean the temporarily created file under `path.Join(os.TempDir(), ".drand_test_ports")`. Use the `FreeBind()` helper to guarantee the free port.
- It makes `TestHTTPWaiting` runnable again. The issue was caused by a race between receiving the beacon and making the request for it.
- It clarifies why some tests are skipped.

Misc changes:
- It makes the production logs less noisy by moving the Cursor.Next() error to the Debug level when it's expected to an ErrNoBeaconsStored value.
- It drops the unused `timeout` from the default Postgres DSN.
- It improves tests by adding a few more logs.


To address the issue of open ports not being usable, I had to use a `filelock` library.
[This particular one](https://github.com/rogpeppe/go-internal) is licensed in the style of Go and contains the implementation behind stdlib. Since this implementation is chosen, it shouldn't need anything special in terms of license compliance. However, I'm not a lawyer.