### PR TITLE
validate round number on returned beacons

### DIFF
--- a/client/verify.go
+++ b/client/verify.go
@@ -57,6 +57,9 @@ func (v *verifyingClient) Get(ctx context.Context, round uint64) (Result, error)
 	if err := v.verify(ctx, info, rd); err != nil {
 		return nil, err
 	}
+	if round != 0 && rd.Round() != round {
+		return nil, fmt.Errorf("round misatch: %d != %d", rd.Round(), round)
+	}
 	return rd, nil
 }
 

--- a/client/verify.go
+++ b/client/verify.go
@@ -58,7 +58,7 @@ func (v *verifyingClient) Get(ctx context.Context, round uint64) (Result, error)
 		return nil, err
 	}
 	if round != 0 && rd.Round() != round {
-		return nil, fmt.Errorf("round misatch: %d != %d", rd.Round(), round)
+		return nil, fmt.Errorf("round mismatch: %d != %d", rd.Round(), round)
 	}
 	return rd, nil
 }

--- a/client/verify_test.go
+++ b/client/verify_test.go
@@ -53,7 +53,12 @@ func VerifyFuncTest(t *testing.T, clients, upTo int) {
 }
 
 func TestGetWithRoundMismatch(t *testing.T) {
-	c, _ := mockClientWithVerifiableResults(t, 3, false)
-	_, err := c.Get(context.Background(), 2)
-	require.ErrorContains(t, err, "round mismatch: 1 != 2")
+	c, results := mockClientWithVerifiableResults(t, 3, false)
+	r0 := results[0]
+	for i := range results {
+		results[i] = r0
+	}
+
+	_, err := c.Get(context.Background(), 3)
+	require.ErrorContains(t, err, "round mismatch: 1 != 3")
 }

--- a/client/verify_test.go
+++ b/client/verify_test.go
@@ -55,5 +55,5 @@ func VerifyFuncTest(t *testing.T, clients, upTo int) {
 func TestGetWithRoundMismatch(t *testing.T) {
 	c, _ := mockClientWithVerifiableResults(t, 3, false)
 	_, err := c.Get(context.Background(), 2)
-	require.ErrorContains(t, err, "round misatch: 1 != 2")
+	require.ErrorContains(t, err, "round mismatch: 1 != 2")
 }

--- a/client/verify_test.go
+++ b/client/verify_test.go
@@ -54,9 +54,8 @@ func VerifyFuncTest(t *testing.T, clients, upTo int) {
 
 func TestGetWithRoundMismatch(t *testing.T) {
 	c, results := mockClientWithVerifiableResults(t, 3, false)
-	r0 := results[0]
-	for i := range results {
-		results[i] = r0
+	for i := 1; i < len(results); i++ {
+		results[i] = results[0]
 	}
 
 	_, err := c.Get(context.Background(), 3)


### PR DESCRIPTION
`make test` passing locally.