### PR TITLE
Fixing our pprof routes and closing our GRPC conn.

### DIFF
--- a/internal/metrics/pprof/pprof.go
+++ b/internal/metrics/pprof/pprof.go
@@ -13,10 +13,11 @@ func WithProfile() http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/", pprof.Index)
-	mux.HandleFunc("/cmdline", pprof.Cmdline)
-	mux.HandleFunc("/profile", pprof.Profile)
-	mux.HandleFunc("/symbol", pprof.Symbol)
-	mux.HandleFunc("/trace", pprof.Trace)
+	// sub-path need to handle the whole path for the matching to work
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 	return mux
 }

--- a/internal/net/conn_other.go
+++ b/internal/net/conn_other.go
@@ -27,6 +27,8 @@ func (g *grpcClient) conn(ctx context.Context, p Peer) (*grpc.ClientConn, error)
 	c, ok := g.conns[p.Address()]
 	if ok && c.GetState() == connectivity.Shutdown {
 		ok = false
+		// we need to close the connection before deleting it to avoid goroutine leaks
+		c.Close()
 		delete(g.conns, p.Address())
 		metrics.OutgoingConnectionState.WithLabelValues(p.Address()).Set(float64(c.GetState()))
 	}

--- a/internal/net/conn_tls.go
+++ b/internal/net/conn_tls.go
@@ -27,6 +27,8 @@ func (g *grpcClient) conn(ctx context.Context, p Peer) (*grpc.ClientConn, error)
 	c, ok := g.conns[p.Address()]
 	if ok && c.GetState() == connectivity.Shutdown {
 		ok = false
+		// we need to close the connection before deleting it to avoid goroutine leaks
+		c.Close()
 		delete(g.conns, p.Address())
 		g.log.Debugw("grpc conn in Shutdown state", "to", p.Address())
 		metrics.OutgoingConnectionState.WithLabelValues(p.Address()).Set(float64(connectivity.Shutdown))

--- a/internal/net/conn_tls.go
+++ b/internal/net/conn_tls.go
@@ -28,6 +28,7 @@ func (g *grpcClient) conn(ctx context.Context, p Peer) (*grpc.ClientConn, error)
 	if ok && c.GetState() == connectivity.Shutdown {
 		ok = false
 		delete(g.conns, p.Address())
+		g.log.Debugw("grpc conn in Shutdown state", "to", p.Address())
 		metrics.OutgoingConnectionState.WithLabelValues(p.Address()).Set(float64(connectivity.Shutdown))
 	}
 


### PR DESCRIPTION
Seems you cannot nest ServeMux-es into one another without either triming the prefix from the path or just specifying the whole path.

Also to avoid leaking grpc callbacks, we need to close our outgoing connections when we re-establish them.