### PR TITLE
Addressing comments for #1199

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -54,8 +54,10 @@ var tracesFlag = &cli.StringFlag{
 }
 
 var tracesProbabilityFlag = &cli.Float64Flag{
-	Name:    "traces-probability",
-	Usage:   "Publish metrics to the specific OpenTelemetry compatible host:port server.",
+	Name: "traces-probability",
+	Usage: "The probability for a certain trace to end up being collected." +
+		"Between 0.0 and 1.0 values, that corresponds to 0% and 100%." +
+		"Be careful as a high probability ratio can produce a lot of data.",
 	EnvVars: []string{"DRAND_TRACES_PROBABILITY"},
 	Value:   0.05,
 }
@@ -64,7 +66,7 @@ var tracesProbabilityFlag = &cli.Float64Flag{
 //
 //nolint:gocyclo,funlen
 func Relay(c *cli.Context) error {
-	tracesProbability := 0.1
+	tracesProbability := 0.05
 	if c.IsSet(tracesProbabilityFlag.Name) {
 		tracesProbability = c.Float64(tracesProbabilityFlag.Name)
 	}

--- a/crypto/schemes.go
+++ b/crypto/schemes.go
@@ -14,6 +14,7 @@ import (
 	bls "github.com/drand/kyber-bls12381"
 	"github.com/drand/kyber/pairing"
 	"github.com/drand/kyber/sign"
+
 	// The package github.com/drand/kyber/sign/bls is deprecated because it is vulnerable to
 	// rogue public-key attack against BLS aggregated signature. The new version of the protocol can be used to
 	// make sure a signature aggregate cannot be verified by a forged key. You can find the protocol in kyber/sign/bdn.

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/jedib0t/go-pretty/v6 v6.4.6
 	github.com/jmoiron/sqlx v1.3.5
-	github.com/jonboulle/clockwork v0.3.0
+	github.com/jonboulle/clockwork v0.4.0
 	github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3
 	github.com/lib/pq v1.10.7
 	github.com/libp2p/go-libp2p v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -723,8 +723,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
-github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
-github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/internal/chain/beacon/chainstore.go
+++ b/internal/chain/beacon/chainstore.go
@@ -277,7 +277,7 @@ func (c *chainStore) runAggregator() {
 			c.l.Debugw("", "new_aggregated", "not_appendable", "last", lastBeacon.String(), "new", newBeacon.String())
 			if c.shouldSync(lastBeacon, newBeacon) {
 				peers := toPeers(c.crypto.GetGroup().Nodes)
-				c.syncm.SendSyncRequest(span.SpanContext(), newBeacon.Round, peers)
+				c.syncm.SendSyncRequest(ctx, newBeacon.Round, peers)
 			}
 			span.End()
 		}
@@ -340,14 +340,14 @@ func (c *chainStore) shouldSync(last *common.Beacon, newB likeBeacon) bool {
 // will follow the chain indefinitely. If peers is nil, it uses the peers of
 // the current group.
 func (c *chainStore) RunSync(ctx context.Context, upTo uint64, peers []net.Peer) {
-	_, span := metrics.NewSpan(ctx, "c.RunSync")
+	ctx, span := metrics.NewSpan(ctx, "c.RunSync")
 	defer span.End()
 
 	if len(peers) == 0 {
 		peers = toPeers(c.crypto.GetGroup().Nodes)
 	}
 
-	c.syncm.SendSyncRequest(span.SpanContext(), upTo, peers)
+	c.syncm.SendSyncRequest(ctx, upTo, peers)
 }
 
 // RunReSync will sync up with other nodes to repair the invalid beacons in the store.

--- a/internal/chain/beacon/sync_manager.go
+++ b/internal/chain/beacon/sync_manager.go
@@ -115,11 +115,12 @@ type RequestInfo struct {
 // round. Depending on the current state of the syncing process, there might not
 // be a new process starting (for example if we already have the round
 // requested). upTo == 0 means the syncing process goes on forever.
-func (s *SyncManager) SendSyncRequest(spanContext oteltrace.SpanContext, upTo uint64, nodes []net.Peer) {
-	s.newReq <- NewRequestInfo(spanContext, upTo, nodes)
+func (s *SyncManager) SendSyncRequest(ctx context.Context, upTo uint64, nodes []net.Peer) {
+	s.newReq <- NewRequestInfo(ctx, upTo, nodes)
 }
 
-func NewRequestInfo(spanContext oteltrace.SpanContext, upTo uint64, nodes []net.Peer) RequestInfo {
+func NewRequestInfo(ctx context.Context, upTo uint64, nodes []net.Peer) RequestInfo {
+	spanContext := oteltrace.SpanContextFromContext(ctx)
 	return RequestInfo{
 		spanContext: spanContext,
 

--- a/internal/core/drand_beacon.go
+++ b/internal/core/drand_beacon.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	oteltrace "go.opentelemetry.io/otel/trace"
-
 	common2 "github.com/drand/drand/common"
 	chain2 "github.com/drand/drand/common/chain"
 	"github.com/drand/drand/common/key"
@@ -195,8 +193,9 @@ func (bp *BeaconProcess) StartBeacon(ctx context.Context, catchup bool) error {
 	return nil
 }
 
-func (bp *BeaconProcess) StartListeningForDKGUpdates(sctx oteltrace.SpanContext) {
-	ctx := oteltrace.ContextWithSpanContext(context.Background(), sctx)
+func (bp *BeaconProcess) StartListeningForDKGUpdates(ctx context.Context) {
+	ctx, span := metrics.NewSpan(ctx, "bp.StartListeningForDKGUpdates")
+	defer span.End()
 	for dkgOutput := range bp.completedDKGs {
 		if err := bp.onDKGCompleted(ctx, &dkgOutput); err != nil {
 			bp.log.Errorw("Error performing DKG key transition", "err", err)
@@ -207,6 +206,8 @@ func (bp *BeaconProcess) StartListeningForDKGUpdates(sctx oteltrace.SpanContext)
 // onDKGCompleted transitions between an "old" group and a new group. This method is called
 // *after* a DKG has completed.
 func (bp *BeaconProcess) onDKGCompleted(ctx context.Context, dkgOutput *dkg.SharingOutput) error {
+	ctx, span := metrics.NewSpan(ctx, "bp.onDKGCompleted")
+	defer span.End()
 	if dkgOutput.BeaconID != bp.beaconID {
 		bp.log.Infow(fmt.Sprintf("BeaconProcess for beaconID %s ignoring DKG for beaconID %s", bp.beaconID, dkgOutput.BeaconID))
 		return nil

--- a/internal/core/drand_beacon.go
+++ b/internal/core/drand_beacon.go
@@ -194,7 +194,7 @@ func (bp *BeaconProcess) StartBeacon(ctx context.Context, catchup bool) error {
 }
 
 func (bp *BeaconProcess) StartListeningForDKGUpdates(ctx context.Context) {
-	ctx, span := metrics.NewSpan(ctx, "bp.StartListeningForDKGUpdates")
+	ctx, span := metrics.NewSpanFromContext(context.Background(), ctx, "bp.StartListeningForDKGUpdates")
 	defer span.End()
 	for dkgOutput := range bp.completedDKGs {
 		if err := bp.onDKGCompleted(ctx, &dkgOutput); err != nil {

--- a/internal/core/drand_beacon_control.go
+++ b/internal/core/drand_beacon_control.go
@@ -544,7 +544,8 @@ func (bp *BeaconProcess) chainInfoFromPeers(ctx context.Context, peers []net.Pee
 // sendProgressCallback returns a function that sends SyncProgress on the
 // passed stream. It also returns a channel that closes when the callback is
 // called with a beacon whose round matches the passed upTo value.
-func (bp *BeaconProcess) sendProgressCallback(ctx context.Context,
+func (bp *BeaconProcess) sendProgressCallback(
+	ctx context.Context,
 	stream drand.Control_StartFollowChainServer,
 	upTo uint64, info *chain2.Info,
 	clk clock.Clock,

--- a/internal/core/drand_beacon_control.go
+++ b/internal/core/drand_beacon_control.go
@@ -390,7 +390,7 @@ func (bp *BeaconProcess) StartFollowChain(ctx context.Context, req *drand.StartS
 	for {
 		syncCtx, syncCancel := context.WithCancel(ctx)
 		go func() {
-			errChan <- syncer.Sync(syncCtx, beacon.NewRequestInfo(span.SpanContext(), req.GetUpTo(), peers))
+			errChan <- syncer.Sync(syncCtx, beacon.NewRequestInfo(ctx, req.GetUpTo(), peers))
 		}() // wait for all the callbacks to be called and progress sent before returning
 		select {
 		case <-done:

--- a/internal/core/drand_daemon.go
+++ b/internal/core/drand_daemon.go
@@ -209,7 +209,7 @@ func (dd *DrandDaemon) InstantiateBeaconProcess(ctx context.Context, beaconID st
 		span.RecordError(err)
 		return nil, err
 	}
-	go bp.StartListeningForDKGUpdates(span.SpanContext())
+	go bp.StartListeningForDKGUpdates(ctx)
 
 	dd.state.Lock()
 	dd.beaconProcesses[beaconID] = bp

--- a/internal/core/drand_daemon.go
+++ b/internal/core/drand_daemon.go
@@ -393,7 +393,6 @@ func (dd *DrandDaemon) LoadBeaconFromStore(ctx context.Context, beaconID string,
 	dd.AddBeaconHandler(ctx, beaconID, bp)
 
 	err = bp.StartBeacon(ctx, true)
-
 	if err != nil {
 		span.RecordError(err)
 	}

--- a/internal/dkg/broadcast.go
+++ b/internal/dkg/broadcast.go
@@ -318,7 +318,7 @@ func newDispatcher(ctx context.Context, dkgClient net.DKGClient, l log.Logger, t
 // broadcast uses the regular channel limitation for messages coming from other
 // nodes.
 func (d *dispatcher) broadcast(ctx context.Context, p broadcastPacket) {
-	ctx, span := metrics.NewSpan(ctx, "d.broadcast")
+	ctx, span := metrics.NewSpanFromContext(context.Background(), ctx, "d.broadcast")
 	defer span.End()
 
 	for _, i := range rand.Perm(len(d.senders)) {

--- a/internal/dkg/broadcast.go
+++ b/internal/dkg/broadcast.go
@@ -380,7 +380,7 @@ func (s *sender) run(ctx context.Context) {
 }
 
 func (s *sender) sendDirect(ctx context.Context, newPacket broadcastPacket) {
-	ctx, span := metrics.NewSpan(ctx, "s.sendDirect")
+	ctx, span := metrics.NewSpanFromContext(context.Background(), ctx, "s.sendDirect")
 	defer span.End()
 
 	node := util.ToPeer(s.to)

--- a/internal/dkg/broadcast.go
+++ b/internal/dkg/broadcast.go
@@ -371,7 +371,7 @@ func (s *sender) sendPacket(ctx context.Context, p broadcastPacket) {
 }
 
 func (s *sender) run(ctx context.Context) {
-	ctx, span := metrics.NewSpan(ctx, "s.run")
+	ctx, span := metrics.NewSpanFromContext(context.Background(), ctx, "s.run")
 	defer span.End()
 
 	for newPacket := range s.newCh {

--- a/internal/drand-cli/cli_test.go
+++ b/internal/drand-cli/cli_test.go
@@ -498,7 +498,6 @@ func TestStartWithoutGroup(t *testing.T) {
 	testStartedDrandFunctional(t, ctrlPort2, tmpPath, priv.Public.Address(), group, fileStore, beaconID)
 }
 
-//nolint:lll // This function has nicely named parameters, so it's long.
 func testStartedDrandFunctional(t *testing.T, ctrlPort, rootPath, address string, group *key.Group, fileStore key.Store, beaconID string) {
 	t.Helper()
 	lg := testlogger.New(t)

--- a/internal/metrics/tracer.go
+++ b/internal/metrics/tracer.go
@@ -78,6 +78,12 @@ func NewSpanFromSpanContext(ctx context.Context, spCtx oteltrace.SpanContext, sp
 	return otel.Tracer(myAppName).Start(oteltrace.ContextWithSpanContext(ctx, spCtx), spanName, opts...)
 }
 
+// NewSpanFromContext is like NewSpanFromSpanContext but uses a span from a context to work
+func NewSpanFromContext(ctx, sctx context.Context, spanName string, opts ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
+	spCtx := oteltrace.SpanContextFromContext(sctx)
+	return otel.Tracer(myAppName).Start(oteltrace.ContextWithSpanContext(ctx, spCtx), spanName, opts...)
+}
+
 //nolint:gocritic
 func noopTracer(appName string) (oteltrace.Tracer, func(context.Context)) {
 	traceProvider := oteltrace.NewNoopTracerProvider()

--- a/internal/metrics/tracer.go
+++ b/internal/metrics/tracer.go
@@ -64,6 +64,8 @@ func InitTracer(appName, endpoint string, probability float64) (oteltrace.Tracer
 }
 
 // NewSpan is a wrapper for metrics.NewSpan(ctx, spanName, opts).
+// If the context.Context provided in `ctx` contains a Span then the newly-created
+// Span will be a child of that span, otherwise it will be a root span.
 // Don't forget to defer span.End and use the newly provided context.
 func NewSpan(ctx context.Context, spanName string, opts ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
 	return otel.Tracer(myAppName).Start(ctx, spanName, opts...)


### PR DESCRIPTION
Addressing my own code review comments from #1199 
Most notable change: trying to use plain context.Context instead of otel SpanContext when possible in function APIs.

Note: care must be taken not to reuse a context that's coming from a stream in e.g. broadcasting since it could get canceled too early