### PR TITLE
Extend chain head fetch timeout

### DIFF
--- a/client/http/http.go
+++ b/client/http/http.go
@@ -52,7 +52,7 @@ func New(url string, chainHash []byte, transport nhttp.RoundTripper) (client.Cli
 		done:   make(chan struct{}),
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	chainInfo, err := c.FetchChainInfo(ctx, chainHash)


### PR DESCRIPTION
I can never get lotus unit tests to pass locally because of this timeout. Caused by this test: https://github.com/filecoin-project/lotus/blob/0eddfee5d62adf4db1a0810b62ecbf75281aaf86/chain/beacon/drand/drand_test.go#L20-L21

`Servers[0]` in this case is `pl-eu.testnet.drand.sh`; which is an antipode server for me, even with my shiny new fibre connection I can't get better than a 1.2s round-trip.

```
$ time curl https://pl-eu.testnet.drand.sh/info
{"public_key":"922a2e93828ff83345bae533f5172669a26c02dc76d6bf59c80892e12ab1455c229211886f35bb56af6d5bea981024df","period":25,"genesis_time":1590445175,"hash":"84b2234fb34e835dccd048255d7ad3194b81af7d978c3bf157e3469592ae4e02","groupHash":"4dd408e5fdff9323c76a9b6f087ba8fdc5a6da907bd9217d9d10f2287d081957","schemeID":"pedersen-bls-chained","metadata":{"beaconID":"default"}}

real    0m1.206s
```

Also a shame that this isn't a constant or doesn't use one of the constants already in this file, perhaps it should? Without understanding too much about what's going on here this seems odd to hard-wire, I'd love to be able to override it if it's strict by default.