### PR TITLE
Do not use TLS GRPC in test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,75 +59,75 @@ clean:
 test: test-unit test-integration
 
 test-unit:
-	go test -failfast $(SHORTTEST) -race -v ./...
+	go test -failfast $(SHORTTEST) -race -v -tags test ./...
 
 test-unit-boltdb: test-unit
 
 test-unit-memdb:
-	go test -failfast $(SHORTTEST) -race -v -tags memdb ./...
+	go test -failfast $(SHORTTEST) -race -v -tags test,memdb ./...
 
 test-unit-postgres:
-	go test -failfast $(SHORTTEST) -race -v -tags postgres ./...
+	go test -failfast $(SHORTTEST) -race -v -tags test,postgres ./...
 
 test-unit-cover:
-	go test -failfast $(SHORTTEST) -v -coverprofile=coverage.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
+	go test -failfast $(SHORTTEST) -tags test -v -coverprofile=coverage.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
 
 test-unit-boltdb-cover: test-unit-cover
 
 test-unit-memdb-cover:
-	go test -failfast $(SHORTTEST) -v -tags memdb -coverprofile=coverage-memdb.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
+	go test -failfast $(SHORTTEST) -v -tags test,memdb -coverprofile=coverage-memdb.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
 
 test-unit-postgres-cover:
-	go test -failfast $(SHORTTEST) -v -tags postgres -coverprofile=coverage-postgres.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
+	go test -failfast $(SHORTTEST) -v -tags test,postgres -coverprofile=coverage-postgres.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
 
 test-integration:
-	go test -failfast $(SHORTTEST) -race -v -tags integration ./demo/
+	go test -failfast $(SHORTTEST) -race -v -tags test,integration ./demo/
 
 test-integration-boltdb: test-integration
 
 test-integration-memdb:
-	go test -failfast $(SHORTTEST) -race -v -tags integration,memdb ./demo/
+	go test -failfast $(SHORTTEST) -race -v -tags test,integration,memdb ./demo/
 
 test-integration-postgres:
-	go test -failfast $(SHORTTEST) -race -v -tags integration,postgres ./demo/
+	go test -failfast $(SHORTTEST) -race -v -tags test,integration,postgres ./demo/
 
 test-integration-run-demo:
-	cd demo && go build && ./demo -build -test -debug
+	cd demo && go build -tags test && ./demo -build -test -debug
 
 test-integration-run-demo-boltdb: test-integration-run-demo
 
 test-integration-run-demo-memdb:
-	cd demo && go build && ./demo -dbtype=memdb -build -test -debug
+	cd demo && go build  -tags test && ./demo -dbtype=memdb -build -test -debug
 
 test-integration-run-demo-postgres:
-	cd demo && go build && ./demo -dbtype=postgres -build -test -debug
+	cd demo && go build  -tags test && ./demo -dbtype=postgres -build -test -debug
 
 
 coverage:
 	go get -v -t -d ./...
-	go test -failfast $(SHORTTEST) -v -covermode=atomic -coverpkg ./... -coverprofile=coverage.txt ./...
+	go test -failfast $(SHORTTEST) -v  -tags test -covermode=atomic -coverpkg ./... -coverprofile=coverage.txt ./...
 
 coverage-boltdb: coverage
 
 coverage-memdb:
 	go get -tags=memdb -v -t -d ./...
-	go test -failfast $(SHORTTEST) -v -tags=memdb -covermode=atomic -coverpkg ./... -coverprofile=coverage-memdb.txt ./...
+	go test -failfast $(SHORTTEST) -v -tags=test,memdb -covermode=atomic -coverpkg ./... -coverprofile=coverage-memdb.txt ./...
 
 coverage-postgres:
 	go get -tags=postgres -v -t -d ./...
-	go test -failfast $(SHORTTEST) -v -tags=postgres -covermode=atomic -coverpkg ./... -coverprofile=coverage-postgres.txt ./...
+	go test -failfast $(SHORTTEST) -v -tags=test,postgres -covermode=atomic -coverpkg ./... -coverprofile=coverage-postgres.txt ./...
 
 demo:
-	cd demo && go build && ./demo -build
+	cd demo && go build -tags test && ./demo -build
 	#cd demo && sudo ./run.sh
 
 demo-boltdb: demo
 
 demo-memdb:
-	cd demo && go build && ./demo -dbtype=memdb -build
+	cd demo && go build -tags test && ./demo -dbtype=memdb -build
 
 demo-postgres:
-	cd demo && go build && ./demo -dbtype=postgres -build
+	cd demo && go build -tags test && ./demo -dbtype=postgres -build
 
 ############################################ Build ############################################
 

--- a/Makefile
+++ b/Makefile
@@ -59,75 +59,74 @@ clean:
 test: test-unit test-integration
 
 test-unit:
-	go test -failfast $(SHORTTEST) -race -v -tags test ./...
+	go test -failfast $(SHORTTEST) -race -v -tags conn_insecure ./...
 
 test-unit-boltdb: test-unit
 
 test-unit-memdb:
-	go test -failfast $(SHORTTEST) -race -v -tags test,memdb ./...
+	go test -failfast $(SHORTTEST) -race -v -tags conn_insecure,memdb ./...
 
 test-unit-postgres:
-	go test -failfast $(SHORTTEST) -race -v -tags test,postgres ./...
+	go test -failfast $(SHORTTEST) -race -v -tags conn_insecure,postgres ./...
 
 test-unit-cover:
-	go test -failfast $(SHORTTEST) -tags test -v -coverprofile=coverage.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
+	go test -failfast $(SHORTTEST) -tags conn_insecure -v -coverprofile=coverage.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
 
 test-unit-boltdb-cover: test-unit-cover
 
 test-unit-memdb-cover:
-	go test -failfast $(SHORTTEST) -v -tags test,memdb -coverprofile=coverage-memdb.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
+	go test -failfast $(SHORTTEST) -v -tags conn_insecure,memdb -coverprofile=coverage-memdb.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
 
 test-unit-postgres-cover:
-	go test -failfast $(SHORTTEST) -v -tags test,postgres -coverprofile=coverage-postgres.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
+	go test -failfast $(SHORTTEST) -v -tags conn_insecure,postgres -coverprofile=coverage-postgres.txt -covermode=count -coverpkg=all $(go list ./... | grep -v /demo/)
 
 test-integration:
-	go test -failfast $(SHORTTEST) -race -v -tags test,integration ./demo/
+	go test -failfast $(SHORTTEST) -race -v -tags conn_insecure,integration ./demo/
 
 test-integration-boltdb: test-integration
 
 test-integration-memdb:
-	go test -failfast $(SHORTTEST) -race -v -tags test,integration,memdb ./demo/
+	go test -failfast $(SHORTTEST) -race -v -tags conn_insecure,integration,memdb ./demo/
 
 test-integration-postgres:
-	go test -failfast $(SHORTTEST) -race -v -tags test,integration,postgres ./demo/
+	go test -failfast $(SHORTTEST) -race -v -tags conn_insecure,integration,postgres ./demo/
 
 test-integration-run-demo:
-	cd demo && go build -tags test && ./demo -build -test -debug
+	cd demo && go build -tags conn_insecure && ./demo -build -test -debug
 
 test-integration-run-demo-boltdb: test-integration-run-demo
 
 test-integration-run-demo-memdb:
-	cd demo && go build  -tags test && ./demo -dbtype=memdb -build -test -debug
+	cd demo && go build  -tags conn_insecure && ./demo -dbtype=memdb -build -test -debug
 
 test-integration-run-demo-postgres:
-	cd demo && go build  -tags test && ./demo -dbtype=postgres -build -test -debug
+	cd demo && go build  -tags conn_insecure && ./demo -dbtype=postgres -build -test -debug
 
 
 coverage:
 	go get -v -t -d ./...
-	go test -failfast $(SHORTTEST) -v  -tags test -covermode=atomic -coverpkg ./... -coverprofile=coverage.txt ./...
+	go test -failfast $(SHORTTEST) -v  -tags conn_insecure -covermode=atomic -coverpkg ./... -coverprofile=coverage.txt ./...
 
 coverage-boltdb: coverage
 
 coverage-memdb:
 	go get -tags=memdb -v -t -d ./...
-	go test -failfast $(SHORTTEST) -v -tags=test,memdb -covermode=atomic -coverpkg ./... -coverprofile=coverage-memdb.txt ./...
+	go test -failfast $(SHORTTEST) -v -tags=conn_insecure,memdb -covermode=atomic -coverpkg ./... -coverprofile=coverage-memdb.txt ./...
 
 coverage-postgres:
 	go get -tags=postgres -v -t -d ./...
-	go test -failfast $(SHORTTEST) -v -tags=test,postgres -covermode=atomic -coverpkg ./... -coverprofile=coverage-postgres.txt ./...
+	go test -failfast $(SHORTTEST) -v -tags=conn_insecure,postgres -covermode=atomic -coverpkg ./... -coverprofile=coverage-postgres.txt ./...
 
 demo:
-	cd demo && go build -tags test && ./demo -build
-	#cd demo && sudo ./run.sh
+	cd demo && go build -tags conn_insecure && ./demo -build
 
 demo-boltdb: demo
 
 demo-memdb:
-	cd demo && go build -tags test && ./demo -dbtype=memdb -build
+	cd demo && go build -tags conn_insecure && ./demo -dbtype=memdb -build
 
 demo-postgres:
-	cd demo && go build -tags test && ./demo -dbtype=postgres -build
+	cd demo && go build -tags conn_insecure && ./demo -dbtype=postgres -build
 
 ############################################ Build ############################################
 
@@ -138,11 +137,19 @@ build_proto:
 
 # create the "drand" binary and install it in $GOBIN
 install:
+	$(info This is installing drand with TLS enabled.)
+	$(info  )
 	go install -ldflags "-X $(VER_PACKAGE).COMMIT=$(GIT_REVISION) -X $(VER_PACKAGE).BUILDDATE=$(BUILD_DATE) -X $(CLI_PACKAGE).buildDate=$(BUILD_DATE) -X $(CLI_PACKAGE).gitCommit=$(GIT_REVISION)" ./cmd/drand
 
 # create the "drand" binary in the current folder
 build:
+	$(info This is building drand with TLS enabled, use 'make build_insecure' to do local tests without TLS.)
+	$(info  )
 	go build -o drand -mod=readonly -ldflags "-X $(VER_PACKAGE).COMMIT=$(GIT_REVISION) -X $(VER_PACKAGE).BUILDDATE=$(BUILD_DATE) -X $(CLI_PACKAGE).buildDate=$(BUILD_DATE) -X $(CLI_PACKAGE).gitCommit=$(GIT_REVISION)" ./cmd/drand
+
+# create the "drand" binary in the current folder without TLS connections, useful for tests.
+build_insecure:
+	go build -tags conn_insecure -o drand -mod=readonly -ldflags "-X $(VER_PACKAGE).COMMIT=$(GIT_REVISION) -X $(VER_PACKAGE).BUILDDATE=$(BUILD_DATE) -X $(CLI_PACKAGE).buildDate=$(BUILD_DATE) -X $(CLI_PACKAGE).gitCommit=$(GIT_REVISION)" ./cmd/drand
 
 build_all: drand
 

--- a/demo/main.go
+++ b/demo/main.go
@@ -22,7 +22,7 @@ func installDrand() {
 	curr, err := os.Getwd()
 	checkErr(err)
 	checkErr(os.Chdir("../"))
-	install := exec.Command("go", "install", "./cmd/drand")
+	install := exec.Command("go", "install", "-tags=test", "./cmd/drand")
 	runCommand(install)
 	checkErr(os.Chdir(curr))
 }

--- a/demo/main.go
+++ b/demo/main.go
@@ -22,7 +22,7 @@ func installDrand() {
 	curr, err := os.Getwd()
 	checkErr(err)
 	checkErr(os.Chdir("../"))
-	install := exec.Command("go", "install", "-tags=test", "./cmd/drand")
+	install := exec.Command("go", "install", "-tags=conn_insecure", "./cmd/drand")
 	runCommand(install)
 	checkErr(os.Chdir(curr))
 }

--- a/internal/net/client_grpc.go
+++ b/internal/net/client_grpc.go
@@ -2,7 +2,6 @@ package net
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -10,16 +9,12 @@ import (
 	"sync"
 	"time"
 
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"golang.org/x/net/proxy"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding/gzip"
 
 	"github.com/drand/drand/v2/common/log"
 	"github.com/drand/drand/v2/common/tracer"
-	"github.com/drand/drand/v2/internal/metrics"
 	"github.com/drand/drand/v2/protobuf/drand"
 )
 
@@ -228,51 +223,6 @@ func (g *grpcClient) Status(ctx context.Context, p Peer, in *drand.StatusRequest
 	defer cancel()
 	resp, err = client.Status(ctx, in, opts...)
 	return resp, err
-}
-
-// conn retrieve an already existing conn to the given peer or create a new one
-func (g *grpcClient) conn(ctx context.Context, p Peer) (*grpc.ClientConn, error) {
-	g.Lock()
-	defer g.Unlock()
-	var err error
-
-	// we try to retrieve an existing connection if available
-	c, ok := g.conns[p.Address()]
-	if ok && (c.GetState() == connectivity.Shutdown || c.GetState() == connectivity.TransientFailure) {
-		ok = false
-		delete(g.conns, p.Address())
-		metrics.OutgoingConnectionState.WithLabelValues(p.Address()).Set(float64(c.GetState()))
-	}
-
-	// otherwise we try to re-dial it
-	if !ok {
-		g.log.Debugw("initiating new grpc conn using TLS", "to", p.Address())
-		var opts []grpc.DialOption
-
-		config := &tls.Config{MinVersion: tls.VersionTLS12}
-		opts = append(opts, g.opts...)
-		opts = append(opts,
-			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
-		)
-
-		c, err = grpc.DialContext(ctx, p.Address(), append(opts,
-			grpc.WithTransportCredentials(credentials.NewTLS(config)))...)
-		if err != nil {
-			g.log.Errorw("error initiating a new grpc conn using TLS", "to", p.Address(), "err", err)
-			// We increase the GroupDialFailures counter when both failed
-			metrics.GroupDialFailures.WithLabelValues(p.Address()).Inc()
-		} else {
-			g.log.Debugw("new grpc conn established", "state", c.GetState(), "to", p.Address())
-			g.conns[p.Address()] = c
-			metrics.OutgoingConnections.Set(float64(len(g.conns)))
-		}
-	}
-
-	// Emit the connection state regardless of whether it's a new or an existing connection
-	if err == nil {
-		metrics.OutgoingConnectionState.WithLabelValues(p.Address()).Set(float64(c.GetState()))
-	}
-	return c, err
 }
 
 func (g *grpcClient) Stop() {

--- a/internal/net/conn_other.go
+++ b/internal/net/conn_other.go
@@ -1,0 +1,58 @@
+//go:build test
+
+package net
+
+import (
+	"context"
+
+	"github.com/drand/drand/v2/internal/metrics"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	insecure "google.golang.org/grpc/credentials/insecure"
+)
+
+// conn retrieve an already existing conn to the given peer or create a new one
+func (g *grpcClient) conn(ctx context.Context, p Peer) (*grpc.ClientConn, error) {
+	g.Lock()
+	defer g.Unlock()
+	var err error
+
+	// we try to retrieve an existing connection if available
+	c, ok := g.conns[p.Address()]
+	if ok && c.GetState() == connectivity.Shutdown {
+		ok = false
+		delete(g.conns, p.Address())
+		metrics.OutgoingConnectionState.WithLabelValues(p.Address()).Set(float64(c.GetState()))
+	}
+
+	// otherwise we try to re-dial it
+	if !ok {
+		g.log.Debugw("initiating new grpc conn without TLS", "to", p.Address())
+
+		opts := append(
+			[]grpc.DialOption{
+				grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			},
+			g.opts...,
+		)
+
+		c, err = grpc.DialContext(ctx, p.Address(), opts...)
+		if err != nil {
+			// We increase the GroupDialFailures counter when both failed
+			metrics.GroupDialFailures.WithLabelValues(p.Address()).Inc()
+			g.log.Errorw("error initiating a new grpc non-TLS conn", "to", p.Address(), "err", err)
+		} else {
+			g.log.Debugw("new grpc conn established", "state", c.GetState(), "to", p.Address())
+			g.conns[p.Address()] = c
+			metrics.OutgoingConnections.Set(float64(len(g.conns)))
+		}
+	}
+
+	// Emit the connection state regardless of whether it's a new or an existing connection
+	if err == nil {
+		metrics.OutgoingConnectionState.WithLabelValues(p.Address()).Set(float64(c.GetState()))
+	}
+	return c, err
+}

--- a/internal/net/conn_other.go
+++ b/internal/net/conn_other.go
@@ -1,4 +1,4 @@
-//go:build test
+//go:build conn_insecure
 
 package net
 
@@ -12,8 +12,12 @@ import (
 	insecure "google.golang.org/grpc/credentials/insecure"
 )
 
-// conn retrieve an already existing conn to the given peer or create a new one
+// conn retrieve an already existing conn to the given peer or create a new one.
+// This version is the NON-TLS CONNECTION FOR TEST PURPOSES, it's behind a build tag that we use in our tests.
 func (g *grpcClient) conn(ctx context.Context, p Peer) (*grpc.ClientConn, error) {
+	// This is the NON-TLS version!
+	// If you change anything here, don't forget to also change it in the TLS one in conn_tls.go
+
 	g.Lock()
 	defer g.Unlock()
 	var err error

--- a/internal/net/conn_tls.go
+++ b/internal/net/conn_tls.go
@@ -1,4 +1,4 @@
-//go:build !test
+//go:build !conn_insecure
 
 package net
 
@@ -16,6 +16,9 @@ import (
 
 // conn retrieve an already existing conn to the given peer or create a new one
 func (g *grpcClient) conn(ctx context.Context, p Peer) (*grpc.ClientConn, error) {
+	// This is the TLS version!
+	// If you change anything here, don't forget to also change it in the non-TLS one in conn_other.go
+
 	g.Lock()
 	defer g.Unlock()
 	var err error

--- a/internal/net/conn_tls.go
+++ b/internal/net/conn_tls.go
@@ -1,0 +1,62 @@
+//go:build !test
+
+package net
+
+import (
+	"context"
+	"crypto/tls"
+
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/drand/drand/v2/internal/metrics"
+)
+
+// conn retrieve an already existing conn to the given peer or create a new one
+func (g *grpcClient) conn(ctx context.Context, p Peer) (*grpc.ClientConn, error) {
+	g.Lock()
+	defer g.Unlock()
+	var err error
+
+	// we try to retrieve an existing connection if available
+	c, ok := g.conns[p.Address()]
+	if ok && c.GetState() == connectivity.Shutdown {
+		ok = false
+		delete(g.conns, p.Address())
+		metrics.OutgoingConnectionState.WithLabelValues(p.Address()).Set(float64(connectivity.Shutdown))
+	}
+
+	// otherwise we try to re-dial it
+	if !ok {
+		g.log.Debugw("initiating new grpc conn using TLS", "to", p.Address())
+
+		config := &tls.Config{MinVersion: tls.VersionTLS12}
+
+		opts := append(
+			[]grpc.DialOption{
+				grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+				grpc.WithTransportCredentials(credentials.NewTLS(config)),
+			},
+			g.opts...,
+		)
+
+		c, err = grpc.DialContext(ctx, p.Address(), opts...)
+		if err != nil {
+			g.log.Errorw("error initiating a new grpc conn using TLS", "to", p.Address(), "err", err)
+			// We increase the GroupDialFailures counter when both failed
+			metrics.GroupDialFailures.WithLabelValues(p.Address()).Inc()
+		} else {
+			g.log.Debugw("new grpc conn established", "state", c.GetState(), "to", p.Address())
+			g.conns[p.Address()] = c
+			metrics.OutgoingConnections.Set(float64(len(g.conns)))
+		}
+	}
+
+	// Emit the connection state regardless of whether it's a new or an existing connection
+	if err == nil {
+		metrics.OutgoingConnectionState.WithLabelValues(p.Address()).Set(float64(c.GetState()))
+	}
+	return c, err
+}


### PR DESCRIPTION
But we still use TLS in prod.

Note that now you need to use `go test -tags test ./...` when running locally, sadly.

There isn't any official build tags for tests in Go, sadly: https://github.com/golang/go/issues/21360.