### PR TITLE
Fixing panic in callback called twice for next beacon

### DIFF
--- a/common/time.go
+++ b/common/time.go
@@ -14,7 +14,7 @@ const maxTimeBuffer = int64(1 << timeBufferBits)
 // specified.
 const TimeOfRoundErrorValue = math.MaxInt64 - maxTimeBuffer
 
-// TimeOfRound is returning the time the current round should happen
+// TimeOfRound is returning the time the `round` should happen
 func TimeOfRound(period time.Duration, genesis int64, round uint64) int64 {
 	if round == 0 {
 		return genesis

--- a/common/version.go
+++ b/common/version.go
@@ -14,7 +14,7 @@ import (
 var version = Version{
 	Major:      2,
 	Minor:      0,
-	Patch:      2,
+	Patch:      4,
 	Prerelease: "",
 }
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - 9080:9080
     environment:
       PORT: 8080
+
 volumes:
   drand:
     external: true
-

--- a/internal/core/drand_beacon_public.go
+++ b/internal/core/drand_beacon_public.go
@@ -65,6 +65,7 @@ func (bp *BeaconProcess) PublicRand(ctx context.Context, in *drand.PublicRandReq
 		if err != nil {
 			_ = copy(rnd, beaconResp.GetRandomness())
 		}
+		cbId := addr + hex.EncodeToString(rnd)
 		var mu sync.Mutex
 		// the closed bool is only ever called if the same callback is re-added,
 		// this has 0 chances of happening thanks to the rnd in the callback ID.
@@ -75,7 +76,7 @@ func (bp *BeaconProcess) PublicRand(ctx context.Context, in *drand.PublicRandReq
 				return
 			}
 			// we can remove our callback as soon as it's executing once
-			bp.beacon.Store().RemoveCallback(addr + hex.EncodeToString(rnd))
+			bp.beacon.Store().RemoveCallback(cbId)
 
 			if b.GetRound() == wanted {
 				waitlist <- b
@@ -84,11 +85,11 @@ func (bp *BeaconProcess) PublicRand(ctx context.Context, in *drand.PublicRandReq
 			close(waitlist)
 			cancel()
 		}
-		bp.beacon.Store().AddCallback(addr+hex.EncodeToString(rnd), fn)
+		bp.beacon.Store().AddCallback(cbId, fn)
 		select {
 		case <-ctx.Done():
 			// make sure to remove callback, noop if already removed
-			bp.beacon.Store().RemoveCallback(addr + hex.EncodeToString(rnd))
+			bp.beacon.Store().RemoveCallback(cbId)
 			return nil, fmt.Errorf("ctx Done in PublicRand waiting for next beacon: %w", ctx.Err())
 		case b, ok := <-waitlist:
 			if ok {
@@ -99,7 +100,7 @@ func (bp *BeaconProcess) PublicRand(ctx context.Context, in *drand.PublicRandReq
 		case <-time.After(bp.group.Period + time.Second):
 			// we cancel after period+1s since we should never wait so long anyway
 			cancel()
-			bp.beacon.Store().RemoveCallback(addr + hex.EncodeToString(rnd))
+			bp.beacon.Store().RemoveCallback(cbId)
 			return nil, fmt.Errorf("waited too long for next beacon %d", wanted)
 		}
 	} else if wanted > 0 {


### PR DESCRIPTION
~~This is a more stupid way of doing it. I didn't want to do that initially because I'm worried about the aggregation latency of \~400-700ms conflicting with the sleep, so using a callback which is guaranteed to be called when the next round is produced seemed much cleaner.~~

~~I'm tempted to do a +1 on the targetTime to mitigate for that.~~

Okay, ignore my first commit, I reverted to a callback to avoid the above problem, but now it's got a mutex and the impossible $2^{-128}$ edge case is removed.
Also changed the way the context and cancellations are handled.
All edgecases should also be covered now.