### PR TITLE
Improve handling of node startup when group file is missing

### DIFF
--- a/internal/core/drand_beacon.go
+++ b/internal/core/drand_beacon.go
@@ -106,6 +106,7 @@ func NewBeaconProcess(ctx context.Context,
 }
 
 var ErrDKGNotStarted = errors.New("DKG not started")
+var ErrMissingGroupFileWithDKGState = errors.New("group file missing but DKG DB has state")
 
 // Load restores a drand instance that is ready to serve randomness, with a
 // pre-existing distributed share.

--- a/internal/core/drand_daemon.go
+++ b/internal/core/drand_daemon.go
@@ -407,14 +407,13 @@ func (dd *DrandDaemon) LoadBeaconFromStore(ctx context.Context, beaconID string,
 	// Check if DKG has state but group file is missing
 	if status.Complete != nil {
 		g, err := store.LoadGroup()
-		if err != nil && errors.Is(err, fs.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) {
 			// DKG DB has state but group file is missing - fail only this beacon
 			dd.log.Errorw("beacon failed to start: group file missing but DKG DB has state",
 				"beacon id", beaconID,
 				"err", err)
 			return nil, ErrMissingGroupFileWithDKGState
-		}
-		if err != nil {
+		} else if err != nil {
 			return nil, err
 		}
 		if g == nil {

--- a/internal/core/drand_daemon.go
+++ b/internal/core/drand_daemon.go
@@ -328,6 +328,14 @@ func (dd *DrandDaemon) LoadBeaconsFromDisk(ctx context.Context, metricsFlag stri
 
 		_, err := dd.LoadBeaconFromStore(ctx, beaconID, fileStore)
 		if err != nil {
+			// If this is a missing group file with DKG state error, log it but continue
+			// loading other beacons instead of failing the entire daemon
+			if errors.Is(err, ErrMissingGroupFileWithDKGState) {
+				dd.log.Errorw("skipping beacon: group file missing but DKG DB has state",
+					"beacon id", beaconID,
+					"err", err)
+				continue
+			}
 			return err
 		}
 
@@ -393,6 +401,26 @@ func (dd *DrandDaemon) LoadBeaconFromStore(ctx context.Context, beaconID string,
 
 		if err := dd.dkg.Migrate(beaconID, g, share); err != nil {
 			return nil, err
+		}
+	}
+
+	// Check if DKG has state but group file is missing
+	if status.Complete != nil {
+		g, err := store.LoadGroup()
+		if err != nil && errors.Is(err, fs.ErrNotExist) {
+			// DKG DB has state but group file is missing - fail only this beacon
+			dd.log.Errorw("beacon failed to start: group file missing but DKG DB has state",
+				"beacon id", beaconID,
+				"err", err)
+			return nil, ErrMissingGroupFileWithDKGState
+		}
+		if err != nil {
+			return nil, err
+		}
+		if g == nil {
+			dd.log.Errorw("beacon failed to start: group file missing but DKG DB has state",
+				"beacon id", beaconID)
+			return nil, ErrMissingGroupFileWithDKGState
 		}
 	}
 


### PR DESCRIPTION




## Problem

If you accidentally delete the group file, but maintain DB state, the node entirely fails to start. On one hand, this catches inconsistencies immediately. On the other hand, it could deny service to other beacons if one of them gets messed up.

## Solution

Modified `LoadBeaconsFromDisk()` to continue loading other beacons when one fails due to missing group file with DKG state. Only the specific beacon that's missing the group file fails to start, while other beacons continue normally.

## Changes

- Added `ErrMissingGroupFileWithDKGState` error type
- Modified `LoadBeaconFromStore()` to detect missing group file when DKG DB has state
- Modified `LoadBeaconsFromDisk()` to skip problematic beacons and continue loading others
- Added proper error logging for the specific beacon that failed

## Testing

- Code builds successfully
- No linter errors
- Other beacons can still start even if one has a missing group file


Fixes #1335