### PR TITLE
Remove the drand show private command from the CLI

### DIFF
--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -569,12 +569,6 @@ var appCommands = []*cli.Command{
 				Action: showChainInfo,
 			},
 			{
-				Name:   "private",
-				Usage:  "shows the long-term private key of a node.\n",
-				Flags:  toArray(controlFlag, beaconIDFlag),
-				Action: showPrivateCmd,
-			},
-			{
 				Name:   "public",
 				Usage:  "shows the long-term public key of a node.\n",
 				Flags:  toArray(controlFlag, beaconIDFlag),

--- a/cmd/drand-cli/control.go
+++ b/cmd/drand-cli/control.go
@@ -591,21 +591,6 @@ func showChainInfo(c *cli.Context) error {
 	return printChainInfo(c, ci)
 }
 
-func showPrivateCmd(c *cli.Context) error {
-	client, err := controlClient(c)
-	if err != nil {
-		return err
-	}
-
-	beaconID := getBeaconID(c)
-	resp, err := client.PrivateKey(beaconID)
-	if err != nil {
-		return fmt.Errorf("could not request drand.private: %w", err)
-	}
-
-	return printJSON(resp)
-}
-
 func showPublicCmd(c *cli.Context) error {
 	client, err := controlClient(c)
 	if err != nil {


### PR DESCRIPTION
As the title says, this PR removes the `drand show private` command.
The command was removed at the server level already, but now it's also removed from the CLI completely.