### PR TITLE
Use `go-drand:latest` in network scripts

### DIFF
--- a/docker/start-network-with-nginx.sh
+++ b/docker/start-network-with-nginx.sh
@@ -13,7 +13,7 @@ docker compose --file docker-compose-nginx.yml down
 
 # then let's create a volume for the nginx drand node and put a keypair on it pointing to the grpc port
 docker volume create drand_docker_demo_drand
-docker run --rm --volume drand_docker_demo_drand:/data/drand ghcr.io/drand/go-drand:v2.0.2 generate-keypair --folder /data/drand/.drand --id default drand_docker_demo-nginx:81
+docker run --rm --volume drand_docker_demo_drand:/data/drand ghcr.io/drand/go-drand:latest generate-keypair --folder /data/drand/.drand --id default drand_docker_demo-nginx:81
 docker compose --file docker-compose-nginx.yml up --detach
 
 # start the resharing as leader

--- a/docker/start-network.sh
+++ b/docker/start-network.sh
@@ -2,7 +2,7 @@
 
 
 num_of_nodes=3
-docker_image_version=v2.0.5
+docker_image_version=latest
 
 ### first we check if docker and docker-compose are installed
 


### PR DESCRIPTION
Now that the `latest` tag [is available in the registry](https://github.com/drand/drand/commit/ab7d378aed20d1461382481e70c1982ff2277a49#diff-f19282b5176e32c52fe46db7e7522d9b16710ece9e48cfaffd0a2d0a2b088fc6), let's use it so there is no need to constantly bump these versions manually.