### PR TITLE
use fan-out channel for DKG results

### DIFF
--- a/crypto/curve_test.go
+++ b/crypto/curve_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -44,7 +43,6 @@ func TestBLS12381CompatMockData(t *testing.T) {
 	require.NoError(t, err)
 
 	prev, err := hex.DecodeString(previous)
-	fmt.Println(len(prev))
 	require.NoError(t, err)
 
 	h := sha256.New()

--- a/demo/node/node_inprocess.go
+++ b/demo/node/node_inprocess.go
@@ -147,7 +147,7 @@ func (l *LocalNode) Start(dbEngineType chain.StorageType, pgDSN func() string, m
 		}
 
 		err = bp.Load(ctx)
-		isFreshRun := err == core.ErrDKGNotStarted
+		isFreshRun := errors.Is(err, core.ErrDKGNotStarted)
 		if err != nil && !isFreshRun {
 			return err
 		}

--- a/internal/core/drand_beacon.go
+++ b/internal/core/drand_beacon.go
@@ -44,7 +44,7 @@ type BeaconProcess struct {
 	privGateway *net.PrivateGateway
 
 	beacon        *beacon.Handler
-	completedDKGs <-chan dkg.SharingOutput
+	completedDKGs *util.FanOutChan[dkg.SharingOutput]
 
 	// dkg private share. can be nil if dkg not finished yet.
 	share *key.Share
@@ -68,7 +68,7 @@ type BeaconProcess struct {
 func NewBeaconProcess(ctx context.Context,
 	log dlog.Logger,
 	store key.Store,
-	completedDKGs chan dkg.SharingOutput,
+	completedDKGs *util.FanOutChan[dkg.SharingOutput],
 	beaconID string,
 	opts *Config,
 	privGateway *net.PrivateGateway) (*BeaconProcess, error) {
@@ -186,9 +186,13 @@ func (bp *BeaconProcess) StartBeacon(ctx context.Context, catchup bool) error {
 func (bp *BeaconProcess) StartListeningForDKGUpdates(ctx context.Context) {
 	ctx, span := tracer.NewSpanFromContext(context.Background(), ctx, "bp.StartListeningForDKGUpdates")
 	defer span.End()
-	for dkgOutput := range bp.completedDKGs {
-		if err := bp.onDKGCompleted(ctx, &dkgOutput); err != nil {
-			bp.log.Errorw("Error performing DKG key transition", "err", err)
+	ch := bp.completedDKGs.Listen()
+	for {
+		select {
+		case dkgOutput := <-ch:
+			if err := bp.onDKGCompleted(ctx, &dkgOutput); err != nil {
+				bp.log.Errorw("Error performing DKG key transition", "err", err)
+			}
 		}
 	}
 }

--- a/internal/core/drand_beacon.go
+++ b/internal/core/drand_beacon.go
@@ -187,12 +187,9 @@ func (bp *BeaconProcess) StartListeningForDKGUpdates(ctx context.Context) {
 	ctx, span := tracer.NewSpanFromContext(context.Background(), ctx, "bp.StartListeningForDKGUpdates")
 	defer span.End()
 	ch := bp.completedDKGs.Listen()
-	for {
-		select {
-		case dkgOutput := <-ch:
-			if err := bp.onDKGCompleted(ctx, &dkgOutput); err != nil {
-				bp.log.Errorw("Error performing DKG key transition", "err", err)
-			}
+	for dkgOutput := range ch {
+		if err := bp.onDKGCompleted(ctx, &dkgOutput); err != nil {
+			bp.log.Errorw("Error performing DKG key transition", "err", err)
 		}
 	}
 }

--- a/internal/core/drand_daemon.go
+++ b/internal/core/drand_daemon.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"sync"
 
-	"github.com/drand/drand/v2/internal/util"
 	"go.opentelemetry.io/otel/attribute"
 
 	pdkg "github.com/drand/drand/v2/protobuf/dkg"
@@ -23,6 +22,7 @@ import (
 	"github.com/drand/drand/v2/internal/metrics"
 	"github.com/drand/drand/v2/internal/metrics/pprof"
 	"github.com/drand/drand/v2/internal/net"
+	"github.com/drand/drand/v2/internal/util"
 	"github.com/drand/drand/v2/protobuf/drand"
 )
 

--- a/internal/core/drand_daemon.go
+++ b/internal/core/drand_daemon.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"sync"
 
+	"github.com/drand/drand/v2/internal/util"
 	"go.opentelemetry.io/otel/attribute"
 
 	pdkg "github.com/drand/drand/v2/protobuf/dkg"
@@ -43,7 +44,7 @@ type DrandDaemon struct {
 
 	// global state lock
 	state         sync.Mutex
-	completedDKGs chan dkg.SharingOutput
+	completedDKGs *util.FanOutChan[dkg.SharingOutput]
 	exitCh        chan bool
 
 	// version indicates the base code variant
@@ -70,7 +71,7 @@ func NewDrandDaemon(ctx context.Context, c *Config) (*DrandDaemon, error) {
 		opts:            c,
 		log:             logger,
 		exitCh:          make(chan bool, 1),
-		completedDKGs:   make(chan dkg.SharingOutput),
+		completedDKGs:   util.NewFanOutChan[dkg.SharingOutput](),
 		version:         common2.GetAppVersion(),
 		beaconProcesses: make(map[string]*BeaconProcess),
 		chainHashes:     make(map[string]string),

--- a/internal/dkg/actions.go
+++ b/internal/dkg/actions.go
@@ -57,7 +57,7 @@ func (d *Process) gossip(
 			continue
 		}
 
-		// attempt to gossip with exponential backoff
+		// attempt to gossip with other peers
 		go func() {
 			err := sendToPeer(d.internalClient, p, packet)
 			if err != nil {

--- a/internal/dkg/dkg_process.go
+++ b/internal/dkg/dkg_process.go
@@ -7,6 +7,7 @@ import (
 	"github.com/drand/drand/v2/common/key"
 	"github.com/drand/drand/v2/common/log"
 	"github.com/drand/drand/v2/internal/net"
+	"github.com/drand/drand/v2/internal/util"
 )
 
 type Process struct {
@@ -22,7 +23,7 @@ type Process struct {
 	Executions map[string]Broadcast
 	// a set of the packets that have been seen already for easy deduping
 	SeenPackets   map[string]bool
-	completedDKGs chan<- SharingOutput
+	completedDKGs *util.FanOutChan[SharingOutput]
 }
 
 type Config struct {
@@ -83,7 +84,7 @@ type BeaconIdentifier interface {
 func NewDKGProcess(
 	store Store,
 	beaconIdentifier BeaconIdentifier,
-	completedDKGs chan<- SharingOutput,
+	completedDKGs *util.FanOutChan[SharingOutput],
 	dkgClient net.DKGClient,
 	protocolClient net.ProtocolClient,
 	config Config,

--- a/internal/dkg/dkg_process_test.go
+++ b/internal/dkg/dkg_process_test.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc"
 )
 
+//nolint:funlen // it's a test
 func TestDKGFailedAtProtocol(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
@@ -130,6 +131,7 @@ func TestFailedReshare(t *testing.T) {
 
 	leaderNode := nodes[0]
 	leader, err := leaderNode.RunnerFor(beaconID)
+	require.NoError(t, err)
 	err = leader.StartNetwork(2, 1, crypto.DefaultSchemeID, 1*time.Minute, 1, identities)
 	require.NoError(t, err)
 
@@ -172,6 +174,7 @@ func TestFailedReshare(t *testing.T) {
 	require.Equal(t, uint32(1), status.Complete.Epoch)
 }
 
+//nolint:funlen // it's a test
 func TestMultipleDKGsInFlight(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/internal/dkg/execution.go
+++ b/internal/dkg/execution.go
@@ -135,7 +135,7 @@ func (d *Process) executeAndFinishDKG(ctx context.Context, beaconID string, conf
 		return err
 	}
 
-	d.completedDKGs <- SharingOutput{
+	d.completedDKGs.Chan() <- SharingOutput{
 		BeaconID: beaconID,
 		Old:      lastCompleted,
 		New:      *finalState,

--- a/internal/util/fan_out_chan.go
+++ b/internal/util/fan_out_chan.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"sync"
+)
+
+const MaxDKGsInFlight = 20
+
+// FanOutChan has one producer channel and multiple consumers for each message ont he channel
+type FanOutChan[T any] struct {
+	lock      sync.RWMutex
+	delegate  chan T
+	listeners []chan T
+}
+
+func NewFanOutChan[T any]() *FanOutChan[T] {
+	f := &FanOutChan[T]{
+		delegate:  make(chan T, MaxDKGsInFlight),
+		listeners: make([]chan T, 0),
+	}
+
+	go func() {
+		for item := range f.delegate {
+			f.lock.RLock()
+			for _, l := range f.listeners {
+				l := l
+				l <- item
+			}
+			f.lock.RUnlock()
+		}
+	}()
+
+	return f
+}
+
+func (f *FanOutChan[T]) Listen() chan T {
+	ch := make(chan T, MaxDKGsInFlight)
+
+	f.lock.Lock()
+	f.listeners = append(f.listeners, ch)
+	defer f.lock.Unlock()
+	return ch
+}
+
+func (f *FanOutChan[T]) Chan() chan T {
+	return f.delegate
+}


### PR DESCRIPTION
- added a fan-out channel to ensure that multiple DKGs can be in flight
- added a test for multiple DKGs happening at the same time
- refactored DKG process tests not to use an interface so we can grab a  reference to the channel