### PR TITLE
Support hash list in gossip relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ test/docker/tmp
 test/docker/data*
 **/nohup.out
 .tool-versions
+datastore
+identity.key

--- a/cmd/client/lib/cli.go
+++ b/cmd/client/lib/cli.go
@@ -66,6 +66,12 @@ var (
 		Usage: "Path to a drand group configuration (TOML encoded) or chain info (JSON encoded)," +
 			" can be used instead of `-hash` flag to verify the chain.",
 	}
+	// GroupConfListFlag is like GroupConfFlag but for a list values.
+	GroupConfListFlag = &cli.StringSliceFlag{
+		Name: "group-conf-list",
+		Usage: "Paths to at least one drand group configuration (TOML encoded) or chain info (JSON encoded)," +
+			fmt.Sprintf(" can be used instead of `-%s` flag to verify the chain.", HashListFlag.Name),
+	}
 	// InsecureFlag is the CLI flag to allow autodetection of the chain
 	// information.
 	InsecureFlag = &cli.BoolFlag{
@@ -168,8 +174,7 @@ func buildGrpcClient(c *cli.Context, info *chain.Info) ([]client.Client, *chain.
 		return nil, info, nil
 	}
 
-	hash := make([]byte, 0)
-
+	var hash []byte
 	if c.IsSet(HashFlag.Name) {
 		var err error
 

--- a/cmd/relay-gossip/README.md
+++ b/cmd/relay-gossip/README.md
@@ -70,7 +70,9 @@ make relay-gossip
 
 ## Usage
 
-In general, you _should_ specify either a `-hash`, `-hash-list`, or `-group-conf` flag in order for your client to validate the randomness it receives is from the correct chain.
+In general, you _should_ specify either a `-hash-list` or `-group-conf-list` flag in order for your client to validate the randomness it receives is from the correct chain.
+
+_Note_: You can provide multiple values to both `-hash-list` and`-group-conf-list` flags to support multiple beacons.
 
 ### Relay gRPC
 
@@ -100,7 +102,7 @@ The gossip relay can also relay directly from an HTTP API. You can specify multi
 ```sh
 drand-relay-gossip run -url=https://api.drand.sh \
                        -url=https://api2.drand.sh \
-                       -hash=dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493
+                       -hash-list=dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493
 ```
 
 ### Relay Gossipsub
@@ -110,7 +112,7 @@ The gossip relay can also relay directly from _other_ gossip relays. You can spe
 ```sh
 drand-relay-gossip run -relay=/ip4/127.0.0.1/tcp/44544/p2p/QmPeerID0 \
                        -relay=/ip4/127.0.0.1/tcp/44545/p2p/QmPeerID1 \
-                       -group-conf=/home/user/.drand/groups/drand_group.toml
+                       -group-conf-list=/home/user/.drand/groups/drand_group.toml
 ```
 
 Alternatively, you can provide URL(s) of HTTP API(s) that can be contacted to retrieve chain information. In this case we must provide the chain `-hash` to verify the information we retrieve is for the chain we expect (or provide the `-insecure` flag):
@@ -119,7 +121,7 @@ Alternatively, you can provide URL(s) of HTTP API(s) that can be contacted to re
 drand-relay-gossip run -relay=/ip4/127.0.0.1/tcp/44544/p2p/QmPeerID0 \
                        -relay=/ip4/127.0.0.1/tcp/44545/p2p/QmPeerID1 \
                        -url=http://127.0.0.1:3002 \
-                       -hash=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
+                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
 ```
 
 If you want to verify multiple networks, you can provide the `-hash-list` flag, e.g.:
@@ -150,7 +152,7 @@ drand-relay-gossip run -grpc-connect=127.0.0.1:3000 \
 ```sh
 drand-relay-gossip run -relay=/ip4/127.0.0.1/tcp/44544/p2p/QmPeerID0 \
                        -relay=/ip4/127.0.0.1/tcp/44545/p2p/QmPeerID1 \
-                       -hash=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83 \
+                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83 \
                        -url=http://127.0.0.1:3102
 ```
 

--- a/cmd/relay-gossip/README.md
+++ b/cmd/relay-gossip/README.md
@@ -70,20 +70,22 @@ make relay-gossip
 
 ## Usage
 
-In general, you _should_ specify either a `-hash` or `-group-conf` flag in order for your client to validate the randomness it receives is from the correct chain.
+You _must_ specify a `-hash-list` flag for your client to validate the randomness it receives is from the correct chain.
 
 ### Relay gRPC
 
 ```sh
 drand-relay-gossip run -grpc-connect=127.0.0.1:3000 \
-                       -cert=/path/to/grpc-drand-cert
+                       -cert=/path/to/grpc-drand-cert \
+                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
 ```
 
 If you do not have gRPC transport credentials, you can use the `-insecure` flag:
 
 ```sh
 drand-relay-gossip run -grpc-connect=127.0.0.1:3000 \
-                       -insecure
+                       -insecure\
+                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
 ```
 
 ### Relay HTTP
@@ -93,7 +95,7 @@ The gossip relay can also relay directly from an HTTP API. You can specify multi
 ```sh
 drand-relay-gossip run -url=http://127.0.0.1:3002 \
                        -url=http://127.0.0.1:3102 \
-                       -hash=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
+                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
 ```
 
 ### Relay Gossipsub
@@ -103,6 +105,7 @@ The gossip relay can also relay directly from _other_ gossip relays. You can spe
 ```sh
 drand-relay-gossip run -relay=/ip4/127.0.0.1/tcp/44544/p2p/QmPeerID0 \
                        -relay=/ip4/127.0.0.1/tcp/44545/p2p/QmPeerID1 \
+                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83 \
                        -group-conf=/home/user/.drand/groups/drand_group.toml
 ```
 
@@ -112,7 +115,7 @@ Alternatively, you can provide URL(s) of HTTP API(s) that can be contacted to re
 drand-relay-gossip run -relay=/ip4/127.0.0.1/tcp/44544/p2p/QmPeerID0 \
                        -relay=/ip4/127.0.0.1/tcp/44545/p2p/QmPeerID1 \
                        -url=http://127.0.0.1:3002 \
-                       -hash=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
+                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
 ```
 
 ### Other options
@@ -128,7 +131,8 @@ The `-url` flag provides the URL(s) of alternative HTTP API endpoints that may b
 ```sh
 drand-relay-gossip run -grpc-connect=127.0.0.1:3000 \
                        -insecure \
-                       -url=http://127.0.0.1:3102
+                       -url=http://127.0.0.1:3102 \
+                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
 ```
 
 ```sh

--- a/cmd/relay-gossip/README.md
+++ b/cmd/relay-gossip/README.md
@@ -70,22 +70,27 @@ make relay-gossip
 
 ## Usage
 
-You _must_ specify a `-hash-list` flag for your client to validate the randomness it receives is from the correct chain.
+In general, you _should_ specify either a `-hash`, `-hash-list`, or `-group-conf` flag in order for your client to validate the randomness it receives is from the correct chain.
 
 ### Relay gRPC
 
 ```sh
 drand-relay-gossip run -grpc-connect=127.0.0.1:3000 \
-                       -cert=/path/to/grpc-drand-cert \
-                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
+                       -cert=/path/to/grpc-drand-cert
 ```
 
 If you do not have gRPC transport credentials, you can use the `-insecure` flag:
 
 ```sh
 drand-relay-gossip run -grpc-connect=127.0.0.1:3000 \
-                       -insecure\
-                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
+                       -insecure
+```
+
+Or, with a hashlist:
+```shell
+ drand-relay-gossip run -grpc-connect=127.0.0.1:3000 \
+                       -insecure \
+                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83,dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493
 ```
 
 ### Relay HTTP
@@ -95,7 +100,7 @@ The gossip relay can also relay directly from an HTTP API. You can specify multi
 ```sh
 drand-relay-gossip run -url=http://127.0.0.1:3002 \
                        -url=http://127.0.0.1:3102 \
-                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
+                       -hash=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
 ```
 
 ### Relay Gossipsub
@@ -105,7 +110,6 @@ The gossip relay can also relay directly from _other_ gossip relays. You can spe
 ```sh
 drand-relay-gossip run -relay=/ip4/127.0.0.1/tcp/44544/p2p/QmPeerID0 \
                        -relay=/ip4/127.0.0.1/tcp/44545/p2p/QmPeerID1 \
-                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83 \
                        -group-conf=/home/user/.drand/groups/drand_group.toml
 ```
 
@@ -115,7 +119,16 @@ Alternatively, you can provide URL(s) of HTTP API(s) that can be contacted to re
 drand-relay-gossip run -relay=/ip4/127.0.0.1/tcp/44544/p2p/QmPeerID0 \
                        -relay=/ip4/127.0.0.1/tcp/44545/p2p/QmPeerID1 \
                        -url=http://127.0.0.1:3002 \
-                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
+                       -hash=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
+```
+
+If you want to verify multiple networks, you can provide the `-hash-list` flag, e.g.:
+
+```shell
+drand-relay-gossip run -relay=/ip4/127.0.0.1/tcp/44544/p2p/QmPeerID0 \
+                       -relay=/ip4/127.0.0.1/tcp/44545/p2p/QmPeerID1 \
+                       -url=http://127.0.0.1:3002 \
+                       -hash=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83,dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493
 ```
 
 ### Other options
@@ -131,8 +144,7 @@ The `-url` flag provides the URL(s) of alternative HTTP API endpoints that may b
 ```sh
 drand-relay-gossip run -grpc-connect=127.0.0.1:3000 \
                        -insecure \
-                       -url=http://127.0.0.1:3102 \
-                       -hash-list=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
+                       -url=http://127.0.0.1:3102
 ```
 
 ```sh

--- a/cmd/relay-gossip/README.md
+++ b/cmd/relay-gossip/README.md
@@ -98,9 +98,9 @@ Or, with a hashlist:
 The gossip relay can also relay directly from an HTTP API. You can specify multiple endpoints to enable failover.
 
 ```sh
-drand-relay-gossip run -url=http://127.0.0.1:3002 \
-                       -url=http://127.0.0.1:3102 \
-                       -hash=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83
+drand-relay-gossip run -url=https://api.drand.sh \
+                       -url=https://api2.drand.sh \
+                       -hash=dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493
 ```
 
 ### Relay Gossipsub
@@ -128,7 +128,7 @@ If you want to verify multiple networks, you can provide the `-hash-list` flag, 
 drand-relay-gossip run -relay=/ip4/127.0.0.1/tcp/44544/p2p/QmPeerID0 \
                        -relay=/ip4/127.0.0.1/tcp/44545/p2p/QmPeerID1 \
                        -url=http://127.0.0.1:3002 \
-                       -hash=6093f9e4320c285ac4aab50ba821cd5678ec7c5015d3d9d11ef89e2a99741e83,dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493
+                       -hash-list=dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493,8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce
 ```
 
 ### Other options

--- a/cmd/relay-gossip/main.go
+++ b/cmd/relay-gossip/main.go
@@ -212,8 +212,8 @@ func boostrapGossipRelayNode(cctx *cli.Context, chainHash string) error {
 
 func computeHashesMap(hashMaps, groupConfs []string) (map[string]string, error) {
 	hashesMap := make(map[string]string)
-	if hashMaps == nil ||
-		len(hashMaps) == 0 {
+	if len(hashMaps) == 0 {
+		//nolint:nilnil // We want to return an nil instead of an empty map.
 		return nil, nil
 	}
 

--- a/cmd/relay-gossip/main.go
+++ b/cmd/relay-gossip/main.go
@@ -163,7 +163,7 @@ var runCmd = &cli.Command{
 			}
 		}
 
-		// Wait indefinitely for our client(s) to run
+		// Wait until we are signaled to shutdown.
 		<-cctx.Context.Done()
 
 		return cctx.Context.Err()
@@ -217,14 +217,15 @@ func computeHashesMap(hashMaps, groupConfs []string) (map[string]string, error) 
 		return nil, nil
 	}
 
-	if groupConfs != nil {
+	switch {
+	case groupConfs != nil:
 		// Here we overload the -group-conf flag and we convert it from String to StringSlice.
 		// This is required to provide the correct -group-conf value for the client library.
 		if len(groupConfs) > 0 &&
 			len(groupConfs) != len(hashMaps) {
 			return nil, fmt.Errorf("list of provided hashes is different from list of group-conf files")
 		}
-	} else {
+	default:
 		for i := 0; i < len(hashMaps); i++ {
 			groupConfs = append(groupConfs, "")
 		}

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,6 @@ require (
 	golang.org/x/crypto v0.5.0
 	golang.org/x/net v0.7.0
 	golang.org/x/sys v0.5.0
-	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 	google.golang.org/grpc v1.52.0
 	google.golang.org/protobuf v1.28.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1101,8 +1101,6 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
-golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=

--- a/lp2p/client/client.go
+++ b/lp2p/client/client.go
@@ -3,10 +3,10 @@ package client
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"sync"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"golang.org/x/xerrors"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/drand/drand/chain"
@@ -49,7 +49,7 @@ func WithPubsub(ps *pubsub.PubSub) client.Option {
 // NewWithPubsub creates a gossip randomness client.
 func NewWithPubsub(ps *pubsub.PubSub, info *chain.Info, cache client.Cache) (*Client, error) {
 	if info == nil {
-		return nil, xerrors.Errorf("No chain supplied for joining")
+		return nil, fmt.Errorf("no chain supplied for joining")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -63,17 +63,17 @@ func NewWithPubsub(ps *pubsub.PubSub, info *chain.Info, cache client.Cache) (*Cl
 	topic := lp2p.PubSubTopic(chainHash)
 	if err := ps.RegisterTopicValidator(topic, randomnessValidator(info, cache, c)); err != nil {
 		cancel()
-		return nil, xerrors.Errorf("creating topic: %w", err)
+		return nil, fmt.Errorf("creating topic: %w", err)
 	}
 	t, err := ps.Join(topic)
 	if err != nil {
 		cancel()
-		return nil, xerrors.Errorf("joining pubsub: %w", err)
+		return nil, fmt.Errorf("joining pubsub: %w", err)
 	}
 	s, err := t.Subscribe()
 	if err != nil {
 		cancel()
-		return nil, xerrors.Errorf("subscribe: %w", err)
+		return nil, fmt.Errorf("subscribe: %w", err)
 	}
 
 	c.subs.M = make(map[*int]chan drand.PublicRandResponse)

--- a/lp2p/relaynode.go
+++ b/lp2p/relaynode.go
@@ -21,7 +21,6 @@ import (
 type GossipRelayConfig struct {
 	// ChainHash is a hash that uniquely identifies the drand chain.
 	ChainHash    string
-	BeaconID     string
 	PeerWith     []string
 	Addr         string
 	DataDir      string
@@ -34,7 +33,6 @@ type GossipRelayConfig struct {
 // GossipRelayNode is a gossip relay runtime.
 type GossipRelayNode struct {
 	l         log.Logger
-	beaconID  string
 	bootstrap []ma.Multiaddr
 	ds        *bds.Datastore
 	priv      crypto.PrivKey
@@ -85,18 +83,8 @@ func NewGossipRelayNode(l log.Logger, cfg *GossipRelayConfig) (*GossipRelayNode,
 		return nil, fmt.Errorf("joining topic: %w", err)
 	}
 
-	beaconID := cfg.BeaconID
-	if beaconID == "" {
-		chainInfo, err := cfg.Client.Info(context.Background())
-		if err != nil {
-			return nil, fmt.Errorf("cannot retrieve chain info: %w", err)
-		}
-		beaconID = chainInfo.ID
-	}
-
 	g := &GossipRelayNode{
 		l:         l,
-		beaconID:  beaconID,
 		bootstrap: bootstrap,
 		ds:        ds,
 		priv:      priv,
@@ -154,13 +142,13 @@ func (g *GossipRelayNode) background(w client.Watcher) {
 			select {
 			case res, ok := <-results:
 				if !ok {
-					g.l.Warnw("", "relay_node", "watch channel closed", "beaconID", g.beaconID)
+					g.l.Warnw("", "relay_node", "watch channel closed")
 					break LOOP
 				}
 
 				rd, ok := res.(*client.RandomData)
 				if !ok {
-					g.l.Errorw("", "relay_node", "unexpected client result type", "beaconID", g.beaconID)
+					g.l.Errorw("", "relay_node", "unexpected client result type")
 					continue
 				}
 
@@ -171,17 +159,17 @@ func (g *GossipRelayNode) background(w client.Watcher) {
 					Randomness:        res.Randomness(),
 				})
 				if err != nil {
-					g.l.Errorw("", "relay_node", "err marshaling", "beaconID", g.beaconID, "err", err)
+					g.l.Errorw("", "relay_node", "err marshaling", "err", err)
 					continue
 				}
 
 				err = g.t.Publish(ctx, randB)
 				if err != nil {
-					g.l.Errorw("", "relay_node", "err publishing on pubsub", "beaconID", g.beaconID, "err", err)
+					g.l.Errorw("", "relay_node", "err publishing on pubsub", "err", err)
 					continue
 				}
 
-				g.l.Infow("", "relay_node", "Published randomness on pubsub", "beaconID", g.beaconID, "round", res.Round())
+				g.l.Infow("", "relay_node", "Published randomness on pubsub", "round", res.Round())
 			case <-g.done:
 				return
 			}


### PR DESCRIPTION
This PR adds support for `--hash-list` as a way to specify multiple hashes.
It also allows for multiple `-group-conf` values to be specified via `,` delimiter between values.
Finally, it keeps all the original functionality/library signatures, so it's a drop-in replacement for the current implementations using this library.

Fixes #1196.