### PR TITLE
ci: change regression test to run against latest release

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -31,13 +31,28 @@ jobs:
       - name: Dir Setup
         run: mkdir -p ~/go/bin
 
-      # Master branch
-      - name: Checkout master branch
+      # Latest release
+      - name: Get latest release
+        id: latest_release
+        uses: actions/github-script@v7
+        env:
+          REPOSITORY: ${{ github.repository }}
+        with:
+          result-encoding: string
+          script: |
+            const repository = process.env.REPOSITORY;
+            const { data: release } = await github.rest.repos.getLatestRelease({
+              owner: repository.split('/')[0],
+              repo: repository.split('/')[1],
+            });
+            return release.tag_name;
+
+      - name: Checkout latest release
         uses: actions/checkout@v4
         with:
-          ref: 'master'
+          ref: ${{ steps.latest_release.outputs.result }}
 
-      - name: Build Master
+      - name: Build Latest Release
         run: make build_insecure && cp drand ~/go/bin/drand-existing
 
       # Candidate branch


### PR DESCRIPTION
This PR tries to fix #293 by changing the regression test to run against latest release instead of the latest commit of master branch.