### PR TITLE
Remove unnecessary panics in test mocks 

### DIFF
--- a/internal/dkg/actions_active_test.go
+++ b/internal/dkg/actions_active_test.go
@@ -509,8 +509,11 @@ type MockDKGClient struct {
 	mock.Mock
 }
 
+// errUnexpectedMockCall is returned by Command/DKGStatus when called without an expectation, so tests fail clearly instead of silently succeeding
+var errUnexpectedMockCall = errors.New("unexpected call to mock")
+
 func (m *MockDKGClient) Command(_ context.Context, _ net.Peer, _ *drand.DKGCommand, _ ...grpc.CallOption) (*drand.EmptyDKGResponse, error) {
-	panic("implement me")
+	return nil, errUnexpectedMockCall
 }
 
 func (m *MockDKGClient) Packet(_ context.Context, _ net.Peer, in *drand.GossipPacket, _ ...grpc.CallOption) (*drand.EmptyDKGResponse, error) {
@@ -519,7 +522,7 @@ func (m *MockDKGClient) Packet(_ context.Context, _ net.Peer, in *drand.GossipPa
 }
 
 func (m *MockDKGClient) DKGStatus(_ context.Context, _ net.Peer, _ *drand.DKGStatusRequest, _ ...grpc.CallOption) (*drand.DKGStatusResponse, error) {
-	panic("implement me")
+	return nil, errUnexpectedMockCall
 }
 
 func (m *MockDKGClient) BroadcastDKG(_ context.Context, _ net.Peer, in *drand.DKGPacket, _ ...grpc.CallOption) (*drand.EmptyDKGResponse, error) {

--- a/internal/metrics/threshold_monitor_test.go
+++ b/internal/metrics/threshold_monitor_test.go
@@ -263,29 +263,17 @@ type mockLogger struct {
 	mock.Mock
 }
 
-func (m *mockLogger) Info(keyvals ...interface{}) {
-	panic("implement me")
-}
+func (m *mockLogger) Info(keyvals ...interface{}) {}
 
-func (m *mockLogger) Debug(keyvals ...interface{}) {
-	panic("implement me")
-}
+func (m *mockLogger) Debug(keyvals ...interface{}) {}
 
-func (m *mockLogger) Warn(keyvals ...interface{}) {
-	panic("implement me")
-}
+func (m *mockLogger) Warn(keyvals ...interface{}) {}
 
-func (m *mockLogger) Error(keyvals ...interface{}) {
-	panic("implement me")
-}
+func (m *mockLogger) Error(keyvals ...interface{}) {}
 
-func (m *mockLogger) Fatal(keyvals ...interface{}) {
-	panic("implement me")
-}
+func (m *mockLogger) Fatal(keyvals ...interface{}) {}
 
-func (m *mockLogger) Panic(keyvals ...interface{}) {
-	panic("implement me")
-}
+func (m *mockLogger) Panic(keyvals ...interface{}) {}
 
 func (m *mockLogger) Infow(msg string, keyvals ...interface{}) {
 	m.Called()
@@ -303,24 +291,20 @@ func (m *mockLogger) Errorw(msg string, keyvals ...interface{}) {
 	m.Called()
 }
 
-func (m *mockLogger) Fatalw(msg string, keyvals ...interface{}) {
-	panic("implement me")
-}
+func (m *mockLogger) Fatalw(msg string, keyvals ...interface{}) {}
 
-func (m *mockLogger) Panicw(msg string, keyvals ...interface{}) {
-	panic("implement me")
-}
+func (m *mockLogger) Panicw(msg string, keyvals ...interface{}) {}
 
 func (m *mockLogger) With(args ...interface{}) log.Logger {
-	panic("implement me")
+	return m
 }
 
 func (m *mockLogger) Named(s string) log.Logger {
-	panic("implement me")
+	return m
 }
 
 func (m *mockLogger) Name() string { return "mockLogger" }
 
 func (m *mockLogger) AddCallerSkip(skip int) log.Logger {
-	panic("implement me")
+	return m
 }


### PR DESCRIPTION


## Problem

Issue #1137 asked to review all `panic` calls in tests and remove those that are not needed. Several test mocks used `panic("implement me")` for interface methods that were not exercised by the tests, making the codebase noisier and risking panics if future tests call those paths.

Panics in unused mock paths violate the principle that tests should fail only for assertions relevant to the behavior under test.

## Solution

Replaced all remaining `panic("implement me")` in test files with safe, non-panicking behavior:

### 1. `internal/metrics/threshold_monitor_test.go` — `mockLogger`

- **Void methods** (`Info`, `Debug`, `Warn`, `Error`, `Fatal`, `Panic`, `Fatalw`, `Panicw`): no-op implementations (empty body). Tests only use `*w` variants that were already implemented via `m.Called()`.
- **Methods returning `log.Logger`** (`With`, `Named`, `AddCallerSkip`): return `m` so the interface is satisfied without panicking; callers get a valid logger.

### 2. `internal/dkg/actions_active_test.go` — `MockDKGClient`

- **`Command`** and **`DKGStatus`**: return `(nil, errUnexpectedMockCall)` instead of panicking. No test in this file sets expectations for these methods. Returning an error ensures that if a future test (or refactor) accidentally calls them without an expectation, the test fails clearly instead of silently succeeding. Tests that need to mock these can add `On("Command", ...).Return(...)` and the mock can be extended to use `m.Called()` and return those values.

## Scope

- **Tests only.** No production code or demo code changed.
- Tests that previously would panic on unused mock paths now either no-op (logger) or return a clear error (DKG client). No change to tests that already exercise the mocks via expectations.

## Checklist

- [x] Build passes (`go build ./...`)
- [x] Tests pass (`go test ./internal/metrics/... ./internal/dkg/...`)
- [x] No new panics in test mocks; unexpected mock calls fail with a clear error instead of silent success

Fixes #1137
