### PR TITLE
Some code cleanups in DKG

### DIFF
--- a/common/key/store.go
+++ b/common/key/store.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/BurntSushi/toml"
+
 	"github.com/drand/drand/v2/common"
 	"github.com/drand/drand/v2/common/log"
 	"github.com/drand/drand/v2/internal/fs"

--- a/internal/dkg/actions_passive.go
+++ b/internal/dkg/actions_passive.go
@@ -64,15 +64,13 @@ func (d *Process) Packet(ctx context.Context, packet *drand.GossipPacket) (*dran
 
 	// if we have aborted or timed out, we actually want to apply the proposal to the last successful state
 	if util.Cont(terminalStates, current.State) {
-		finished, err := d.store.GetFinished(beaconID)
+		current, err = d.store.GetFinished(beaconID)
 		if err != nil {
 			return nil, err
 		}
 
-		if finished == nil {
+		if current == nil {
 			current = NewFreshState(beaconID)
-		} else {
-			current = finished
 		}
 	}
 
@@ -96,7 +94,7 @@ func (d *Process) Packet(ctx context.Context, packet *drand.GossipPacket) (*dran
 	recipients := util.Concat(nextState.Joining, nextState.Remaining, nextState.Leaving)
 	// we ignore the errors here because it's a best effort gossip
 	// however we can continue with execution
-	_, _ = d.gossip(me, recipients, packet)
+	_ = d.gossip(me, recipients, packet)
 	// we could theoretically ignore when the gossip ends, but due to the mutex we're holding it _could_ lead to a race
 	// condition with future requests
 

--- a/internal/net/client_grpc.go
+++ b/internal/net/client_grpc.go
@@ -33,7 +33,7 @@ type grpcClient struct {
 	log           log.Logger
 }
 
-var defaultConnTimeout = 1 * time.Minute
+var defaultConnTimeout = 5 * time.Second
 var defaultHealthTimeout = 3 * time.Second
 
 // NewGrpcClient returns an implementation of an InternalClient  and

--- a/internal/util/participant_utils.go
+++ b/internal/util/participant_utils.go
@@ -1,7 +1,7 @@
 package util
 
 import (
-	"reflect"
+	"bytes"
 	"sort"
 
 	"github.com/drand/drand/v2/common/key"
@@ -40,29 +40,31 @@ func ContainsAll(haystack, needles []*drand.Participant) bool {
 	return true
 }
 
+// Without removes needle from the haystack. Careful: it modifies the input slice but also returns the resulting slice.
+// It removes all instances of needle, and zeros the removed items to allow garbage collection.
 func Without(haystack []*drand.Participant, needle *drand.Participant) []*drand.Participant {
 	if haystack == nil {
 		return nil
 	}
 
-	indexToRemove := -1
-	for i, v := range haystack {
+	// ret will reuse the underlying array of haystack
+	ret := haystack[:0]
+	for _, v := range haystack {
 		if EqualParticipant(v, needle) {
-			indexToRemove = i
+			continue
 		}
+		ret = append(ret, v)
+	}
+	// we let the deleted items get garbage collected
+	for i := len(ret); i < len(haystack); i++ {
+		haystack[i] = nil
 	}
 
-	if indexToRemove == -1 {
-		return haystack
-	}
-
-	if len(haystack) == 1 {
+	if len(ret) == 0 {
 		return nil
 	}
 
-	var ret []*drand.Participant
-	ret = append(ret, haystack[:indexToRemove]...)
-	return append(ret, haystack[indexToRemove+1:]...)
+	return ret
 }
 
 func EqualParticipant(p1, p2 *drand.Participant) bool {
@@ -70,8 +72,8 @@ func EqualParticipant(p1, p2 *drand.Participant) bool {
 		return false
 	}
 	return p1.Address == p2.Address &&
-		reflect.DeepEqual(p1.Key, p2.Key) &&
-		reflect.DeepEqual(p1.Signature, p2.Signature)
+		bytes.Equal(p1.Key, p2.Key) &&
+		bytes.Equal(p1.Signature, p2.Signature)
 }
 
 func PublicKeyAsParticipant(identity *key.Identity) (*drand.Participant, error) {

--- a/internal/util/participant_utils.go
+++ b/internal/util/participant_utils.go
@@ -68,7 +68,7 @@ func Without(haystack []*drand.Participant, needle *drand.Participant) []*drand.
 }
 
 func EqualParticipant(p1, p2 *drand.Participant) bool {
-	// we use the Getters sibce tgey handle the nil cases
+	// we use the Getters since they handle the nil cases
 	return p1.GetAddress() == p2.GetAddress() &&
 		bytes.Equal(p1.GetKey(), p2.GetKey()) &&
 		bytes.Equal(p1.GetSignature(), p2.GetSignature())

--- a/internal/util/participant_utils.go
+++ b/internal/util/participant_utils.go
@@ -68,12 +68,10 @@ func Without(haystack []*drand.Participant, needle *drand.Participant) []*drand.
 }
 
 func EqualParticipant(p1, p2 *drand.Participant) bool {
-	if p1 == nil || p2 == nil {
-		return false
-	}
-	return p1.Address == p2.Address &&
-		bytes.Equal(p1.Key, p2.Key) &&
-		bytes.Equal(p1.Signature, p2.Signature)
+	// we use the Getters sibce tgey handle the nil cases
+	return p1.GetAddress() == p2.GetAddress() &&
+		bytes.Equal(p1.GetKey(), p2.GetKey()) &&
+		bytes.Equal(p1.GetSignature(), p2.GetSignature())
 }
 
 func PublicKeyAsParticipant(identity *key.Identity) (*drand.Participant, error) {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,131 @@
+package util
+
+import (
+	"testing"
+
+	drand "github.com/drand/drand/v2/protobuf/dkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithout(t *testing.T) {
+	t.Run("empty haystack", func(st *testing.T) {
+		empty := make([]*drand.Participant, 0)
+		needle := &drand.Participant{
+			Address: "test",
+		}
+		res := Without(empty, needle)
+		assert.Nil(st, res)
+		assert.NotContains(st, res, needle)
+	})
+	t.Run("emptyied haystack", func(st *testing.T) {
+		list := make([]*drand.Participant, 0)
+		needle := &drand.Participant{
+			Address: "test",
+		}
+		list = append(list, needle)
+		res := Without(list, needle)
+		assert.Nil(st, res)
+		assert.NotContains(st, list, needle)
+	})
+	t.Run("two same items in haystack", func(st *testing.T) {
+		list := make([]*drand.Participant, 0)
+		needle := &drand.Participant{
+			Address: "test",
+		}
+		list = append(list, needle)
+		list = append(list, &drand.Participant{
+			Address: "yolo",
+		})
+		list = append(list, needle)
+		assert.Len(st, list, 3)
+		res := Without(list, needle)
+		assert.Len(st, res, 1)
+		assert.NotContains(st, list, needle)
+	})
+	t.Run("normal usage", func(st *testing.T) {
+		list := make([]*drand.Participant, 0)
+		needle := &drand.Participant{
+			Address: "test",
+		}
+		list = append(list, &drand.Participant{
+			Address: "one",
+		})
+		list = append(list, &drand.Participant{
+			Address: "two",
+		})
+		list = append(list, needle)
+		assert.Len(st, list, 3)
+		res := Without(list, needle)
+		assert.Len(st, res, 2)
+		assert.NotContains(st, list, needle)
+		// the underlying list got its items zeroized
+		assert.Contains(st, list, (*drand.Participant)(nil))
+		assert.Len(st, list, 3)
+	})
+	t.Run("nil needle with nil entries", func(st *testing.T) {
+		list := make([]*drand.Participant, 3)
+		list = append(list, &drand.Participant{
+			Address: "one",
+		})
+		list = append(list, &drand.Participant{
+			Address: "two",
+		})
+		assert.Contains(st, list, (*drand.Participant)(nil))
+		assert.Len(st, list, 5)
+		res := Without(list, nil)
+		assert.Len(st, res, 2)
+		assert.NotContains(st, list, nil)
+		assert.NotContains(st, res, (*drand.Participant)(nil))
+	})
+	t.Run("nil needle", func(st *testing.T) {
+		list := make([]*drand.Participant, 0)
+		list = append(list, &drand.Participant{
+			Address: "one",
+		})
+		list = append(list, &drand.Participant{
+			Address: "two",
+		})
+		assert.Len(st, list, 2)
+		res := Without(list, nil)
+		assert.Len(st, res, 2)
+		assert.NotContains(st, list, nil)
+		assert.NotContains(st, list, (*drand.Participant)(nil))
+	})
+	t.Run("buggy needle", func(st *testing.T) {
+		list := make([]*drand.Participant, 0)
+		needle := &drand.Participant{
+			Key: []byte("lacking an address"),
+		}
+		list = append(list, &drand.Participant{
+			Address: "one",
+		})
+		list = append(list, &drand.Participant{
+			Address: "two",
+		})
+		list = append(list, needle)
+		assert.Len(st, list, 3)
+		res := Without(list, needle)
+		assert.Len(st, res, 2)
+		assert.NotContains(st, list, needle)
+	})
+	t.Run("same address, different keys", func(st *testing.T) {
+		list := make([]*drand.Participant, 0)
+		needle := &drand.Participant{
+			Address: "one",
+			Key:     []byte("an address"),
+		}
+		list = append(list, &drand.Participant{
+			Address: "one",
+			Key:     []byte("another different address"),
+		})
+		list = append(list, &drand.Participant{
+			Address: "two",
+		})
+		list = append(list, needle)
+		assert.Len(st, list, 3)
+		res := Without(list, needle)
+		assert.Len(st, res, 2)
+		assert.NotContains(st, list, needle)
+		assert.NotContains(st, res, needle)
+	})
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -32,28 +32,61 @@ func TestWithout(t *testing.T) {
 		needle := &drand.Participant{
 			Address: "test",
 		}
-		list = append(list, needle)
-		list = append(list, &drand.Participant{
-			Address: "yolo",
-		})
-		list = append(list, needle)
+		list = append(list, needle,
+			&drand.Participant{Address: "yolo"},
+			needle)
 		assert.Len(st, list, 3)
 		res := Without(list, needle)
 		assert.Len(st, res, 1)
 		assert.NotContains(st, list, needle)
 	})
-	t.Run("normal usage", func(st *testing.T) {
+	t.Run("normal usage needle in the beginning", func(st *testing.T) {
 		list := make([]*drand.Participant, 0)
 		needle := &drand.Participant{
 			Address: "test",
 		}
-		list = append(list, &drand.Participant{
-			Address: "one",
-		})
-		list = append(list, &drand.Participant{
-			Address: "two",
-		})
-		list = append(list, needle)
+		list = append(list,
+			needle,
+			&drand.Participant{Address: "one"},
+			&drand.Participant{Address: "two"},
+			&drand.Participant{Address: "three"},
+		)
+		assert.Len(st, list, 4)
+		res := Without(list, needle)
+		assert.Len(st, res, 3)
+		assert.NotContains(st, list, needle)
+		// the underlying list got its items zeroized
+		assert.Contains(st, list, (*drand.Participant)(nil))
+		assert.Len(st, list, 4)
+	})
+	t.Run("normal usage needle in the end", func(st *testing.T) {
+		list := make([]*drand.Participant, 0)
+		needle := &drand.Participant{
+			Address: "test",
+		}
+		list = append(list,
+			&drand.Participant{Address: "one"},
+			&drand.Participant{Address: "two"},
+			needle,
+		)
+		assert.Len(st, list, 3)
+		res := Without(list, needle)
+		assert.Len(st, res, 2)
+		assert.NotContains(st, list, needle)
+		// the underlying list got its items zeroized
+		assert.Contains(st, list, (*drand.Participant)(nil))
+		assert.Len(st, list, 3)
+	})
+	t.Run("normal usage needle in the middle", func(st *testing.T) {
+		list := make([]*drand.Participant, 0)
+		needle := &drand.Participant{
+			Address: "test",
+		}
+		list = append(list,
+			&drand.Participant{Address: "one"},
+			needle,
+			&drand.Participant{Address: "two"},
+		)
 		assert.Len(st, list, 3)
 		res := Without(list, needle)
 		assert.Len(st, res, 2)

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -17,7 +17,7 @@ func TestWithout(t *testing.T) {
 		assert.Nil(st, res)
 		assert.NotContains(st, res, needle)
 	})
-	t.Run("emptyied haystack", func(st *testing.T) {
+	t.Run("emptied haystack", func(st *testing.T) {
 		list := make([]*drand.Participant, 0)
 		needle := &drand.Participant{
 			Address: "test",

--- a/test/regression/regression_test.go
+++ b/test/regression/regression_test.go
@@ -193,6 +193,9 @@ func TestMigrateOldGroupFile(t *testing.T) {
 
 //nolint:funlen
 func TestLeaverNodeDownDoesntFailProposal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	n := 3
 
 	// we create a few nodes on v1.5.7


### PR DESCRIPTION
This does a few things:
- changing `util.Without` to delete all instances of needle, not just the last one, it also now does so without a single allocation
- we don't need a `done` channel to signal when we are done if we can simply close the `error` channel instead, changing gossip accordingly
- removed constants from `sendToPeer`
- reduced allocations in `Packet`