### PR TITLE
Update Local Docker Setup for Multi Beacon Setup

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -90,7 +90,7 @@ This setup differs from the standard network script by:
 2. Setting up a more complete DKG configuration with additional parameters:
    - Explicitly specifying all parameters for `generate-proposal` to ensure correct node addressing
    - Using an increased `genesis-delay` (60s instead of the default) to provide enough time for network initialization
-   - Setting additional parameters like `catchup-period` and `timeout` for better local testing
+   - Setting additional parameters like `catchup-period` and `timeout` for local testing
 3. Including a delay to ensure followers have time to join before executing the DKG
 
 To run the local test network:

--- a/docker/README.md
+++ b/docker/README.md
@@ -77,6 +77,35 @@ Additionally, you can easily set up a test network of three nodes by running [th
 It can be torn down and cleaned up by using the [./cleanup.sh shell script](./cleanup.sh).
 This manifest will spin up a network of three nodes and run an initial distributed key generation process, and they will start generating randomness beacons.
 
+## Running a local test network
+
+For local development and testing, you can use the [start-local-network.sh](./start-local-network.sh) script along with [docker-compose-local-network.yml](./docker-compose-local-network.yml) to run a local network of 3 nodes.
+
+> [!IMPORTANT]
+> The docker-compose-local-network.yml builds from source rather than using the prebuilt `ghcr.io/drand/go-drand-local` image. This is because the prebuilt image doesn't properly support the `conn_insecure` build tag needed for local development with multiple nodes communicating with each other. Instead, the compose file passes `buildTag: conn_insecure` as a build argument to ensure this flag is included.
+
+This setup differs from the standard network script by:
+
+1. Building with the `conn_insecure` tag to allow local node-to-node communication without TLS
+2. Setting up a more complete DKG configuration with additional parameters:
+   - Explicitly specifying all parameters for `generate-proposal` to ensure correct node addressing
+   - Using an increased `genesis-delay` (60s instead of the default) to provide enough time for network initialization
+   - Setting additional parameters like `catchup-period` and `timeout` for better local testing
+3. Including a delay to ensure followers have time to join before executing the DKG
+
+To run the local test network:
+
+```shell
+./start-local-network.sh
+```
+
+This will create a three-node network and automatically perform the distributed key generation. Once complete, you can access the public API endpoints at:
+- Node 1: http://127.0.0.1:9010
+- Node 2: http://127.0.0.1:9020
+- Node 3: http://127.0.0.1:9030
+
+For more details about drand commands and DKG operations, see the [drand CLI documentation](https://docs.drand.love/operator/drand-cli/#drand-dkg).
+
 ## Running with nginx
 Many LoE partners like to run a reverse proxy in front of their node to easily manage TLS termination, domain names and firewalling.
 In [docker-compose-nginx.yml](./docker-compose-nginx.yml) you can find a manifest for running a single drand docker container and an

--- a/docker/docker-compose-local-network.yml
+++ b/docker/docker-compose-local-network.yml
@@ -1,0 +1,59 @@
+services:
+  drand_docker_demo_1:
+    container_name: drand_docker_demo1
+    # image: ghcr.io/drand/go-drand-local:latest
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        buildTag: conn_insecure
+    command: start --verbose --private-listen drand_docker_demo1:8010 --control 8888 --public-listen 0.0.0.0:9080
+    volumes:
+      - drand_docker_demo1:/data/drand
+    restart: always
+    ports:
+      - 8010:8080
+      - 8818:8888
+      - 9010:9080
+
+  drand_docker_demo_2:
+    container_name: drand_docker_demo2
+    # image: ghcr.io/drand/go-drand-local:latest
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        buildTag: conn_insecure
+    command: start --verbose --private-listen drand_docker_demo2:8020 --control 8888 --public-listen 0.0.0.0:9080
+    volumes:
+      - drand_docker_demo2:/data/drand
+    restart: always
+    ports:
+      - 8020:8080
+      - 8828:8888
+      - 9020:9080
+
+  drand_docker_demo_3:
+    container_name: drand_docker_demo3
+    # image: ghcr.io/drand/go-drand-local:latest
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        buildTag: conn_insecure
+    command: start --verbose --private-listen drand_docker_demo3:8030 --control 8888 --public-listen 0.0.0.0:9080
+    volumes:
+      - drand_docker_demo3:/data/drand
+    restart: always
+    ports:
+      - 8030:8080
+      - 8838:8888
+      - 9030:9080
+
+volumes:
+  drand_docker_demo1:
+    external: true
+  drand_docker_demo2:
+    external: true
+  drand_docker_demo3:
+    external: true

--- a/docker/docker-compose-local-network.yml
+++ b/docker/docker-compose-local-network.yml
@@ -1,7 +1,6 @@
 services:
   drand_docker_demo_1:
     container_name: drand_docker_demo1
-    # image: ghcr.io/drand/go-drand-local:latest
     build:
       context: ..
       dockerfile: Dockerfile
@@ -18,7 +17,6 @@ services:
 
   drand_docker_demo_2:
     container_name: drand_docker_demo2
-    # image: ghcr.io/drand/go-drand-local:latest
     build:
       context: ..
       dockerfile: Dockerfile
@@ -35,7 +33,6 @@ services:
 
   drand_docker_demo_3:
     container_name: drand_docker_demo3
-    # image: ghcr.io/drand/go-drand-local:latest
     build:
       context: ..
       dockerfile: Dockerfile

--- a/docker/start-local-network.sh
+++ b/docker/start-local-network.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+
+num_of_nodes=3
+docker_image_version=latest
+
+### first we check if docker and docker-compose are installed
+
+has_docker=$(docker version | echo "$?")
+
+if [ ! has_docker ]; then
+  echo [-] You must have docker installed to run the network
+  exit 1
+fi
+
+has_docker_compose=$(docker compose --version | echo "$?")
+
+if [ ! has_docker_compose ]; then
+  echo [-] You must have docker compose installed to run the network
+  exit 1
+fi
+
+echo [+] Cleaning up old run
+docker compose -f docker-compose-network.yml down -v
+
+echo [+] Pulling the official drand docker image $docker_image_version
+docker pull ghcr.io/drand/go-drand-local:$docker_image_version 1>/dev/null
+
+
+### then we create a volume for each of those nodes
+echo [+] Creating docker volumes for $num_of_nodes nodes
+
+for i in $(seq 1 $num_of_nodes);
+do
+  docker volume create drand_docker_demo$i
+done
+
+### next we're going to generate a keypair on each of those volumes
+echo [+] Generating a default network keypair for each node
+
+for i in $(seq 1 $num_of_nodes);
+do
+  # these will end up on drand1:8010, drand2:8020, drand3:8030, etc
+  # note they map to the container's mapped ports, but the internal ports; internally the services still listen on 8080
+  path=drand_docker_demo$i:80${i}0
+  docker run --rm --volume drand_docker_demo$i:/data/drand ghcr.io/drand/go-drand-local:$docker_image_version generate-keypair --folder /data/drand/.drand --id default $path 1>/dev/null
+done
+
+### now we start them all using docker-compose as it'll be easy to spin up and down
+echo [+] Starting all the nodes using docker-compose
+
+docker compose -f docker-compose-network.yml up -d
+
+
+### sleep to let the nodes start up
+sleep 5
+
+### now we run the initial distributed key generation
+### we're going to use the first node as the leader node
+
+echo [+] Initialising distributed key generation for the leader
+
+docker exec drand_docker_demo1 drand dkg generate-proposal  --joiner drand_docker_demo1:8010 --joiner drand_docker_demo2:8020 --joiner drand_docker_demo3:8030 --out proposal.toml
+# we start the DKG and send it to the background;
+docker exec drand_docker_demo1 drand dkg init --scheme pedersen-bls-chained --proposal ./proposal.toml --threshold 2 --period 3s --catchup-period 0s --genesis-delay 60s --timeout 24h --control 8888
+
+
+echo [+] Joining distributed key generation for the followers
+for i in $(seq 2 $num_of_nodes);
+do
+  # we start the DKG and send it to the background
+  docker exec --detach drand_docker_demo$i drand dkg join --control 8888
+done
+
+# Add a delay to allow followers time to join
+echo [+] Waiting for followers to join...
+sleep 30
+
+echo [+] Started distributed key generation execution on the leader
+docker exec --detach drand_docker_demo1 drand dkg execute --control 8888
+### now we wait for the distributed key generation to be completed and the first round to be created
+
+echo [+] Waiting for the DKG to finish - could take up to a minute!
+attempts=60
+
+while :
+do
+  ### if it isn't working after a bunch of attempts, it probably failed
+  if [ "$attempts" -eq 0 ]; then
+    echo [-] the DKG didn\'t finish successfully - check the container logs with '`docker logs -f drand_docker_demo1`'
+    exit 1
+  fi
+
+  ### once the first round has been created, we know that the DKG happened successfully
+  response=$(curl --silent 127.0.0.1:9010/public/1)
+  code=$?
+  if [ $code -eq 0 ]; then
+    if [[ $response =~ "round" ]]; then
+      break
+    fi
+  fi
+
+  attempts=$(($attempts - 1))
+  sleep 1
+done
+
+echo [+] Network running successfully!


### PR DESCRIPTION
This pull request introduces a new setup for running a local test network of three nodes for development and testing purposes. It includes updates to the documentation, a new Docker Compose configuration, and a script to automate the setup process. These changes aim to simplify local testing by ensuring compatibility with the `conn_insecure` build tag and providing a more robust configuration for distributed key generation (DKG).

### Documentation Updates:
* Added a new section in `docker/README.md` explaining how to set up and run a local test network using the `start-local-network.sh` script and `docker-compose-local-network.yml`. It highlights key differences from the standard network setup, such as the use of the `conn_insecure` build tag and additional DKG parameters.

### New Docker Configuration:
* Introduced `docker/docker-compose-local-network.yml` to define services for a three-node local network. Each node is configured with specific ports, volumes, and the `conn_insecure` build tag to enable local communication without TLS.

### Automation Script:
* Added `docker/start-local-network.sh`, a script to automate the setup of the local test network. It performs the following tasks:
  - Checks for required dependencies (Docker and Docker Compose).
  - Cleans up any previous runs and creates Docker volumes for the nodes.
  - Generates key pairs for each node and starts the network using Docker Compose.
  - Executes the distributed key generation process, including leader initialization and follower joining, with appropriate delays to ensure synchronization.