### PR TITLE
aggregate prometheus partial errors by beaconID

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -259,7 +258,7 @@ var (
 	ErrorSendingPartialCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "error_sending_partial",
 		Help: "Number of errors sending partial beacons to nodes. A good proxy for whether nodes are up or down",
-	}, []string{"beaconID", "round", "address"})
+	}, []string{"beaconID"})
 
 	metricsBound sync.Once
 )
@@ -526,6 +525,6 @@ func ReshareStateChange(s ReshareState, beaconID string, leader bool) {
 	reshareLeader.WithLabelValues(beaconID).Set(value)
 }
 
-func ErrorSendingPartial(beaconID string, round uint64, address string) {
-	ErrorSendingPartialCounter.WithLabelValues(beaconID, strconv.Itoa(int(round)), address).Inc()
+func ErrorSendingPartial(beaconID string) {
+	ErrorSendingPartialCounter.WithLabelValues(beaconID).Add(1)
 }

--- a/metrics/threshold_monitor.go
+++ b/metrics/threshold_monitor.go
@@ -95,7 +95,7 @@ func (t *ThresholdMonitor) ReportFailure(beaconID string, round uint64, addr str
 	t.lock.Lock()
 	t.failedConnections[addr] = true
 	t.lock.Unlock()
-	ErrorSendingPartial(beaconID, round, addr)
+	ErrorSendingPartial(beaconID)
 }
 
 func (t *ThresholdMonitor) UpdateThreshold(newThreshold int) {


### PR DESCRIPTION
The additional fields in the partial error counter meant that a new counter was created for _every_ combination. Given that they could only be emitted for each round, a new entry was created for every partial... which is definitely wrong