### PR TITLE
Enforce a deterministic msg in dkg packet verification

### DIFF
--- a/internal/core/drand_daemon_control.go
+++ b/internal/core/drand_daemon_control.go
@@ -178,6 +178,7 @@ func (dd *DrandDaemon) ListBeaconIDs(ctx context.Context, _ *drand.ListBeaconIDs
 
 	metas := make([]*drand.Metadata, 0, len(dd.chainHashes))
 	for chainHex, id := range dd.chainHashes {
+		dd.log.Debugw("processing", "chainhex", chainHex, "id", id)
 		if chainHex == common.DefaultChainHash {
 			continue
 		}
@@ -192,6 +193,8 @@ func (dd *DrandDaemon) ListBeaconIDs(ctx context.Context, _ *drand.ListBeaconIDs
 			ChainHash:   chain,
 		})
 	}
+
+	dd.log.Debugw("responding to ListBeaconIDs request", "metas", metas, "ids", ids)
 
 	return &drand.ListBeaconIDsResponse{Ids: ids, Metadatas: metas}, nil
 }

--- a/internal/dkg/actions_passive.go
+++ b/internal/dkg/actions_passive.go
@@ -95,7 +95,7 @@ func (d *Process) applyPacketToState(beaconID string, packet *drand.GossipPacket
 	}
 
 	// we must verify the message against the next state, as the current state upon first proposal will be empty
-	err = d.verifyMessage(packet, packet.Metadata, termsFromState(nextState))
+	err = d.verifyMessage(packet, termsFromState(nextState))
 	if err != nil {
 		return fmt.Errorf("invalid packet signature from %s: %w", packet.Metadata.Address, err)
 	}

--- a/internal/dkg/actions_signing.go
+++ b/internal/dkg/actions_signing.go
@@ -75,7 +75,11 @@ func (d *Process) verifyMessage(packet *drand.GossipPacket, proposal *drand.Prop
 	msg := messageForSigning(beaconID, packet, proposal)
 	err = kp.Scheme().AuthScheme.Verify(pubPoint, msg, sig)
 	if err != nil {
-		return fmt.Errorf("error verifying '%s' packet with msg '%s' and metadata '%s': %w ", packetName(packet), hex.EncodeToString(msg), packet.GetMetadata(), err)
+		return fmt.Errorf("error verifying '%s' packet with msg '%s' and metadata '%s': %w ",
+			packetName(packet),
+			hex.EncodeToString(msg),
+			packet.GetMetadata(),
+			err)
 	}
 	return nil
 }
@@ -109,8 +113,9 @@ func messageForSigning(beaconID string, packet *drand.GossipPacket, proposal *dr
 	default:
 		// this is impossible in theory: there are checks erroring out much earlier
 		// so if we get an unknown packet type we make sure signature verification fails
-		ensureFailure := make([]byte, 64)
-		rand.Reader.Read(ensureFailure)
+		//nolint:mnd
+		ensureFailure := make([]byte, 16)
+		_, _ = rand.Reader.Read(ensureFailure)
 		ret.Write(ensureFailure)
 	}
 

--- a/internal/dkg/broadcast.go
+++ b/internal/dkg/broadcast.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"sync"
 
-	commonutils "github.com/drand/drand/v2/common"
 	"github.com/drand/drand/v2/common/log"
 	"github.com/drand/drand/v2/common/tracer"
 	"github.com/drand/drand/v2/crypto"
@@ -53,7 +52,6 @@ type echoBroadcast struct {
 	ctx context.Context
 	sync.Mutex
 	l        log.Logger
-	version  commonutils.Version
 	beaconID string
 	// responsible for sending out the messages
 	dispatcher *dispatcher
@@ -75,7 +73,6 @@ func newEchoBroadcast(
 	ctx context.Context,
 	client net.DKGClient,
 	l log.Logger,
-	version commonutils.Version,
 	beaconID string,
 	own string,
 	to []*pdkg.Participant,
@@ -90,7 +87,6 @@ func newEchoBroadcast(
 	return &echoBroadcast{
 		ctx:        ctx,
 		l:          l.Named("echoBroadcast"),
-		version:    version,
 		beaconID:   beaconID,
 		dispatcher: newDispatcher(ctx, client, l, to, own),
 		dealCh:     make(chan dkg.DealBundle, len(to)),

--- a/internal/dkg/broadcast_test.go
+++ b/internal/dkg/broadcast_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/drand/drand/v2/common"
 	"github.com/drand/drand/v2/common/testlogger"
 	"github.com/drand/drand/v2/crypto"
 	"github.com/drand/drand/v2/internal/net"
@@ -23,7 +22,6 @@ func TestNewBroadcasterWithNoParticipantsFails(t *testing.T) {
 		ctx,
 		gateway.DKGClient,
 		l,
-		common.GetAppVersion(),
 		"default",
 		"127.0.0.1:8080",
 		[]*drand.Participant{},
@@ -43,7 +41,6 @@ func TestNewBroadcasterWithParticipantsDoesNotFail(t *testing.T) {
 		ctx,
 		gateway.DKGClient,
 		l,
-		common.GetAppVersion(),
 		"default",
 		"127.0.0.1:8080",
 		[]*drand.Participant{

--- a/internal/dkg/execution.go
+++ b/internal/dkg/execution.go
@@ -83,7 +83,6 @@ func (d *Process) setupDKG(ctx context.Context, beaconID string) (*dkg.Config, e
 		ctx,
 		d.internalClient,
 		d.log,
-		common.GetAppVersion(),
 		beaconID,
 		me.Address,
 		sortedParticipants,

--- a/internal/dkg/state_machine.go
+++ b/internal/dkg/state_machine.go
@@ -706,8 +706,8 @@ func hasTimedOut(details *DBState) bool {
 }
 
 func ValidateProposal(currentState *DBState, terms *drand.ProposalTerms) error {
-	err := validateForAllDKGs(currentState, terms)
-	if err != nil {
+
+	if err := validateForAllDKGs(currentState, terms); err != nil {
 		return err
 	}
 
@@ -724,10 +724,10 @@ func ValidateProposal(currentState *DBState, terms *drand.ProposalTerms) error {
 	// nodes joining after the first epoch accept some things at face value
 	// nodes already in the network shouldn't accept e.g. a change of genesis time
 	if currentState.State != Fresh {
-		err = validateReshareForRemainers(currentState, terms)
+		return validateReshareForRemainers(currentState, terms)
 	}
 
-	return err
+	return nil
 }
 
 func validateForAllDKGs(currentState *DBState, terms *drand.ProposalTerms) error {

--- a/internal/dkg/state_machine.go
+++ b/internal/dkg/state_machine.go
@@ -706,7 +706,6 @@ func hasTimedOut(details *DBState) bool {
 }
 
 func ValidateProposal(currentState *DBState, terms *drand.ProposalTerms) error {
-
 	if err := validateForAllDKGs(currentState, terms); err != nil {
 		return err
 	}


### PR DESCRIPTION
We need to ensure the messages we are signing during the DKG process are encoded in the same way on both the signer and verifiers no matter what version or build of drand they are using.

This is building an explicit message instead of using the `String()` methods from protobuf which are not stable nor consistent across builds.