### PR TITLE
Reject invalid self-index in received partials

### DIFF
--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -136,7 +136,6 @@ func (h *Handler) ProcessPartialBeacon(c context.Context, p *proto.PartialBeacon
 	}
 
 	node := h.crypto.GetGroup().Node(uint32(idx))
-
 	if node == nil {
 		return nil, fmt.Errorf("attempted to process beacon from node of index %d, but it was not in the group file", uint32(idx))
 	}

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -142,6 +142,11 @@ func (h *Handler) ProcessPartialBeacon(c context.Context, p *proto.PartialBeacon
 	}
 
 	nodeName := node.Address()
+	if nodeName == h.addr {
+		h.l.Warnw("received a partial with our own index", "partial", pRound, "from", addr)
+		return nil, fmt.Errorf("invalid self index %d in partial with msg %v partial_round %v", idx, msg, pRound)
+	}
+
 	// verify if request is valid
 	if err := h.crypto.ThresholdScheme.VerifyPartial(h.crypto.GetPub(), msg, p.GetPartialSig()); err != nil {
 		h.l.Errorw("",


### PR DESCRIPTION
If a received partial is specifying our own node index, either our node or the other node is using a wrong group file.

This can happen typically when a node leaves the network during a resharing but keep running after the resharing with its old groupfile.