### PR TITLE
Feature/docker guide linux fixes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -8,22 +8,35 @@
 ## Creation of a keypair
 
 Pull the latest drand image:
-`docker pull drandorg/go-drand:v1.5.2-testnet`
+```shell
+docker pull drandorg/go-drand:v1.5.3
+```
 
 Create a volume where you're going to store your keypairs and other config data
-`docker volume create drand`
+```shell
+docker volume create drand
+```
 
 Next we must create a keypair and store it in the docker volume we've just created.
 
-`docker run --volume drand:/data/drand drandorg/go-drand:v1.5.2-testnet generate-keypair  --folder /data/drand/.drand --tls-disable --id default 0.0.0.0:8080`
+```shell
+docker run --rm --volume drand:/data/drand drandorg/go-drand:v1.5.3 generate-keypair  --folder /data/drand/.drand --tls-disable --id default 0.0.0.0:8080
+```
 
-This will create a keypair for the default public listening address (0.0.0.0:8080) and store it in the `/data/drand/.drand` directory which is mapped to the `drand` volume we created in the previous step. You should replace 0.0.0.0:8080 with your public IP address, e.g. pl1-rpc.drand.sh:443, as this key is how other nodes in the network will verify that they're talking to your node. 
-Note: access to this path should be firewalled to only allow connections from nodes in the relevant allowlist ([mainnet allowlist](https://github.com/drand/loe-mainnet-allowlist/) and [testnet allowlist](https://github.com/drand/loe-testnet-allowlist/))
+This will create a keypair for the default public listening address (0.0.0.0:8080) and store it in the `/data/drand/.drand` directory
+which is mapped to the `drand` volume we created in the previous step.
+
+You should replace `0.0.0.0:8080` with your public IP address, e.g. `pl1-rpc.drand.sh:443`, as this key is how other nodes in the network
+will verify that they're talking to your node. 
+
+_Note_: access to this path should be firewalled to only allow connections from nodes in the relevant allowlist ([mainnet allowlist](https://github.com/drand/loe-mainnet-allowlist/) and [testnet allowlist](https://github.com/drand/loe-testnet-allowlist/))
 
 
 ## Starting drand
 Finally we can start the docker container by running:
-`docker run -d -p"8080:8080" -p"8888:8888" --name drand  --volume drand:/data/drand drandorg/go-drand:v1.5.2-testnet start --tls-disable --private-listen 0.0.0.0:8080`
+```shell
+docker run --rm -d -p"8080:8080" -p"8888:8888" --name drand  --volume drand:/data/drand drandorg/go-drand:v1.5.3 start --tls-disable --private-listen 0.0.0.0:8080
+```
 
 If we run `docker logs -f drand`, we should be able to see that the node has started and is waiting for distributed key generation:
 ```
@@ -33,16 +46,25 @@ drand 1.5.2-testnet (date 06/02/2023@10:47:55, commit 7ea4a3c536bebf9436bfbc5d7b
 2023-02-08T14:08:42.679Z	INFO	0.0.0.0:8080	core/drand_daemon.go:316	beacon id [default]: will run as fresh install -> expect to run DKG.
 ```
 
-If we try and run `curl -v localhost:8080/chains` we won't get anything back! The private listening port only speaks gRPC and is used when nodes talk to one another. To expose the randomness itself, we must provide a public listening port.
+If we try and run `curl -v localhost:8080/chains` we won't get anything back! The private listening port only speaks gRPC and is used when
+nodes talk to one another. To expose the randomness itself, we must provide a public listening port.
+
 Kill the container and rerun it with a command such as:
-`docker run -d -p"8080:8080" -p"8888:8888" -p"9080:9080" --name drand  --volume drand:/data/drand drandorg/go-drand:v1.5.2-testnet start --tls-disable --private-listen 0.0.0.0:8080 --public-listen 0.0.0.0:9080`
+```shell
+docker run --rm -d -p"8080:8080" -p"8888:8888" -p"9080:9080" --name drand  --volume drand:/data/drand drandorg/go-drand:v1.5.3 start --tls-disable --private-listen 0.0.0.0:8080 --public-listen 0.0.0.0:9080
+```
 
 Now if we run `curl -v localhost:9080/chains` we should get a 200 response back and an empty list of chains.
 
 ## Running with docker compose
-This dir contains a sample [docker-compose.yml](./docker-compose.yml) that can be used to spin up a single node. You will still have to go through the steps of creating a volume and keypair above to use it.
-Additionally, you can easily set up a test network of three nodes by running [the start-network.sh script](./start-network.sh). It can be torn down and cleaned up by using the [./cleanup.sh shell script](./cleanup.sh). This manifest will spin up a network of three nodes and run an initial distributed key generation process, and they will start generating randomness beacons.
+This dir contains a sample [docker-compose.yml](./docker-compose.yml) that can be used to spin up a single node. You will still have to go through
+the steps of creating a volume and keypair above to use it.
+
+Additionally, you can easily set up a test network of three nodes by running [the start-network.sh script](./start-network.sh).
+It can be torn down and cleaned up by using the [./cleanup.sh shell script](./cleanup.sh).
+This manifest will spin up a network of three nodes and run an initial distributed key generation process, and they will start generating randomness beacons.
 
 ## Running with nginx
 Many LoE partners like to run a reverse proxy in front of their node to easily manage TLS termination, domain names and firewalling. 
-In [docker-compose-nginx.yml](./docker-compose-nginx.yml) you can find a manifest for running a single drand docker container and an nginx container to route traffic to it. Similar to the keypair, we will have to create a volume containing the nginx config (and any TLS config you wish to add).
+In [docker-compose-nginx.yml](./docker-compose-nginx.yml) you can find a manifest for running a single drand docker container and an 
+ginx container to route traffic to it. Similar to the keypair, we will have to create a volume containing the nginx config (and any TLS config you wish to add).

--- a/docker/cleanup.sh
+++ b/docker/cleanup.sh
@@ -1,6 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-docker compose -f ./docker-compose-network.yml down
-docker stop $(docker ps --all --quiet)
-docker rm $(docker ps --all --quiet)
-docker volume rm $(docker volume ls --quiet)
+docker compose -f ./docker-compose-nginx.yml down --volumes --remove-orphans
+docker compose -f ./docker-compose-network.yml down --volumes --remove-orphans
+
+volumes=$(docker volume ls  --format '{{.Name}}' | grep -i drand_docker_demo | tr '\n' ' ')
+
+if [[ -n "$volumes" ]]; then
+  docker volume rm $volumes
+fi
+
+

--- a/docker/cleanup.sh
+++ b/docker/cleanup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-docker-compose -f ./docker-compose-network.yml down
+docker compose -f ./docker-compose-network.yml down
 docker stop $(docker ps --all --quiet)
 docker rm $(docker ps --all --quiet)
 docker volume rm $(docker volume ls --quiet)

--- a/docker/docker-compose-network.yml
+++ b/docker/docker-compose-network.yml
@@ -1,36 +1,36 @@
 version: "3"
 
 services:
-  drand_1:
-    container_name: drand1
-    image: drandorg/go-drand:v1.5.3-testnet
-    command: start --verbose --tls-disable --private-listen drand1:8010 --control 8888 --public-listen 0.0.0.0:9080
+  drand_docker_demo_1:
+    container_name: drand_docker_demo1
+    image: drandorg/go-drand:v1.5.3
+    command: start --verbose --tls-disable --private-listen drand_docker_demo1:8010 --control 8888 --public-listen 0.0.0.0:9080
     volumes:
-      - drand1:/data/drand
+      - drand_docker_demo1:/data/drand
     restart: always
     ports:
       - 8010:8080
       - 8818:8888
       - 9010:9080
 
-  drand_2:
-    container_name: drand2
-    image: drandorg/go-drand:v1.5.3-testnet
-    command: start --verbose --tls-disable --private-listen drand2:8020 --control 8888 --public-listen 0.0.0.0:9080
+  drand_docker_demo_2:
+    container_name: drand_docker_demo2
+    image: drandorg/go-drand:v1.5.3
+    command: start --verbose --tls-disable --private-listen drand_docker_demo2:8020 --control 8888 --public-listen 0.0.0.0:9080
     volumes:
-      - drand2:/data/drand
+      - drand_docker_demo2:/data/drand
     restart: always
     ports:
       - 8020:8080
       - 8828:8888
       - 9020:9080
 
-  drand_3:
-    container_name: drand3
-    image: drandorg/go-drand:v1.5.3-testnet
-    command: start --verbose --tls-disable --private-listen drand3:8030 --control 8888 --public-listen 0.0.0.0:9080
+  drand_docker_demo_3:
+    container_name: drand_docker_demo3
+    image: drandorg/go-drand:v1.5.3
+    command: start --verbose --tls-disable --private-listen drand_docker_demo3:8030 --control 8888 --public-listen 0.0.0.0:9080
     volumes:
-      - drand3:/data/drand
+      - drand_docker_demo3:/data/drand
     restart: always
     ports:
       - 8030:8080
@@ -38,13 +38,13 @@ services:
       - 9030:9080
 
 volumes:
-  drand1:
+  drand_docker_demo1:
     external: true
-    name: drand1
-  drand2:
+    name: drand_docker_demo1
+  drand_docker_demo2:
     external: true
-    name: drand2
-  drand3:
+    name: drand_docker_demo2
+  drand_docker_demo3:
     external: true
-    name: drand3
+    name: drand_docker_demo3
 

--- a/docker/docker-compose-nginx.yml
+++ b/docker/docker-compose-nginx.yml
@@ -18,9 +18,9 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
     ports:
-      - 80:80
-      - 81:81
-      - 443:443
+      - 22180:80
+      - 22181:81
+      - 22443:443
     links:
       - drand-nginx
 

--- a/docker/docker-compose-nginx.yml
+++ b/docker/docker-compose-nginx.yml
@@ -1,19 +1,19 @@
 version: "3"
 
 services:
-  drand-nginx:
-    container_name: drand-nginx
-    image: drandorg/go-drand:v1.5.3-testnet
+  drand_docker_demo_drand:
+    container_name: drand_docker_demo_drand
+    image: drandorg/go-drand:v1.5.3
     command: start --verbose --tls-disable --private-listen 0.0.0.0:8080 --control 8888 --public-listen 0.0.0.0:9080
     volumes:
-      - drand-nginx:/data/drand
+      - drand_docker_demo_drand:/data/drand
     restart: always
     ports:
       - 8080:8080
       - 8888:8888
       - 9080:9080
-  nginx:
-    container_name: nginx
+  drand_docker_demo-nginx:
+    container_name: drand_docker_demo-nginx
     image: nginx:1.23.3-alpine
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
@@ -22,10 +22,9 @@ services:
       - 22181:81
       - 22443:443
     links:
-      - drand-nginx
+      - drand_docker_demo_drand
 
 volumes:
-  drand-nginx:
+  drand_docker_demo_drand:
     external: true
-    name: drand-nginx
-
+    name: drand_docker_demo_drand

--- a/docker/docker-compose-nginx.yml
+++ b/docker/docker-compose-nginx.yml
@@ -14,7 +14,7 @@ services:
       - 9080:9080
   nginx:
     container_name: nginx
-    image: nginx:1.23.0-alpine
+    image: nginx:1.23.3-alpine
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: "3"
 
 services:
-  drand:
-    container_name: drand
-    image: drandorg/go-drand:v1.5.2-testnet
+  drand_docker_demo:
+    container_name: drand_docker_demo
+    image: drandorg/go-drand:v1.5.3
     command: start --verbose --tls-disable --private-listen 0.0.0.0:8080 --control 8888 --public-listen 0.0.0.0:9080
     volumes:
-      - drand:/data/drand
+      - drand_docker_demo:/data/drand
     restart: always
     ports:
       - 8080:8080
@@ -15,7 +15,7 @@ services:
     environment:
       PORT: 8080
 volumes:
-  drand:
+  drand_docker_demo:
     external: true
-    name: drand
+    name: drand_docker_demo
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,27 +1,26 @@
 events {
-  worker_connections  1024;
+    worker_connections  1024;
 }
 
 http {
-    server { 
-        listen       81 http2;
-        server_name rpc.localhost;
-        access_log   /var/log/access.log;
-    
+    server {
+        listen      81 http2;
+        server_name "rpc.localhost";
+        access_log  /var/log/access.log;
+
         location / {
-          grpc_pass grpc://drand-nginx:8080;
-          grpc_set_header X-Real-IP $remote_addr;
-    	  }
+            grpc_pass grpc://drand-nginx:8080;
+            grpc_set_header X-Real-IP $remote_addr;
+    	}
     }
 
     server {
-        listen 80;
-        server_name api.localhost
-        access_log   /var/log/access.log;
+        listen      80;
+        server_name "api.localhost";
+        access_log  /var/log/access.log;
 
         location / {
-    	      proxy_pass http://drand-nginx:9080;
+            proxy_pass http://drand-nginx:9080;
         }
-
     }
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -9,7 +9,7 @@ http {
         access_log  /var/log/access.log;
 
         location / {
-            grpc_pass grpc://drand-nginx:8080;
+            grpc_pass grpc://drand_docker_demo_drand:8080;
             grpc_set_header X-Real-IP $remote_addr;
     	}
     }
@@ -20,7 +20,7 @@ http {
         access_log  /var/log/access.log;
 
         location / {
-            proxy_pass http://drand-nginx:9080;
+            proxy_pass http://drand_docker_demo_drand:9080;
         }
     }
 }

--- a/docker/start-network-with-nginx.sh
+++ b/docker/start-network-with-nginx.sh
@@ -12,34 +12,34 @@ docker compose --file docker-compose-nginx.yml down
 ./start-network.sh
 
 # then let's create a volume for the nginx drand node and put a keypair on it pointing to the grpc port
-docker volume create drand-nginx
-docker run --volume drand-nginx:/data/drand drandorg/go-drand:v1.5.3 generate-keypair  --folder /data/drand/.drand --tls-disable --id default nginx:81
+docker volume create drand_docker_demo_drand
+docker run --rm --volume drand_docker_demo_drand:/data/drand drandorg/go-drand:v1.5.3 generate-keypair  --folder /data/drand/.drand --tls-disable --id default drand_docker_demo-nginx:81
 docker compose --file docker-compose-nginx.yml up --detach
 
 # start the resharing as leader
 echo [+] starting the resharing as leader
-docker exec --detach -e DRAND_SHARE_SECRET=deadbeefdeadbeefdeadbeefdeadbeef drand1 sh -c "drand share --leader   --control 8888 --tls-disable --nodes 4 --threshold 3 --id default --transition"
+docker exec --detach -e DRAND_SHARE_SECRET=deadbeefdeadbeefdeadbeefdeadbeef drand_docker_demo1 sh -c "drand share --leader --control 8888 --tls-disable --nodes 4 --threshold 3 --id default --transition"
 
 # sleep a little so the leader is set up
 sleep 1
 
 echo [+] existing nodes are joining the resharing
 # run the resharing for the two existing nodes
-docker exec --detach -e DRAND_SHARE_SECRET=deadbeefdeadbeefdeadbeefdeadbeef drand2 sh -c "drand share --connect drand1:8010 --tls-disable --id default --transition"
-docker exec --detach -e DRAND_SHARE_SECRET=deadbeefdeadbeefdeadbeefdeadbeef drand3 sh -c "drand share --connect drand1:8010 --tls-disable --id default --transition"
+docker exec --detach -e DRAND_SHARE_SECRET=deadbeefdeadbeefdeadbeefdeadbeef drand_docker_demo2 sh -c "drand share --connect drand_docker_demo1:8010 --tls-disable --id default --transition"
+docker exec --detach -e DRAND_SHARE_SECRET=deadbeefdeadbeefdeadbeefdeadbeef drand_docker_demo3 sh -c "drand share --connect drand_docker_demo1:8010 --tls-disable --id default --transition"
 
 
 # now we join the resharing from the nginx container
 echo [+] the nginx node is joining the resharing
 
 ## first we steal the existing group file from another node
-group_contents=$(docker exec drand1 sh -c cat /data/drand/.drand/multibeacon/default/groups/drand_group.toml)
-docker cp drand1:/data/drand/.drand/multibeacon/default/groups/drand_group.toml ./group.toml
-docker cp ./group.toml drand-nginx:/data/drand/group.toml
+group_contents=$(docker exec drand_docker_demo1 sh -c 'cat /data/drand/.drand/multibeacon/default/groups/drand_group.toml')
+docker cp drand_docker_demo1:/data/drand/.drand/multibeacon/default/groups/drand_group.toml ./group.toml
+docker cp ./group.toml drand_docker_demo_drand:/data/drand/group.toml
 rm -rf ./group.toml
 
 ## then we run the resharing command
-docker exec -e DRAND_SHARE_SECRET=deadbeefdeadbeefdeadbeefdeadbeef --detach drand-nginx sh -c "drand share --connect drand1:8010 --tls-disable  --from /data/drand/group.toml"
+docker exec -e DRAND_SHARE_SECRET=deadbeefdeadbeefdeadbeefdeadbeef --detach drand_docker_demo_drand sh -c "drand share --connect drand_docker_demo1:8010 --tls-disable --from /data/drand/group.toml"
 
 # let's wait until the node reports healthy (i.e. it has caught up with the network)
 echo [+] Waiting for the resharing to finish - could take up to a minute!
@@ -49,7 +49,7 @@ while :
 do
   ### if it isn't working after a bunch of attempts, it probably failed
   if [ "$attempts" -eq 0 ]; then
-    echo [-] the nginx node didn\'t finish the resharing successfully - check the container logs with '`docker logs -f drand-nginx`'
+    echo [-] the nginx node didn\'t finish the resharing successfully - check the container logs with `docker logs -f drand_docker_demo_drand` and `docker logs -f drand_docker_demo-nginx`
     exit 1
   fi
 

--- a/docker/start-network-with-nginx.sh
+++ b/docker/start-network-with-nginx.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 ###
 #   This script sets up a network with 3 nodes, runs an initial distributed key generation, then spins up another node behind nginx
@@ -6,15 +6,15 @@
 ###
 
 # first lets kill any existing runs
-docker-compose --file docker-compose-nginx.yml down
+docker compose --file docker-compose-nginx.yml down
 ./cleanup.sh
 
 ./start-network.sh
 
 # then let's create a volume for the nginx drand node and put a keypair on it pointing to the grpc port
 docker volume create drand-nginx
-docker run --volume drand-nginx:/data/drand drandorg/go-drand:v1.5.3-testnet generate-keypair  --folder /data/drand/.drand --tls-disable --id default nginx:81
-docker-compose --file docker-compose-nginx.yml up --detach
+docker run --volume drand-nginx:/data/drand drandorg/go-drand:v1.5.3 generate-keypair  --folder /data/drand/.drand --tls-disable --id default nginx:81
+docker compose --file docker-compose-nginx.yml up --detach
 
 # start the resharing as leader
 echo [+] starting the resharing as leader

--- a/docker/start-network-with-nginx.sh
+++ b/docker/start-network-with-nginx.sh
@@ -54,7 +54,7 @@ do
   fi
 
   ### once the node reports healthy, we know it has caught up and is part of the network
-  response=$(curl --silent --head localhost:80/health)
+  response=$(curl --silent --head localhost:22180/health)
   if [[ $? -eq 0 && $response =~ "200 OK" ]]; then
     break
   fi

--- a/docker/start-network.sh
+++ b/docker/start-network.sh
@@ -29,7 +29,8 @@ echo [+] Creating docker volumes for $num_of_nodes nodes
 
 for i in $(seq 1 $num_of_nodes);
 do
-  docker volume create drand$i 1>/dev/null
+  echo "docker volume create drand$i"
+  docker volume create drand$i
 done
 
 ### next we're going to generate a keypair on each of those volumes


### PR DESCRIPTION
This PR allows the Docker features to run on Linux and MacOS out of the box.
It also gives a different, virtual, "namespace" to all created Docker resources to allow them to be cleaned-up correctly without nuking the user's environment.