### PR TITLE
Display `insecure` in the version when building without TLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ build:
 
 # create the "drand" binary in the current folder without TLS connections, useful for tests.
 build_insecure:
-	go build -tags conn_insecure -o drand -mod=readonly -ldflags "-X $(VER_PACKAGE).COMMIT=$(GIT_REVISION) -X $(VER_PACKAGE).BUILDDATE=$(BUILD_DATE) -X $(CLI_PACKAGE).buildDate=$(BUILD_DATE) -X $(CLI_PACKAGE).gitCommit=$(GIT_REVISION)" ./cmd/drand
+	go build -tags conn_insecure -o drand -mod=readonly -ldflags "-X $(VER_PACKAGE).COMMIT=$(GIT_REVISION) -X $(VER_PACKAGE).BUILDDATE=$(BUILD_DATE) -X $(VER_PACKAGE).BUILDTAGS=insecure -X $(CLI_PACKAGE).buildDate=$(BUILD_DATE) -X $(CLI_PACKAGE).gitCommit=$(GIT_REVISION)" ./cmd/drand
 
 build_all: drand
 

--- a/common/version.go
+++ b/common/version.go
@@ -70,7 +70,7 @@ func (v Version) String() string {
 		pre += "-insecure"
 	}
 	if v.Prerelease != "" {
-		pre = "-"
+		pre += "-"
 	}
 	return fmt.Sprintf("%d.%d.%d%s%s", v.Major, v.Minor, v.Patch, pre, v.Prerelease)
 }

--- a/common/version.go
+++ b/common/version.go
@@ -25,6 +25,7 @@ var version = Version{
 var (
 	COMMIT    = ""
 	BUILDDATE = ""
+	BUILDTAGS = ""
 )
 
 func GetAppVersion() Version {
@@ -66,6 +67,9 @@ func (v Version) String() string {
 	pre := ""
 	if v.Prerelease != "" {
 		pre = "-"
+	}
+	if BUILDTAGS != "" {
+		pre += "insecure-"
 	}
 	return fmt.Sprintf("%d.%d.%d%s%s", v.Major, v.Minor, v.Patch, pre, v.Prerelease)
 }

--- a/common/version.go
+++ b/common/version.go
@@ -13,7 +13,7 @@ import (
 var version = Version{
 	Major:      2,
 	Minor:      0,
-	Patch:      1,
+	Patch:      2,
 	Prerelease: "",
 }
 
@@ -65,11 +65,11 @@ func (v Version) ToProto() *pbcommon.NodeVersion {
 
 func (v Version) String() string {
 	pre := ""
+	if BUILDTAGS != "" {
+		pre += "-insecure"
+	}
 	if v.Prerelease != "" {
 		pre = "-"
-	}
-	if BUILDTAGS != "" {
-		pre += "insecure-"
 	}
 	return fmt.Sprintf("%d.%d.%d%s%s", v.Major, v.Minor, v.Patch, pre, v.Prerelease)
 }

--- a/common/version.go
+++ b/common/version.go
@@ -3,6 +3,7 @@ package common
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	pbcommon "github.com/drand/drand/v2/protobuf/drand"
 )
@@ -65,7 +66,7 @@ func (v Version) ToProto() *pbcommon.NodeVersion {
 
 func (v Version) String() string {
 	pre := ""
-	if BUILDTAGS != "" {
+	if strings.Contains(BUILDTAGS, "insecure") {
 		pre += "-insecure"
 	}
 	if v.Prerelease != "" {

--- a/common/version_test.go
+++ b/common/version_test.go
@@ -242,5 +242,4 @@ func TestVersionBuildTags(t *testing.T) {
 			t.Fatalf("Incorrct matching string. Actual: %s, expected: %s", actual, tt.expected)
 		}
 	}
-
 }

--- a/common/version_test.go
+++ b/common/version_test.go
@@ -239,7 +239,7 @@ func TestVersionBuildTags(t *testing.T) {
 			t.Fatalf("Incorrect version string. Actual: %s, expected: %s", actual, tt.expected)
 		}
 		if actual == tt.expected && !tt.shouldWork {
-			t.Fatalf("Incorrct matching string. Actual: %s, expected: %s", actual, tt.expected)
+			t.Fatalf("Incorrect matching string. Actual: %s, expected: %s", actual, tt.expected)
 		}
 	}
 }

--- a/common/version_test.go
+++ b/common/version_test.go
@@ -182,3 +182,65 @@ func TestVersionCompatible(tm *testing.T) {
 		})
 	}
 }
+
+func TestVersionBuildTags(t *testing.T) {
+	for _, tt := range []struct {
+		version    Version
+		expected   string
+		buildtags  string
+		shouldWork bool
+	}{
+		{
+			version123pre,
+			"1.2.3-pre",
+			"",
+			true,
+		},
+		{
+			version123pre,
+			"1.2.3-pre",
+			"conn_insecure",
+			false,
+		},
+		{
+			version123pre,
+			"1.2.3-insecure-pre",
+			"conn_insecure",
+			true,
+		},
+		{
+			version123,
+			"1.2.3-insecure",
+			"conn_insecure",
+			true,
+		},
+		{
+			version205,
+			"2.0.5",
+			"conn_insecure",
+			false,
+		},
+		{
+			version205,
+			"2.0.5-insecure",
+			"conn_insecure",
+			true,
+		},
+		{
+			version200pre,
+			"2.0.0-pre",
+			"verysecure",
+			true,
+		},
+	} {
+		BUILDTAGS = tt.buildtags
+		actual := tt.version.String()
+		if actual != tt.expected && tt.shouldWork {
+			t.Fatalf("Incorrect version string. Actual: %s, expected: %s", actual, tt.expected)
+		}
+		if actual == tt.expected && !tt.shouldWork {
+			t.Fatalf("Incorrct matching string. Actual: %s, expected: %s", actual, tt.expected)
+		}
+	}
+
+}


### PR DESCRIPTION
This ensures that a drand daemon built with the `insecure` tag will say so in its version output.