### PR TITLE
threshold monitoring for beacon processes

### DIFF
--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	dmetrics "github.com/drand/drand/metrics"
 	"sync"
 	"time"
 
@@ -45,8 +46,9 @@ type Handler struct {
 	// keeps the cryptographic info (group share etc)
 	crypto *vault.Vault
 	// main logic that treats incoming packet / new beacons created
-	chain  *chainStore
-	ticker *ticker
+	chain            *chainStore
+	ticker           *ticker
+	thresholdMonitor *dmetrics.ThresholdMonitor
 
 	ctx       context.Context
 	ctxCancel context.CancelFunc
@@ -87,16 +89,17 @@ func NewHandler(c net.ProtocolClient, s chain.Store, conf *Config, l log.Logger,
 	ctx, ctxCancel := context.WithCancel(context.Background())
 
 	handler := &Handler{
-		conf:      conf,
-		client:    c,
-		crypto:    v,
-		chain:     store,
-		ticker:    ticker,
-		addr:      addr,
-		ctx:       ctx,
-		ctxCancel: ctxCancel,
-		l:         l,
-		version:   version,
+		conf:             conf,
+		client:           c,
+		crypto:           v,
+		chain:            store,
+		ticker:           ticker,
+		addr:             addr,
+		ctx:              ctx,
+		ctxCancel:        ctxCancel,
+		l:                l,
+		version:          version,
+		thresholdMonitor: dmetrics.NewThresholdMonitor(conf.Group.ID, l, conf.Group.Threshold),
 	}
 	return handler, nil
 }
@@ -200,6 +203,7 @@ func (h *Handler) Start() error {
 	h.started = true
 	h.Unlock()
 
+	h.thresholdMonitor.Start()
 	_, tTime := chain.NextRound(h.conf.Clock.Now().Unix(), h.conf.Group.Period, h.conf.Group.GenesisTime)
 	h.l.Infow("", "beacon", "start", "scheme", h.crypto.Name)
 	go h.run(tTime)
@@ -218,6 +222,7 @@ func (h *Handler) Catchup() {
 	h.Unlock()
 
 	nRound, tTime := chain.NextRound(h.conf.Clock.Now().Unix(), h.conf.Group.Period, h.conf.Group.GenesisTime)
+	h.thresholdMonitor.Start()
 	go h.run(tTime)
 	h.chain.RunSync(nRound, nil)
 }
@@ -270,6 +275,7 @@ func (h *Handler) TransitionNewGroup(newShare *key.Share, newGroup *key.Group) {
 			return
 		}
 		h.crypto.SetInfo(newGroup, newShare)
+		h.thresholdMonitor.UpdateThreshold(newGroup.Threshold)
 		h.chain.RemoveCallback("transition")
 	})
 }
@@ -457,6 +463,7 @@ func (h *Handler) broadcastNextPartial(ctx context.Context, current roundInfo, u
 			h.l.Debugw("sending partial", "round", round, "to", i.Address())
 			err := h.client.PartialBeacon(ctx, &i, packet)
 			if err != nil {
+				h.thresholdMonitor.ReportFailure(i.Address())
 				h.l.Errorw("error sending partial", "round", round, "err", err, "to", i.Address())
 				return
 			}
@@ -476,6 +483,7 @@ func (h *Handler) Stop() {
 
 	h.ticker.Stop()
 	h.chain.Stop()
+	h.thresholdMonitor.Stop()
 
 	h.stopped = true
 	h.running = false

--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -5,9 +5,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	dmetrics "github.com/drand/drand/metrics"
 	"sync"
 	"time"
+
+	dmetrics "github.com/drand/drand/metrics"
 
 	clock "github.com/jonboulle/clockwork"
 

--- a/go.mod
+++ b/go.mod
@@ -141,6 +141,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/weaveworks/promrus v1.2.0 // indirect

--- a/metrics/threshold_monitor.go
+++ b/metrics/threshold_monitor.go
@@ -2,10 +2,11 @@ package metrics
 
 import (
 	"context"
-	"github.com/drand/drand/log"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/drand/drand/log"
 )
 
 type ThresholdMonitor struct {
@@ -19,11 +20,11 @@ type ThresholdMonitor struct {
 	period            time.Duration
 }
 
-func NewThresholdMonitor(beaconID string, log log.Logger, threshold int) *ThresholdMonitor {
+func NewThresholdMonitor(beaconID string, l log.Logger, threshold int) *ThresholdMonitor {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &ThresholdMonitor{
 		lock:              sync.RWMutex{},
-		log:               log,
+		log:               l,
 		beaconID:          beaconID,
 		threshold:         threshold,
 		failedConnections: make(map[string]bool),
@@ -51,11 +52,29 @@ func (t *ThresholdMonitor) Start() {
 				}
 
 				if len(failingNodes) >= t.threshold {
-					t.log.Errorw("failed connections crossed threshold in the last minute", "beaconID", t.beaconID, "threshold", t.threshold, "failures", len(failingNodes), "nodes", strings.Join(failingNodes, ","))
+					t.log.Errorw(
+						"failed connections crossed threshold in the last minute",
+						"beaconID", t.beaconID,
+						"threshold", t.threshold,
+						"failures", len(failingNodes),
+						"nodes", strings.Join(failingNodes, ","),
+					)
 				} else if len(failingNodes) >= t.threshold/2 {
-					t.log.Warnw("failed connections crossed half threshold in the last minute", "beaconID", t.beaconID, "threshold", t.threshold, "failures", len(failingNodes), "nodes", strings.Join(failingNodes, ","))
+					t.log.Warnw(
+						"failed connections crossed half threshold in the last minute",
+						"beaconID", t.beaconID,
+						"threshold", t.threshold,
+						"failures", len(failingNodes),
+						"nodes", strings.Join(failingNodes, ","),
+					)
 				} else {
-					t.log.Debugw("threshold monitor healthy", "threshold", t.threshold, "beaconID", t.beaconID, "failures", len(failingNodes), "nodes", strings.Join(failingNodes, ","))
+					t.log.Debugw(
+						"threshold monitor healthy",
+						"threshold", t.threshold,
+						"beaconID", t.beaconID,
+						"failures", len(failingNodes),
+						"nodes", strings.Join(failingNodes, ","),
+					)
 				}
 				t.lock.RUnlock()
 

--- a/metrics/threshold_monitor.go
+++ b/metrics/threshold_monitor.go
@@ -38,12 +38,11 @@ func (t *ThresholdMonitor) Start() {
 	t.log.Infow("starting threshold monitor", "beaconID", t.beaconID)
 
 	go func() {
-	FOR:
 		for {
 			select {
 			case <-t.ctx.Done():
 				t.log.Infow("ending threshold monitor", "beaconID", t.beaconID)
-				break FOR
+				return
 			default:
 				t.lock.RLock()
 				var failingNodes []string

--- a/metrics/threshold_monitor.go
+++ b/metrics/threshold_monitor.go
@@ -1,0 +1,86 @@
+package metrics
+
+import (
+	"context"
+	"github.com/drand/drand/log"
+	"strings"
+	"sync"
+	"time"
+)
+
+type ThresholdMonitor struct {
+	lock              sync.RWMutex
+	log               log.Logger
+	beaconID          string
+	threshold         int
+	failedConnections map[string]bool
+	ctx               context.Context
+	cancel            func()
+	period            time.Duration
+}
+
+func NewThresholdMonitor(beaconID string, log log.Logger, threshold int) *ThresholdMonitor {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &ThresholdMonitor{
+		lock:              sync.RWMutex{},
+		log:               log,
+		beaconID:          beaconID,
+		threshold:         threshold,
+		failedConnections: make(map[string]bool),
+		ctx:               ctx,
+		cancel:            cancel,
+		period:            1 * time.Minute,
+	}
+}
+
+func (t *ThresholdMonitor) Start() {
+	t.log.Infow("starting threshold monitor", "beaconID", t.beaconID)
+
+	go func() {
+	FOR:
+		for {
+			select {
+			case <-t.ctx.Done():
+				t.log.Infow("ending threshold monitor", "beaconID", t.beaconID)
+				break FOR
+			default:
+				t.lock.RLock()
+				var failingNodes []string
+				for address := range t.failedConnections {
+					failingNodes = append(failingNodes, address)
+				}
+
+				if len(failingNodes) >= t.threshold {
+					t.log.Errorw("failed connections crossed threshold in the last minute", "beaconID", t.beaconID, "threshold", t.threshold, "failures", len(failingNodes), "nodes", strings.Join(failingNodes, ","))
+				} else if len(failingNodes) >= t.threshold/2 {
+					t.log.Warnw("failed connections crossed half threshold in the last minute", "beaconID", t.beaconID, "threshold", t.threshold, "failures", len(failingNodes), "nodes", strings.Join(failingNodes, ","))
+				} else {
+					t.log.Debugw("threshold monitor healthy", "threshold", t.threshold, "beaconID", t.beaconID, "failures", len(failingNodes), "nodes", strings.Join(failingNodes, ","))
+				}
+				t.lock.RUnlock()
+
+				t.lock.Lock()
+				t.failedConnections = make(map[string]bool)
+				t.lock.Unlock()
+
+				time.Sleep(t.period)
+			}
+		}
+	}()
+}
+
+func (t *ThresholdMonitor) Stop() {
+	t.cancel()
+}
+
+func (t *ThresholdMonitor) ReportFailure(addr string) {
+	t.lock.Lock()
+	t.failedConnections[addr] = true
+	t.lock.Unlock()
+}
+
+func (t *ThresholdMonitor) UpdateThreshold(newThreshold int) {
+	t.lock.Lock()
+	t.threshold = newThreshold
+	t.lock.Unlock()
+}

--- a/metrics/threshold_monitor_test.go
+++ b/metrics/threshold_monitor_test.go
@@ -2,11 +2,12 @@ package metrics
 
 import (
 	"context"
-	"github.com/drand/drand/log"
-	"github.com/stretchr/testify/mock"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/drand/drand/log"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestLogsErrorsWhenThresholdReached(t *testing.T) {
@@ -239,7 +240,6 @@ func (m *mockLogger) Debugw(msg string, keyvals ...interface{}) {
 
 func (m *mockLogger) Warnw(msg string, keyvals ...interface{}) {
 	m.Called()
-
 }
 
 func (m *mockLogger) Errorw(msg string, keyvals ...interface{}) {

--- a/metrics/threshold_monitor_test.go
+++ b/metrics/threshold_monitor_test.go
@@ -1,0 +1,267 @@
+package metrics
+
+import (
+	"context"
+	"github.com/drand/drand/log"
+	"github.com/stretchr/testify/mock"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestLogsErrorsWhenThresholdReached(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	l := &mockLogger{}
+	threshold := 3
+	period := 1 * time.Second
+	monitor := ThresholdMonitor{
+		lock:              sync.RWMutex{},
+		log:               l,
+		beaconID:          "default",
+		threshold:         threshold,
+		failedConnections: make(map[string]bool),
+		ctx:               ctx,
+		cancel:            cancel,
+		period:            period,
+	}
+
+	l.On("Infow").Return()
+	l.On("Errorw").Return()
+	l.On("Debugw").Return()
+	l.On("Warnw").Return()
+
+	monitor.Start()
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("b")
+	monitor.ReportFailure("c")
+	time.Sleep(period)
+	monitor.Stop()
+
+	l.AssertCalled(t, "Errorw", mock.Anything)
+}
+
+func TestLogsWarningsWhenThresholdAndAHalfReached(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	l := &mockLogger{}
+	threshold := 3
+	period := 1 * time.Second
+	monitor := ThresholdMonitor{
+		lock:              sync.RWMutex{},
+		log:               l,
+		beaconID:          "default",
+		threshold:         threshold,
+		failedConnections: make(map[string]bool),
+		ctx:               ctx,
+		cancel:            cancel,
+		period:            period,
+	}
+
+	l.On("Infow").Return()
+	l.On("Errorw").Return()
+	l.On("Debugw").Return()
+	l.On("Warnw").Return()
+
+	monitor.Start()
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("c")
+	time.Sleep(period)
+	monitor.Stop()
+
+	l.AssertCalled(t, "Warnw", mock.Anything)
+	l.AssertNotCalled(t, "Errorw", mock.Anything)
+}
+
+func TestLogsDebugWhenAllGood(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	l := &mockLogger{}
+	threshold := 3
+	period := 1 * time.Second
+	monitor := ThresholdMonitor{
+		lock:              sync.RWMutex{},
+		log:               l,
+		beaconID:          "default",
+		threshold:         threshold,
+		failedConnections: make(map[string]bool),
+		ctx:               ctx,
+		cancel:            cancel,
+		period:            period,
+	}
+
+	l.On("Infow").Return()
+	l.On("Errorw").Return()
+	l.On("Debugw").Return()
+	l.On("Warnw").Return()
+
+	monitor.Start()
+	time.Sleep(period)
+	monitor.Stop()
+
+	l.AssertCalled(t, "Debugw", mock.Anything)
+	l.AssertNotCalled(t, "Warnw", mock.Anything)
+	l.AssertNotCalled(t, "Errorw", mock.Anything)
+}
+
+func TestStoppingMonitorStopsTheGoroutine(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	l := &mockLogger{}
+	threshold := 3
+	period := 1 * time.Second
+	monitor := ThresholdMonitor{
+		lock:              sync.RWMutex{},
+		log:               l,
+		beaconID:          "default",
+		threshold:         threshold,
+		failedConnections: make(map[string]bool),
+		ctx:               ctx,
+		cancel:            cancel,
+		period:            period,
+	}
+
+	l.On("Infow").Return()
+	l.On("Errorw").Return()
+	l.On("Debugw").Return()
+	l.On("Warnw").Return()
+
+	monitor.Start()
+	monitor.Stop()
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("b")
+	monitor.ReportFailure("c")
+	monitor.ReportFailure("d")
+	time.Sleep(period)
+
+	l.AssertNotCalled(t, "Debugw", mock.Anything)
+	l.AssertNotCalled(t, "Warnw", mock.Anything)
+	l.AssertNotCalled(t, "Errorw", mock.Anything)
+}
+
+func TestDuplicateFailuresAreOnlyCountedOnce(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	l := &mockLogger{}
+	threshold := 4
+	period := 1 * time.Second
+	monitor := ThresholdMonitor{
+		lock:              sync.RWMutex{},
+		log:               l,
+		beaconID:          "default",
+		threshold:         threshold,
+		failedConnections: make(map[string]bool),
+		ctx:               ctx,
+		cancel:            cancel,
+		period:            period,
+	}
+
+	l.On("Infow").Return()
+	l.On("Errorw").Return()
+	l.On("Debugw").Return()
+	l.On("Warnw").Return()
+
+	monitor.Start()
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("a")
+	time.Sleep(period)
+	monitor.Stop()
+
+	l.AssertCalled(t, "Debugw", mock.Anything)
+	l.AssertNotCalled(t, "Warnw", mock.Anything)
+	l.AssertNotCalled(t, "Errorw", mock.Anything)
+}
+
+func TestStateIsResetEveryPeriod(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	l := &mockLogger{}
+	threshold := 3
+	period := 1 * time.Second
+	monitor := ThresholdMonitor{
+		lock:              sync.RWMutex{},
+		log:               l,
+		beaconID:          "default",
+		threshold:         threshold,
+		failedConnections: make(map[string]bool),
+		ctx:               ctx,
+		cancel:            cancel,
+		period:            period,
+	}
+
+	l.On("Infow").Return()
+	l.On("Errorw").Return()
+	l.On("Debugw").Return()
+	l.On("Warnw").Return()
+
+	monitor.Start()
+	monitor.ReportFailure("a")
+	time.Sleep(period)
+	monitor.ReportFailure("b")
+	time.Sleep(period)
+	monitor.Stop()
+
+	l.AssertCalled(t, "Warnw", mock.Anything)
+	l.AssertNotCalled(t, "Errorw", mock.Anything)
+}
+
+type mockLogger struct {
+	mock.Mock
+}
+
+func (m *mockLogger) Info(keyvals ...interface{}) {
+	panic("implement me")
+}
+
+func (m *mockLogger) Debug(keyvals ...interface{}) {
+	panic("implement me")
+}
+
+func (m *mockLogger) Warn(keyvals ...interface{}) {
+	panic("implement me")
+}
+
+func (m *mockLogger) Error(keyvals ...interface{}) {
+	panic("implement me")
+}
+
+func (m *mockLogger) Fatal(keyvals ...interface{}) {
+	panic("implement me")
+}
+
+func (m *mockLogger) Panic(keyvals ...interface{}) {
+	panic("implement me")
+}
+
+func (m *mockLogger) Infow(msg string, keyvals ...interface{}) {
+	m.Called()
+}
+
+func (m *mockLogger) Debugw(msg string, keyvals ...interface{}) {
+	m.Called()
+}
+
+func (m *mockLogger) Warnw(msg string, keyvals ...interface{}) {
+	m.Called()
+
+}
+
+func (m *mockLogger) Errorw(msg string, keyvals ...interface{}) {
+	m.Called()
+}
+
+func (m *mockLogger) Fatalw(msg string, keyvals ...interface{}) {
+	panic("implement me")
+}
+
+func (m *mockLogger) Panicw(msg string, keyvals ...interface{}) {
+	panic("implement me")
+}
+
+func (m *mockLogger) With(args ...interface{}) log.Logger {
+	panic("implement me")
+}
+
+func (m *mockLogger) Named(s string) log.Logger {
+	panic("implement me")
+}
+
+func (m *mockLogger) AddCallerSkip(skip int) log.Logger {
+	panic("implement me")
+}


### PR DESCRIPTION
beacon processes now log some error and warning messages whenever we get close to or cross a threshold number of failures per node