### PR TITLE
fix(postgres): implement `SaveTo` for beacon backups (NDJSON)

### DIFF
--- a/internal/chain/postgresdb/pgdb/pgdb.go
+++ b/internal/chain/postgresdb/pgdb/pgdb.go
@@ -3,6 +3,7 @@ package pgdb
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -346,12 +347,55 @@ func (p *Store) Cursor(ctx context.Context, fn func(context.Context, chain.Curso
 	return fn(ctx, &c)
 }
 
-// SaveTo does something and I am not sure just yet.
-func (p *Store) SaveTo(ctx context.Context, _ io.Writer) error {
+// SaveTo exports all beacons in a newline-delimited JSON format (NDJSON),
+// compatible with memdb.Store.SaveTo output.
+func (p *Store) SaveTo(ctx context.Context, w io.Writer) error {
 	_, span := tracer.NewSpan(ctx, "pgStore.SaveTo")
 	defer span.End()
 
-	return fmt.Errorf("saveTo not implemented for Postgres Store")
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	return p.Cursor(ctx, func(ctx context.Context, c chain.Cursor) error {
+		b, err := c.First(ctx)
+		if err != nil {
+			// Empty store is fine: produce an empty output.
+			if errors.Is(err, chainerrors.ErrNoBeaconStored) {
+				return nil
+			}
+			return err
+		}
+
+		for {
+			// Export can be long-running; respect cancellation inside the loop.
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
+
+			data, err := b.Marshal()
+			if err != nil {
+				return fmt.Errorf("failed to marshal beacon round %d: %w", b.Round, err)
+			}
+			// Write one NDJSON line per beacon.
+			if _, err := w.Write(append(data, '\n')); err != nil {
+				return fmt.Errorf("failed to write beacon round %d: %w", b.Round, err)
+			}
+
+			next, err := c.Next(ctx)
+			if err != nil {
+				if errors.Is(err, chainerrors.ErrNoBeaconStored) {
+					return nil
+				}
+				return err
+			}
+			b = next
+		}
+	})
 }
 
 // DropFK is used to optimize the calls to Store.BatchPut and should be called before it.

--- a/internal/chain/postgresdb/pgdb/pgdb_test.go
+++ b/internal/chain/postgresdb/pgdb/pgdb_test.go
@@ -3,6 +3,7 @@
 package pgdb_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -171,6 +172,80 @@ func TestStore_Cursor(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+}
+
+func TestStorePG_SaveTo(t *testing.T) {
+	ctx, _, prevMatters := context2.PrevSignatureMattersOnContext(t, context.Background())
+
+	l, db := test.NewUnit(t, c, t.Name())
+
+	beaconName := t.Name()
+	dbStore, err := pgdb.NewStore(ctx, l, db, beaconName)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, dbStore.Close())
+	}()
+
+	// Insert a few beacons.
+	beacons := []*common.Beacon{
+		{
+			PreviousSig: nil,
+			Round:       1,
+			Signature:   common.HexBytes([]byte{0x01, 0x02, 0x03}),
+		},
+		{
+			PreviousSig: common.HexBytes([]byte{0x01, 0x02, 0x03}),
+			Round:       2,
+			Signature:   common.HexBytes([]byte{0x02, 0x03, 0x04}),
+		},
+		{
+			PreviousSig: common.HexBytes([]byte{0x02, 0x03, 0x04}),
+			Round:       3,
+			Signature:   common.HexBytes([]byte{0x03, 0x04, 0x05}),
+		},
+	}
+	if !prevMatters {
+		// In this mode, previous signatures are not guaranteed to be stored/returned.
+		beacons[1].PreviousSig = nil
+		beacons[2].PreviousSig = nil
+	}
+
+	for _, b := range beacons {
+		require.NoError(t, dbStore.Put(ctx, b))
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, dbStore.SaveTo(ctx, &buf))
+
+	output := bytes.TrimSpace(buf.Bytes())
+	require.NotEmpty(t, output)
+
+	lines := bytes.Split(output, []byte("\n"))
+	require.Len(t, lines, len(beacons))
+
+	for i, line := range lines {
+		var got common.Beacon
+		require.NoError(t, got.Unmarshal(line))
+		require.Equal(t, beacons[i].Round, got.Round)
+		require.Equal(t, beacons[i].Signature, got.Signature)
+	}
+}
+
+func TestStorePG_SaveTo_Empty(t *testing.T) {
+	ctx, _, _ := context2.PrevSignatureMattersOnContext(t, context.Background())
+
+	l, db := test.NewUnit(t, c, t.Name())
+
+	beaconName := t.Name()
+	dbStore, err := pgdb.NewStore(ctx, l, db, beaconName)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, dbStore.Close())
+	}()
+
+	var buf bytes.Buffer
+	require.NoError(t, dbStore.SaveTo(ctx, &buf))
+	require.Empty(t, bytes.TrimSpace(buf.Bytes()))
 }
 
 func Test_StorePG(t *testing.T) {


### PR DESCRIPTION
## Summary

- Implement `(*pgdb.Store).SaveTo(ctx, w)` to export stored beacons as NDJSON (one `common.Beacon` per line).
- Remove the postgres `SaveTo` placeholder/`not implemented` behavior.
- Add a unit test (`TestStorePG_SaveTo`) that verifies the output is non-empty (when data exists), has the expected number of lines, and round-trips via `common.Beacon.Unmarshal`.

## Rationale

`BeaconProcess.BackupDatabase` relies on the underlying store backend to implement `SaveTo`. The Postgres backend previously returned a `saveTo not implemented for Postgres Store` error, which breaks chain backup/export when the node uses Postgres as its beacon store.

The export format is aligned with `memdb.Store.SaveTo` (NDJSON), so consumers that expect that shape can reuse the same parsing logic.

## Approach

- Reuse the store abstraction (`Cursor`) instead of duplicating SQL iteration logic.
- For each beacon returned by the cursor:
  - `Marshal()` it to JSON bytes.
  - Write it to `w` followed by a `\n`.
- Treat `chainerrors.ErrNoBeaconStored` as the “end of iteration / empty store” case (returning nil and producing empty output).

## Files touched

- `internal/chain/postgresdb/pgdb/pgdb.go`
- `internal/chain/postgresdb/pgdb/pgdb_test.go`

## Testing

```bash
go test ./internal/chain/postgresdb/pgdb -tags postgres -count=1
```
