### PR TITLE
Prevent our regression tests using the empty string as a DB type

### DIFF
--- a/demo/node/node_subprocess.go
+++ b/demo/node/node_subprocess.go
@@ -142,6 +142,8 @@ func (n *NodeProc) setup() {
 func (n *NodeProc) Start(dbEngineType chain.StorageType, pgDSN func() string, memDBSize int) error {
 	if dbEngineType != "" {
 		n.dbEngineType = dbEngineType
+	} else {
+		n.dbEngineType = chain.BoltDB
 	}
 	if pgDSN != nil {
 		n.pgDSN = pgDSN()


### PR DESCRIPTION
This should fix the issues we've had with our regression tests since the V2 merge into master.