### PR TITLE
Improve GitHub Actions to shorten the run time of tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,12 +67,64 @@ jobs:
           SCHEME_ID: ${{ matrix.scheme_id }}
           CI: "true"
         run: make test-unit-${{ matrix.db_type }}
+
+  test-integration:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        db_type: [ "boltdb", "memdb", "postgres" ]
+        scheme_id: [ "pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-on-g1" ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-go@v3.5.0
+        with:
+          go-version: '1.19.5'
+      - uses: actions/cache@v3.2.3
+        id: cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - run: go get -v -t -d -tags integration,${{ matrix.db_type }} ./...
       - name: Integration tests
         env:
           DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
           SCHEME_ID: ${{ matrix.scheme_id }}
           CI: "true"
         run: make test-integration-${{ matrix.db_type }}
+
+  test-integration-run-demo:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        db_type: [ "boltdb", "memdb", "postgres" ]
+        scheme_id: [ "pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-on-g1" ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.3.0
+      - uses: actions/setup-go@v3.5.0
+        with:
+          go-version: '1.19.5'
+      - uses: actions/cache@v3.2.3
+        id: cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - run: go get -v -t -d -tags integration,${{ matrix.db_type }} ./...
+      - name: Integration tests
+        env:
+          DRAND_TEST_LOGS: "${{ runner.debug == '1' && 'DEBUG' || 'INFO' }}"
+          SCHEME_ID: ${{ matrix.scheme_id }}
+          CI: "true"
+        run: make test-integration-run-demo-${{ matrix.db_type }}
 
   coverage:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 .PHONY: test-unit-cover test-unit-boltdb-cover test-unit-memdb-cover test-unit-postgres-cover
 .PHONY: coverage coverage-boltdb coverage-memdb coverage-postgres
 .PHONY: test-integration test-integration-boltdb test-integration-memdb test-integration-postgres
+.PHONY: test-integration-run-demo test-integration-run-demo-boltdb test-integration-run-demo-memdb test-integration-run-demo-postgres
 .PHONY: demo demo-boltdb demo-memdb demo-postgres
 .PHONY: deploy-local linter install build client drand relay-http relay-gossip relay-s3
 .PHONY: install_deps_linux install_deps_darwin install_deps_darwin-m
@@ -80,18 +81,27 @@ test-unit-postgres-cover:
 	go test -failfast $(SHORTTEST) -v -tags postgres -coverprofile=coverage-postgres.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
 
 test-integration:
-	go test -failfast $(SHORTTEST) -race -v ./demo
-	cd demo && go build && ./demo -build -test -debug
+	go test -failfast $(SHORTTEST) -race -v -tags integration ./demo/
 
 test-integration-boltdb: test-integration
 
 test-integration-memdb:
-	go test -failfast $(SHORTTEST) -race -v -tags memdb ./...
-	cd demo && go build && ./demo -dbtype=memdb -build -test -debug
+	go test -failfast $(SHORTTEST) -race -v -tags integration,memdb ./demo/
 
 test-integration-postgres:
-	go test -failfast $(SHORTTEST) -race -v -tags postgres ./...
+	go test -failfast $(SHORTTEST) -race -v -tags integration,postgres ./demo/
+
+test-integration-run-demo:
+	cd demo && go build && ./demo -build -test -debug
+
+test-integration-run-demo-boltdb: test-integration-run-demo
+
+test-integration-run-demo-memdb:
+	cd demo && go build && ./demo -dbtype=memdb -build -test -debug
+
+test-integration-run-demo-postgres:
 	cd demo && go build && ./demo -dbtype=postgres -build -test -debug
+
 
 coverage:
 	go get -v -t -d ./...

--- a/demo/boltdb_test.go
+++ b/demo/boltdb_test.go
@@ -1,4 +1,4 @@
-//go:build !postgres && !memdb
+//go:build integration && !postgres && !memdb
 
 package main_test
 

--- a/demo/demo_test.go
+++ b/demo/demo_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 package main_test
 
 import (

--- a/demo/memdb_test.go
+++ b/demo/memdb_test.go
@@ -1,4 +1,4 @@
-//go:build memdb
+//go:build integration && memdb
 
 package main_test
 

--- a/demo/postgresdb_test.go
+++ b/demo/postgresdb_test.go
@@ -1,4 +1,4 @@
-//go:build postgres
+//go:build integration && postgres
 
 package main_test
 


### PR DESCRIPTION
This PR changes the way we run integration tests, especially related to the `demo` code.
Now:
- The integration tests are now their own separate jobs instead of steps in the original test jobs.
- There are a couple of separate demo runners to be used for running the `test-demo` and `demo` itself.