### PR TITLE
Fixing our large timing discrepancy issue

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -14,7 +14,7 @@ import (
 var version = Version{
 	Major:      2,
 	Minor:      1,
-	Patch:      1,
+	Patch:      2,
 	Prerelease: "",
 }
 

--- a/internal/chain/beacon/node.go
+++ b/internal/chain/beacon/node.go
@@ -126,6 +126,10 @@ func (h *Handler) ProcessPartialBeacon(ctx context.Context, p *proto.PartialBeac
 
 	addr := net.RemoteAddress(ctx)
 	pRound := p.GetRound()
+	span.SetAttributes(
+		attribute.Int64("round", int64(pRound)),
+		attribute.String("addr", addr),
+	)
 	h.l.Debugw("Processing PartialBeacon", "from", addr, "round", pRound)
 
 	nextRound, _ := common.NextRound(h.conf.Clock.Now().Unix(), h.conf.Group.Period, h.conf.Group.GenesisTime)
@@ -136,6 +140,8 @@ func (h *Handler) ProcessPartialBeacon(ctx context.Context, p *proto.PartialBeac
 	// clock passed to the next round
 	if pRound > nextRound {
 		h.l.Errorw("ignoring future partial", "from", addr, "round", pRound, "current_round", currentRound)
+		span.RecordError(fmt.Errorf("ignoring future partial"))
+
 		return nil, fmt.Errorf("invalid round: %d instead of %d", pRound, currentRound)
 	}
 
@@ -143,6 +149,7 @@ func (h *Handler) ProcessPartialBeacon(ctx context.Context, p *proto.PartialBeac
 	if latest, err := h.chain.Last(ctx); err == nil && pRound <= latest.GetRound() {
 		h.l.Debugw("ignoring past partial", "from", addr, "round", pRound, "current_round", currentRound, "latestStored", latest.GetRound())
 		span.RecordError(fmt.Errorf("invalid past partial"))
+
 		return new(proto.Empty), nil
 	}
 
@@ -154,12 +161,14 @@ func (h *Handler) ProcessPartialBeacon(ctx context.Context, p *proto.PartialBeac
 	if err != nil {
 		span.RecordError(err)
 		h.l.Errorw("invalid index for partial", "from", addr, "err", err)
+
 		return nil, err
 	}
 	if idx < 0 {
 		err := fmt.Errorf("invalid index %d in partial with msg %v partial_round %v", idx, msg, pRound)
 		span.RecordError(err)
 		h.l.Errorw("error", "err", err)
+
 		return nil, err
 	}
 
@@ -168,13 +177,16 @@ func (h *Handler) ProcessPartialBeacon(ctx context.Context, p *proto.PartialBeac
 		err := fmt.Errorf("attempted to process beacon from node of index %d, but it was not in the group file", uint32(idx))
 		span.RecordError(err)
 		h.l.Errorw("error", "err", err)
+
 		return nil, err
 	}
 
 	nodeName := node.Address()
 	if nodeName == h.addr {
-		h.l.Warnw("received a partial with our own index", "partial", pRound, "from", addr)
-		return nil, fmt.Errorf("invalid self index %d in partial with msg %v partial_round %v", idx, msg, pRound)
+		h.l.Warnw("received a partial with our own address", "partial", pRound, "from", addr)
+		span.RecordError(fmt.Errorf("invalid own address in received partial"))
+
+		return nil, fmt.Errorf("invalid own index %d in partial with msg %v partial_round %v", idx, msg, pRound)
 	}
 
 	// verify if request is valid
@@ -192,6 +204,7 @@ func (h *Handler) ProcessPartialBeacon(ctx context.Context, p *proto.PartialBeac
 			"from_idx", idx,
 			"from_node", nodeName)
 		span.RecordError(err)
+
 		return nil, err
 	}
 
@@ -215,6 +228,7 @@ func (h *Handler) ProcessPartialBeacon(ctx context.Context, p *proto.PartialBeac
 		return new(proto.Empty), nil
 	}
 
+	span.AddEvent("h.chain.NewValidPartial")
 	h.chain.NewValidPartial(ctx, addr, p)
 	return new(proto.Empty), nil
 }

--- a/internal/chain/beacon/node.go
+++ b/internal/chain/beacon/node.go
@@ -120,6 +120,8 @@ func NewHandler(ctx context.Context, c net.ProtocolClient, s chain.Store, conf *
 
 // ProcessPartialBeacon receives a request for a beacon partial signature. It
 // forwards it to the round manager if it is a valid beacon.
+//
+//nolint:funlen
 func (h *Handler) ProcessPartialBeacon(ctx context.Context, p *proto.PartialBeaconPacket) (*proto.Empty, error) {
 	ctx, span := tracer.NewSpan(ctx, "h.ProcessPartialBeacon")
 	defer span.End()

--- a/internal/chain/beacon/ticker.go
+++ b/internal/chain/beacon/ticker.go
@@ -65,7 +65,7 @@ func (t *ticker) Start() {
 		now := t.clock.Now().Unix()
 		_, ttime := common.NextRound(now, t.period, t.genesis)
 		if ttime > now {
-			t.clock.Sleep(time.Duration(ttime-now) * time.Second)
+			t.clock.Sleep(t.clock.Until(time.Unix(ttime, 0)))
 		}
 		// first tick happens at specified time
 		chanTime <- t.clock.Now()


### PR DESCRIPTION
I've discovered the culprit for our relatively large timing discrepancy in beacon production!

We were starting our ticker after waiting a given number of seconds without distinguishing whether the current second was already ticking or not. This PR adds extra tracing information and fixes the issue by relying on `clock.Until`, which is precise down to the nanosecond unlike how previous "second" resolution.

This PR brings a 97% decrease in beacon aggregation latency when doing local tests.