### PR TITLE
Adjust transition time. Fix demo not finishing in CI

### DIFF
--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -125,7 +125,7 @@ func (h *Handler) ProcessPartialBeacon(c context.Context, p *proto.PartialBeacon
 
 	idx, _ := h.crypto.ThresholdScheme.IndexOf(p.GetPartialSig())
 	if idx < 0 {
-		return nil, fmt.Errorf("invalid index %d in partial with msg %v", idx, msg)
+		return nil, fmt.Errorf("invalid index %d in partial with msg %v partial_round %v", idx, msg, p.GetRound())
 	}
 
 	node := h.crypto.GetGroup().Node(uint32(idx))
@@ -141,6 +141,7 @@ func (h *Handler) ProcessPartialBeacon(c context.Context, p *proto.PartialBeacon
 			"process_partial", addr, "err", err,
 			"prev_sig", shortSigStr(p.GetPreviousSignature()),
 			"curr_round", currentRound,
+			"partial_round", p.GetRound(),
 			"msg_sign", shortSigStr(msg),
 			"from_idx", idx,
 			"from_node", nodeName)
@@ -150,6 +151,7 @@ func (h *Handler) ProcessPartialBeacon(c context.Context, p *proto.PartialBeacon
 		"process_partial", addr,
 		"prev_sig", shortSigStr(p.GetPreviousSignature()),
 		"curr_round", currentRound,
+		"partial_round", p.GetRound(),
 		"msg_sign", shortSigStr(msg),
 		"from_node", nodeName,
 		"status", "OK")
@@ -247,7 +249,7 @@ func (h *Handler) TransitionNewGroup(newShare *key.Share, newGroup *key.Group) {
 	tRound := chain.CurrentRound(targetTime, h.conf.Group.Period, h.conf.Group.GenesisTime)
 	tTime := chain.TimeOfRound(h.conf.Group.Period, h.conf.Group.GenesisTime, tRound)
 	if tTime != targetTime {
-		h.l.Fatalw("", "transition_time", "invalid_offset", "expected_time", tTime, "got_time", targetTime)
+		h.l.Errorw("", "transition_time", "invalid_offset", "expected_time", tTime, "got_time", targetTime)
 		return
 	}
 	h.l.Infow("", "transition", "new_group", "at_round", tRound)

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -273,6 +273,9 @@ func (bp *BeaconProcess) transition(oldGroup *key.Group, oldPresent, newPresent 
 	// NOTE: this limits the round time of drand - for now it is not a use
 	// case to go that fast
 	ctx := context.Background()
+
+	// We stop the node at or after transition to make sure they are broadcasting
+	// their last partial before transition.
 	timeToStop := bp.group.TransitionTime + int64(bp.group.Period.Seconds()) - 1
 
 	if !newPresent {

--- a/core/drand_beacon.go
+++ b/core/drand_beacon.go
@@ -273,7 +273,7 @@ func (bp *BeaconProcess) transition(oldGroup *key.Group, oldPresent, newPresent 
 	// NOTE: this limits the round time of drand - for now it is not a use
 	// case to go that fast
 	ctx := context.Background()
-	timeToStop := bp.group.TransitionTime - 1
+	timeToStop := bp.group.TransitionTime + int64(bp.group.Period.Seconds()) - 1
 
 	if !newPresent {
 		// an old node is leaving the network
@@ -307,9 +307,11 @@ func (bp *BeaconProcess) transition(oldGroup *key.Group, oldPresent, newPresent 
 
 // Stop simply stops all drand operations.
 func (bp *BeaconProcess) Stop(ctx context.Context) {
+	bp.state.RLock()
 	select {
 	case <-bp.exitCh:
 		bp.log.Errorw("Trying to stop an already stopping beacon process", "id", bp.getBeaconID())
+		bp.state.RUnlock()
 		return
 	default:
 		bp.log.Debugw("Stopping BeaconProcess", "id", bp.getBeaconID())
@@ -322,6 +324,7 @@ func (bp *BeaconProcess) Stop(ctx context.Context) {
 	case <-ctx.Done():
 		bp.log.Warnw("Context canceled, BeaconProcess exitCh probably blocked")
 	}
+	bp.state.RUnlock()
 
 	bp.StopBeacon()
 }

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -1049,13 +1049,19 @@ func (bp *BeaconProcess) pushDKGInfo(outgoing, incoming []*key.Node, previousThr
 				bp.log.Errorw("", "push_dkg", "failed to push", "to", ok.address, "err", ok.err)
 				continue
 			}
-			bp.log.Debugw("", "push_dkg", "sending_group", "success_to", ok.address, "left", total)
 			if nodesContainAddr(outgoing, ok.address) {
 				previousThreshold--
 			}
 			if nodesContainAddr(incoming, ok.address) {
 				newThreshold--
 			}
+			bp.log.Debugw("",
+				"push_dkg", "sending_group",
+				"success_to", ok.address,
+				"left", total,
+				"previousThreshold", previousThreshold,
+				"newThreshold", newThreshold,
+			)
 		case <-bp.opts.clock.After(time.Minute):
 			if previousThreshold <= 0 && newThreshold <= 0 {
 				bp.log.Infow("", "push_dkg", "sending_group", "status", "enough succeeded", "missed", total)

--- a/core/drand_beacon_test.go
+++ b/core/drand_beacon_test.go
@@ -192,6 +192,6 @@ func TestMemDBBeaconJoinsNetworkAfterDKG(t *testing.T) {
 	ts.AdvanceMockClock(t, period)
 	time.Sleep(getSleepDuration())
 
-	err = ts.WaitUntilRound(t, memDBNode, 10)
+	err = ts.WaitUntilRound(t, memDBNode, 11)
 	require.NoError(t, err)
 }

--- a/core/drand_beacon_test.go
+++ b/core/drand_beacon_test.go
@@ -189,6 +189,9 @@ func TestMemDBBeaconJoinsNetworkAfterDKG(t *testing.T) {
 	ts.AdvanceMockClock(t, period)
 	time.Sleep(getSleepDuration())
 
-	err = ts.WaitUntilRound(t, memDBNode, 9)
+	ts.AdvanceMockClock(t, period)
+	time.Sleep(getSleepDuration())
+
+	err = ts.WaitUntilRound(t, memDBNode, 10)
 	require.NoError(t, err)
 }

--- a/core/group_setup.go
+++ b/core/group_setup.go
@@ -256,12 +256,17 @@ func (s *setupManager) createAndSend(keys []*key.Identity) {
 		group = key.NewGroup(keys, s.thr, genesis, s.beaconPeriod, s.catchupPeriod, s.scheme, s.beaconID)
 	} else {
 		genesis := s.oldGroup.GenesisTime
-		atLeast := s.clock.Now().Add(totalDKG).Unix()
+
+		// Transition will happen 2 rounds after the minimum time the DKG takes.
+		// This will allow nodes to not produce "bls: invalid signature" errors from nodes in the network.
+		atLeast := s.clock.Now().Add(totalDKG).Add(s.beaconPeriod).Unix()
+
 		// transitioning to the next round time that is at least
 		// "DefaultResharingOffset" time from now.
 		_, transition := chain.NextRound(atLeast, s.beaconPeriod, s.oldGroup.GenesisTime)
+
 		group = key.NewGroup(keys, s.thr, genesis, s.beaconPeriod, s.catchupPeriod, s.scheme, s.beaconID)
-		group.TransitionTime = transition + int64(s.beaconPeriod.Seconds())
+		group.TransitionTime = transition
 		group.GenesisSeed = s.oldGroup.GetGenesisSeed()
 	}
 	s.l.Debugw("", "setup", "created_group")

--- a/core/group_setup.go
+++ b/core/group_setup.go
@@ -261,7 +261,7 @@ func (s *setupManager) createAndSend(keys []*key.Identity) {
 		// "DefaultResharingOffset" time from now.
 		_, transition := chain.NextRound(atLeast, s.beaconPeriod, s.oldGroup.GenesisTime)
 		group = key.NewGroup(keys, s.thr, genesis, s.beaconPeriod, s.catchupPeriod, s.scheme, s.beaconID)
-		group.TransitionTime = transition
+		group.TransitionTime = transition + int64(s.beaconPeriod.Seconds())
 		group.GenesisSeed = s.oldGroup.GetGenesisSeed()
 	}
 	s.l.Debugw("", "setup", "created_group")

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -785,12 +785,6 @@ func (d *DrandTestScenario) RunReshare(t *testing.T, c *reshareConfig) (*key.Gro
 	d.t.Log("[reshare] LOCK")
 	d.t.Logf("[reshare] old: %d/%d | new: %d/%d", c.oldRun, len(d.nodes), c.newRun, len(d.newNodes))
 
-	// stop the excluded nodes
-	for i, node := range d.nodes[c.oldRun:] {
-		d.t.Logf("[reshare] stop old %d | %s", i, node.addr)
-		d.StopMockNode(node.addr, false)
-	}
-
 	if len(d.newNodes) > 0 {
 		for _, node := range d.newNodes[c.newRun:] {
 			d.t.Logf("[reshare] stop new %s", node.addr)
@@ -867,6 +861,12 @@ func (d *DrandTestScenario) RunReshare(t *testing.T, c *reshareConfig) (*key.Gro
 			d.t.Logf(" \n LEAVING THE LEADER_ONLY RESHARING\n\n")
 			return nil, errPreempted
 		}
+	}
+
+	// stop the excluded nodes
+	for i, node := range d.nodes[c.oldRun:] {
+		d.t.Logf("[reshare] stop old %d | %s", i, node.addr)
+		d.StopMockNode(node.addr, false)
 	}
 
 	// wait for the return of the clients

--- a/core/util_test.go
+++ b/core/util_test.go
@@ -256,10 +256,14 @@ func (d *DrandTestScenario) Ids(n int, newGroup bool) []string {
 func (d *DrandTestScenario) waitFor(
 	t *testing.T,
 	client *net.ControlClient,
-	maxRetries int, //nolint
 	waitFor func(r *drand.StatusResponse) bool,
 ) bool {
-	retry := 0
+	period := d.period
+	if d.period == 0 {
+		period = 10
+	}
+	maxRetries := (period * 3).Milliseconds() / 100
+	retry := int64(0)
 	for {
 		r, err := client.Status(d.beaconID)
 		require.NoError(t, err)
@@ -296,7 +300,7 @@ func (d *DrandTestScenario) RunDKG() (*key.Group, error) {
 	var wg sync.WaitGroup
 	wg.Add(totalNodes)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	done := make(chan bool) // signal we are done with the reshare before the timeout
 
@@ -322,7 +326,7 @@ func (d *DrandTestScenario) RunDKG() (*key.Group, error) {
 		d.t.Logf("[RunDKG] Leader    Finished. GroupHash %x", group.Hash())
 
 		// We need to make sure the daemon is running before continuing
-		d.waitFor(d.t, controlClient, 10, func(r *drand.StatusResponse) bool {
+		d.waitFor(d.t, controlClient, func(r *drand.StatusResponse) bool {
 			// TODO: maybe needs to be changed if running and started aren't both necessary, using "isStarted" could maybe work too
 			return r.Beacon.IsRunning
 		})
@@ -332,7 +336,7 @@ func (d *DrandTestScenario) RunDKG() (*key.Group, error) {
 	// first run the leader and then run the other nodes
 	go runLeaderNode()
 
-	require.True(d.t, d.waitFor(d.t, controlClient, 10, func(r *drand.StatusResponse) bool {
+	require.True(d.t, d.waitFor(d.t, controlClient, func(r *drand.StatusResponse) bool {
 		return r.Dkg.Status == uint32(DkgInProgress)
 	}))
 	d.t.Logf("[DEBUG] node: %s DKG Status: is in progress", leaderNode.GetAddr())
@@ -365,7 +369,7 @@ func (d *DrandTestScenario) RunDKG() (*key.Group, error) {
 			d.t.Logf("[RunDKG] NonLeader %s Finished. GroupHash %x", n.GetAddr(), group.Hash())
 
 			// We need to make sure the daemon is running before continuing
-			d.waitFor(d.t, client, 10, func(r *drand.StatusResponse) bool {
+			d.waitFor(d.t, client, func(r *drand.StatusResponse) bool {
 				// TODO: maybe needs to be changed if running and started aren't both necessary, using "isStarted" could maybe work too
 				return r.Beacon.IsRunning
 			})
@@ -817,7 +821,7 @@ func (d *DrandTestScenario) RunReshare(t *testing.T, c *reshareConfig) (*key.Gro
 	go d.runLeaderReshare(leader, controlClient, d.newN, d.newThr, c.timeout, errCh, leaderGroupReadyCh)
 	d.resharedNodes = append(d.resharedNodes, leader)
 
-	require.True(t, d.waitFor(t, controlClient, 10, func(r *drand.StatusResponse) bool {
+	require.True(t, d.waitFor(t, controlClient, func(r *drand.StatusResponse) bool {
 		return r.Reshare.Status == uint32(ReshareInProgress)
 	}))
 	t.Logf("[DEBUG] node: %s Reshare Status: is in progress", leader.GetAddr())

--- a/demo/main.go
+++ b/demo/main.go
@@ -148,7 +148,7 @@ func main() {
 	orch.WaitTransition()
 	limit := 10000
 	if *testF {
-		limit = 4
+		limit = 5
 	}
 	// look if beacon is still up even with the nodeToExclude being offline
 	for i := 0; i < limit; i++ {

--- a/demo/main.go
+++ b/demo/main.go
@@ -148,7 +148,7 @@ func main() {
 	orch.WaitTransition()
 	limit := 10000
 	if *testF {
-		limit = 5
+		limit = 4
 	}
 	// look if beacon is still up even with the nodeToExclude being offline
 	for i := 0; i < limit; i++ {


### PR DESCRIPTION
This PR:
- Improves context cancel checks in a few more places.
- Adjusts the Transition time after a reshare command to avoid the logs with `bls: invalid signature` due to nodes not being present in the new network yet.
- Fixes the demo code not finishing in CI.