### PR TITLE
use a gauge for counting nodes that have invalid partials

### DIFF
--- a/chain/beacon/node.go
+++ b/chain/beacon/node.go
@@ -463,10 +463,12 @@ func (h *Handler) broadcastNextPartial(ctx context.Context, current roundInfo, u
 			h.l.Debugw("sending partial", "round", round, "to", i.Address())
 			err := h.client.PartialBeacon(ctx, &i, packet)
 			if err != nil {
-				h.thresholdMonitor.ReportFailure(beaconID, round, i.Address())
+				metrics.ErrorSendingPartial(beaconID, i.Address())
+				h.thresholdMonitor.ReportFailure(i.Address())
 				h.l.Errorw("error sending partial", "round", round, "err", err, "to", i.Address())
 				return
 			}
+			metrics.SuccessfulPartial(beaconID, i.Address())
 		}(*idt)
 	}
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -255,10 +255,10 @@ var (
 		Help: "Timestamp when the drand process started up in seconds since the Epoch",
 	})
 
-	ErrorSendingPartialCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+	ErrorSendingPartialCounter = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "error_sending_partial",
-		Help: "Number of errors sending partial beacons to nodes. A good proxy for whether nodes are up or down",
-	}, []string{"beaconID"})
+		Help: "Number of errors sending partial beacons to nodes. A good proxy for whether nodes are up or down. 1 = Error occurred, 0 = No error occurred",
+	}, []string{"beaconID", "address"})
 
 	metricsBound sync.Once
 )
@@ -525,6 +525,10 @@ func ReshareStateChange(s ReshareState, beaconID string, leader bool) {
 	reshareLeader.WithLabelValues(beaconID).Set(value)
 }
 
-func ErrorSendingPartial(beaconID string) {
-	ErrorSendingPartialCounter.WithLabelValues(beaconID).Add(1)
+func ErrorSendingPartial(beaconID string, address string) {
+	ErrorSendingPartialCounter.WithLabelValues(beaconID, address).Set(1)
+}
+
+func SuccessfulPartial(beaconID string, address string) {
+	ErrorSendingPartialCounter.WithLabelValues(beaconID, address).Set(0)
 }

--- a/metrics/threshold_monitor.go
+++ b/metrics/threshold_monitor.go
@@ -91,11 +91,10 @@ func (t *ThresholdMonitor) Stop() {
 	t.cancel()
 }
 
-func (t *ThresholdMonitor) ReportFailure(beaconID string, round uint64, addr string) {
+func (t *ThresholdMonitor) ReportFailure(addr string) {
 	t.lock.Lock()
 	t.failedConnections[addr] = true
 	t.lock.Unlock()
-	ErrorSendingPartial(beaconID)
 }
 
 func (t *ThresholdMonitor) UpdateThreshold(newThreshold int) {

--- a/metrics/threshold_monitor_test.go
+++ b/metrics/threshold_monitor_test.go
@@ -33,9 +33,9 @@ func TestLogsErrorsWhenThresholdReached(t *testing.T) {
 	l.On("Warnw").Return()
 
 	monitor.Start()
-	monitor.ReportFailure(beaconID, 1, "a")
-	monitor.ReportFailure(beaconID, 1, "b")
-	monitor.ReportFailure(beaconID, 1, "c")
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("b")
+	monitor.ReportFailure("c")
 	time.Sleep(period)
 	monitor.Stop()
 
@@ -65,8 +65,8 @@ func TestLogsWarningsWhenThresholdAndAHalfReached(t *testing.T) {
 	l.On("Warnw").Return()
 
 	monitor.Start()
-	monitor.ReportFailure(beaconID, 1, "a")
-	monitor.ReportFailure(beaconID, 1, "c")
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("c")
 	time.Sleep(period)
 	monitor.Stop()
 
@@ -128,10 +128,10 @@ func TestStoppingMonitorStopsTheGoroutine(t *testing.T) {
 
 	monitor.Start()
 	monitor.Stop()
-	monitor.ReportFailure(beaconID, 1, "a")
-	monitor.ReportFailure(beaconID, 1, "b")
-	monitor.ReportFailure(beaconID, 1, "c")
-	monitor.ReportFailure(beaconID, 1, "d")
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("b")
+	monitor.ReportFailure("c")
+	monitor.ReportFailure("d")
 	time.Sleep(period)
 
 	l.AssertNotCalled(t, "Debugw", mock.Anything)
@@ -162,10 +162,10 @@ func TestDuplicateFailuresAreOnlyCountedOnce(t *testing.T) {
 	l.On("Warnw").Return()
 
 	monitor.Start()
-	monitor.ReportFailure(beaconID, 1, "a")
-	monitor.ReportFailure(beaconID, 1, "a")
-	monitor.ReportFailure(beaconID, 1, "a")
-	monitor.ReportFailure(beaconID, 1, "a")
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("a")
+	monitor.ReportFailure("a")
 	time.Sleep(period)
 	monitor.Stop()
 
@@ -197,9 +197,9 @@ func TestStateIsResetEveryPeriod(t *testing.T) {
 	l.On("Warnw").Return()
 
 	monitor.Start()
-	monitor.ReportFailure(beaconID, 1, "a")
+	monitor.ReportFailure("a")
 	time.Sleep(period)
-	monitor.ReportFailure(beaconID, 1, "b")
+	monitor.ReportFailure("b")
 	time.Sleep(period)
 	monitor.Stop()
 


### PR DESCRIPTION
strictly speaking this will lose sight of nodes that go down and back up between prometheus polls; however it's much easier to handle in grafana