### PR TITLE
Report the db type to the group

### DIFF
--- a/chain/store.go
+++ b/chain/store.go
@@ -55,7 +55,8 @@ const (
 	MemDB StorageType = "memdb"
 )
 
-// Metrics values for reporting storage type used
+// Metrics values for reporting storage type used. Only append new values.
+// Also, add new values to the DrandStorageBackend metric Help.
 const (
 	boltDBMetrics = iota + 1
 	postgreSQLMetrics
@@ -72,7 +73,7 @@ func MetricsStorageType(st StorageType) int {
 		return memDBMetrics
 	default:
 		err := fmt.Errorf("unknown storage type %q for metrics reporting", st)
-		// Please add the storage type to the Metrics values list above
+		// Please add the storage type to the Metrics values list above and to the DrandStorageBackend metric Help
 		panic(err)
 	}
 }

--- a/core/drand_daemon.go
+++ b/core/drand_daemon.go
@@ -74,7 +74,9 @@ func NewDrandDaemon(c *Config) (*DrandDaemon, error) {
 		return nil, err
 	}
 
-	metrics.DrandStorageBackend.Set(float64(chain.MetricsStorageType(c.dbStorageEngine)))
+	metrics.DrandStorageBackend.
+		WithLabelValues(string(c.dbStorageEngine)).
+		Set(float64(chain.MetricsStorageType(c.dbStorageEngine)))
 
 	return drandDaemon, nil
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -234,7 +234,7 @@ var (
 	// DrandStorageBackend reports the database the node is running with
 	DrandStorageBackend = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "drand_node_db",
-		Help: "The database type the node is running with",
+		Help: "The database type the node is running with. 1=boltdb, 2=postgres, 3=memdb",
 	})
 
 	// OutgoingConnectionState (Group) tracks the state of an outgoing connection, according to
@@ -268,10 +268,6 @@ func bindMetrics() {
 		log.DefaultLogger().Errorw("error in bindMetrics", "metrics", "processCollector", "err", err)
 		return
 	}
-	if err := PrivateMetrics.Register(DrandStorageBackend); err != nil {
-		log.DefaultLogger().Errorw("error in bindMetrics", "metrics", "storageBackend", "err", err)
-		return
-	}
 
 	// Group metrics
 	group := []prometheus.Collector{
@@ -292,6 +288,7 @@ func bindMetrics() {
 		OutgoingConnectionState,
 		IsDrandNode,
 		DrandStartTimestamp,
+		DrandStorageBackend,
 	}
 	for _, c := range group {
 		if err := GroupMetrics.Register(c); err != nil {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -232,10 +232,10 @@ var (
 	})
 
 	// DrandStorageBackend reports the database the node is running with
-	DrandStorageBackend = prometheus.NewGauge(prometheus.GaugeOpts{
+	DrandStorageBackend = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "drand_node_db",
-		Help: "The database type the node is running with. 1=boltdb, 2=postgres, 3=memdb",
-	})
+		Help: "The database type the node is running with. 1=bolt, 2=postgres, 3=memdb",
+	}, []string{"db_type"})
 
 	// OutgoingConnectionState (Group) tracks the state of an outgoing connection, according to
 	// https://github.com/grpc/grpc-go/blob/master/connectivity/connectivity.go#L51


### PR DESCRIPTION
Tested with:
- for current node:
```
# curl --silent 127.0.0.1:9999/metrics | grep -i db

# HELP drand_node_db The database type the node is running with. 1=bolt, 2=postgres, 3=memdb
# TYPE drand_node_db gauge
drand_node_db{db_type="memdb"} 3
```
- for other nodes
```
# curl --silent 127.0.0.1:9999/peer/127.0.0.1:61102/metrics | grep -i db

# HELP drand_node_db The database type the node is running with. 1=boltdb, 2=postgres, 3=memdb
# TYPE drand_node_db gauge
drand_node_db{db_type="memdb"} 3

# curl --silent 127.0.0.1:9999/peer/127.0.0.1:61103/metrics | grep -i db

# HELP drand_node_db The database type the node is running with. 1=bolt, 2=postgres, 3=memdb
# TYPE drand_node_db gauge
drand_node_db{db_type="bolt"} 1

```