### PR TITLE
Misc nice to have changes

### DIFF
--- a/internal/core/drand_beacon.go
+++ b/internal/core/drand_beacon.go
@@ -385,12 +385,8 @@ func (bp *BeaconProcess) createDBStore(ctx context.Context) (chain.Store, error)
 		dbStore, err = pgdb.NewStore(ctx, bp.log, bp.opts.pgConn, beaconName)
 
 	default:
-		bp.log.Error("unknown database storage engine type", bp.opts.dbStorageEngine)
-
-		dbPath := bp.opts.DBFolder(beaconName)
-		fs.CreateSecureFolder(dbPath)
-
-		dbStore, err = boltdb.NewBoltStore(ctx, bp.log, dbPath, bp.opts.boltOpts)
+		// we default to "bolt" in the storageTypeFlag, so we return an error to alert users trying to use invalid DB
+		return nil, fmt.Errorf("unknown database storage engine type %q", bp.opts.dbStorageEngine)
 	}
 
 	bp.dbStore = dbStore

--- a/internal/drand-cli/cli.go
+++ b/internal/drand-cli/cli.go
@@ -329,8 +329,8 @@ var appCommands = []*cli.Command{
 				return fmt.Errorf("unable to self-sign using new format for keys, check your installation. Err: %w", err)
 			}
 
+			// everything seems fine, we can start
 			banner(c.App.Writer)
-			// l := log.New(nil, logLevel(c), logJSON(c))
 			return startCmd(c, l)
 		},
 	},

--- a/internal/drand-cli/cli.go
+++ b/internal/drand-cli/cli.go
@@ -51,9 +51,26 @@ func banner(w io.Writer) {
 }
 
 var folderFlag = &cli.StringFlag{
-	Name:    "folder",
-	Value:   core.DefaultConfigFolder(),
-	Usage:   "Folder to keep all drand cryptographic information, with absolute path.",
+	Name:  "folder",
+	Value: core.DefaultConfigFolder(),
+	Usage: "Folder to keep all drand cryptographic information, with absolute path.",
+	Action: func(c *cli.Context, path string) error {
+		l := log.New(nil, logLevel(c), logJSON(c))
+		l.Infow("Using non-default path", "folder", path)
+
+		// tries to write a temp file to the path to check write permission.
+		tempFile, err := os.CreateTemp(path, "drandtestwrite-")
+		if err != nil {
+			return fmt.Errorf("unable to write to specified folder: %w", err)
+		}
+		tempFile.Close()
+		os.Remove(tempFile.Name()) // Clean up after test
+
+		// tries to read from the directory to check read permission,
+		// because yes, it is possible to have write but not read permissions
+		_, err = os.ReadDir(path)
+		return err
+	},
 	EnvVars: []string{"DRAND_FOLDER"},
 }
 
@@ -300,19 +317,21 @@ var appCommands = []*cli.Command{
 			skipValidationFlag, jsonFlag, beaconIDFlag,
 			storageTypeFlag, pgDSNFlag, memDBSizeFlag, hiddenInsecureFlag),
 		Action: func(c *cli.Context) error {
-			banner(c.App.Writer)
 			l := log.New(nil, logLevel(c), logJSON(c))
-			return startCmd(c, l)
-		},
-		Before: func(c *cli.Context) error {
-			l := log.New(nil, logLevel(c), logJSON(c))
+
+			// check multibeacon and complain migration wasn't done in v1 if not
+			if err := checkMigration(c, l); err != nil {
+				return err
+			}
 
 			// v1.5.7 -> v2.0.0 migration path
 			if err := selfSign(c, l); err != nil {
 				return fmt.Errorf("unable to self-sign using new format for keys, check your installation. Err: %w", err)
 			}
 
-			return checkMigration(c, l)
+			banner(c.App.Writer)
+			// l := log.New(nil, logLevel(c), logJSON(c))
+			return startCmd(c, l)
 		},
 	},
 	{
@@ -972,7 +991,7 @@ func contextToConfig(c *cli.Context, l log.Logger) *core.Config {
 			core.WithMemDBSize(c.Int(memDBSizeFlag.Name)),
 		)
 	default:
-		opts = append(opts, core.WithDBStorageEngine(chain.BoltDB))
+		// we have a default to "bolt" in storageTypeFlag, we don't set it if it's invalid so that users are alerted
 	}
 
 	conf := core.NewConfig(l, opts...)


### PR DESCRIPTION
Not doing it for the default path ~/.drand, because if a user can't write to their home directory they got issues anyway

Also preventing invalid -db values to start with bolt without erroring.