### PR TITLE
Misc changes & do not process partials for already stored nodes

### DIFF
--- a/cmd/drand-cli/cli.go
+++ b/cmd/drand-cli/cli.go
@@ -733,6 +733,11 @@ func keygenCmd(c *cli.Context) error {
 		return errors.New("missing drand address in argument. Abort")
 	}
 
+	if args.Len() > 1 {
+		return fmt.Errorf("expecting only one argument, the address, but got:"+
+			"\n\t%v\nAborting. Note that the flags need to go before the argument", args.Slice())
+	}
+
 	addr := args.First()
 	var validID = regexp.MustCompile(`:\d+$`)
 	if !validID.MatchString(addr) {

--- a/core/drand_beacon_control.go
+++ b/core/drand_beacon_control.go
@@ -790,8 +790,7 @@ func (bp *BeaconProcess) RemoteStatus(ctx context.Context, in *drand.RemoteStatu
 		var err error
 		var resp *drand.StatusResponse
 		statusReq := &drand.StatusRequest{
-			CheckConn: in.GetAddresses(),
-			Metadata:  bp.newMetadata(),
+			Metadata: bp.newMetadata(),
 		}
 		if remoteAddress == bp.priv.Public.Addr {
 			// it's ourself
@@ -802,7 +801,7 @@ func (bp *BeaconProcess) RemoteStatus(ctx context.Context, in *drand.RemoteStatu
 			resp, err = bp.privGateway.Status(ctx, p, statusReq)
 		}
 		if err != nil {
-			bp.log.Errorw("Status request failed", "remote", addr, "error", err)
+			bp.log.Warnw("Status request failed", "for_node", addr, "error", err)
 		} else {
 			replies[remoteAddress] = resp
 		}

--- a/internal/context/context_test.go
+++ b/internal/context/context_test.go
@@ -1,0 +1,64 @@
+package context
+
+import (
+	"context"
+	"testing"
+)
+
+type thisisatest bool
+
+func TestSkipLogs(t *testing.T) {
+	tests := []struct {
+		name string
+		args context.Context
+		want bool
+	}{
+		{
+			"set false",
+			SetSkipLogs(context.Background(), false),
+			false,
+		},
+		{
+			"none set",
+			context.Background(),
+			false,
+		},
+		{
+			"set true",
+			SetSkipLogs(context.Background(), true),
+			true,
+		},
+		{
+			"set true twice",
+			SetSkipLogs(SetSkipLogs(context.Background(), true), true),
+			true,
+		},
+		{
+			"set false twice",
+			SetSkipLogs(SetSkipLogs(context.Background(), false), false),
+			false,
+		},
+		{
+			"set true set false",
+			SetSkipLogs(SetSkipLogs(context.Background(), true), false),
+			false,
+		},
+		{
+			"set false set true",
+			SetSkipLogs(SetSkipLogs(context.Background(), false), true),
+			true,
+		},
+		{
+			"set true and set other value",
+			context.WithValue(SetSkipLogs(context.Background(), true), thisisatest(true), false),
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSkipLogsFromContext(tt.args); got != tt.want {
+				t.Errorf("IsSkipLogsFromContext() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In order to reduce the CPU load of drand nodes, let us not process partials for rounds we've already aggregated and stored.

This also reworks a few logs.

And it prevents a common issue with `generate-keypair` that we identified during the last ceremony, which is to add flags after the node address, which aren't recognized as flags but as arguments.