### PR TITLE
perf(beacon): validate group membership before BLS verification in ProcessPartialBeacon

### DIFF
--- a/internal/chain/beacon/node.go
+++ b/internal/chain/beacon/node.go
@@ -146,10 +146,6 @@ func (h *Handler) ProcessPartialBeacon(ctx context.Context, p *proto.PartialBeac
 		return new(proto.Empty), nil
 	}
 
-	span.AddEvent("h.crypto.DigestBeacon")
-	msg := h.crypto.DigestBeacon(&common.Beacon{Round: pRound, PreviousSig: p.GetPreviousSignature()})
-	span.AddEvent("h.crypto.DigestBeacon - done")
-
 	idx, err := h.crypto.ThresholdScheme.IndexOf(p.GetPartialSig())
 	if err != nil {
 		span.RecordError(err)
@@ -176,6 +172,11 @@ func (h *Handler) ProcessPartialBeacon(ctx context.Context, p *proto.PartialBeac
 		h.l.Warnw("received a partial with our own index", "partial", pRound, "from", addr)
 		return nil, fmt.Errorf("invalid self index %d in partial with msg %v partial_round %v", idx, msg, pRound)
 	}
+
+	// BLS verification
+	span.AddEvent("h.crypto.DigestBeacon")
+	msg := h.crypto.DigestBeacon(&common.Beacon{Round: pRound, PreviousSig: p.GetPreviousSignature()})
+	span.AddEvent("h.crypto.DigestBeacon - done")
 
 	// verify if request is valid
 	span.AddEvent("h.crypto.ThresholdScheme.VerifyPartial")


### PR DESCRIPTION
Move the group membership validation check before the expensive BLS signature verification in ProcessPartialBeacon. This improves performance by failing fast when receiving partials from nodes not in the group file, avoiding
unnecessary cryptographic operations.

The change reorders the validation steps to:
1. Validate round number
2. Get node index from signature
3. Check if node is in group
4. Only then perform BLS verification

This addresses issue #1178 which noted that partials from nodes not in the group file were being processed too long before rejection.