### PR TITLE
Honor gRPC requests for next beacon

### DIFF
--- a/internal/drand-cli/cli_test.go
+++ b/internal/drand-cli/cli_test.go
@@ -329,7 +329,7 @@ func TestStartWithoutGroup(t *testing.T) {
 	go func() {
 		err := CLI().Run(startArgs)
 		if err != nil {
-			t.Errorf(err.Error())
+			t.Error(err)
 		}
 	}()
 

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -58,24 +58,24 @@ func TestCopyFolder(t *testing.T) {
 	subFolder2Path := path.Join(folder2Path, "folder2")
 
 	if err := CreateSecureFolder(subFolder1Path); err == "" {
-		t.Errorf(err)
+		t.Error("bad permissions", subFolder1Path)
 	}
 	if err := CreateSecureFolder(subFolder2Path); err == "" {
-		t.Errorf(err)
+		t.Error("bad permissions", subFolder2Path)
 	}
 
 	if err := CopyFolder(folder1Path, subFolder2Path); err != nil {
-		t.Errorf(err.Error())
+		t.Error("error copying folders", err)
 	}
 
 	folders, err := Folders(subFolder2Path)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err)
 	}
 
 	for _, fd := range folders {
 		if fd != path.Join(subFolder2Path, "folder1") {
-			t.Errorf("folder1 should be inside subFolder2 path")
+			t.Error("folder1 should be inside subFolder2 path")
 		}
 	}
 }


### PR DESCRIPTION
Since the relays are now talking gRPC it can happen the beacon hasn't yet been aggregated when a requests arrives. 
This is the equivalent of https://github.com/drand/drand/blob/ba859437579cd65e7f445a339ec140bcadd9264c/handler/http/server.go#L327-L366 but using our callback mechanism instead of channels and mutexes.

I'm not 100% convinced by my solution and I could probably achieve a better design on the relay side of things by relying on a PublicRandStream and doing the waiting on the relay side of things. 
WDYT? 