### PR TITLE
Do not send randomness over the wire, compute it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,8 @@ issues:
     - path: internal/core/drand_proxy.go
       linters:
         - nilnil
+    - path: internal/core/drand_proxy.go
+      text: "SA1019" # we need to use the deprecated Randomness field
 run:
   skip-dirs:
     - demo

--- a/internal/core/convert.go
+++ b/internal/core/convert.go
@@ -10,6 +10,5 @@ func beaconToProto(b *common.Beacon) *drand.PublicRandResponse {
 		Round:             b.Round,
 		Signature:         b.Signature,
 		PreviousSignature: b.PreviousSig,
-		Randomness:        b.Randomness(),
 	}
 }

--- a/internal/core/drand_proxy.go
+++ b/internal/core/drand_proxy.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/drand/drand/v2/crypto"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/proto"
@@ -37,8 +38,11 @@ func (d *drandProxy) Get(ctx context.Context, round uint64) (client.Result, erro
 	if err != nil {
 		return nil, err
 	}
-	// we don't need to return the metadata
+	// we don't need to return the metadata to the public
 	resp.Metadata = nil
+	// we need to set the randomness now since it isn't sent over the wire anymore in V2
+	resp.Randomness = crypto.RandomnessFromSignature(resp.GetSignature())
+
 	return resp, err
 }
 

--- a/internal/core/drand_proxy.go
+++ b/internal/core/drand_proxy.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/drand/drand/v2/crypto"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/protobuf/proto"
@@ -13,6 +12,7 @@ import (
 	"github.com/drand/drand/v2/common"
 	chain2 "github.com/drand/drand/v2/common/chain"
 	"github.com/drand/drand/v2/common/client"
+	"github.com/drand/drand/v2/crypto"
 	"github.com/drand/drand/v2/protobuf/drand"
 )
 


### PR DESCRIPTION
We need to delegate computing it to clients/v1 relays instead of still sending it over the wire.